### PR TITLE
Add description to grant permissions for AKS demo

### DIFF
--- a/docs-old/workload/azure/demo.md
+++ b/docs-old/workload/azure/demo.md
@@ -42,6 +42,16 @@ After these steps are completed, you should have the following file on your loca
 
 * `crossplane-azure-provider-key.json`
 
+## Grant Consent to application
+1. `echo ${AZURE_CLIENT_ID}` and note id
+1. Navigate to azure console: https://portal.azure.com
+1. Click Azure Active Directory
+1. Click `App registrations (Preview)`
+1. Click on app item where client id matches step 1
+1. Click `API permissions`
+1. Click `Grant admin consent for Default Directory`
+1. Click `Yes`
+
 ## Set environment variables
 
 Set the following environment variables that will be used in this walkthrough:


### PR DESCRIPTION
Per documentation here: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent#using-the-admin-consent-endpoint

We are granting application permissions so this needs to happen in the console.

Tested the demo flow with this fix and it works.