### PR TITLE
workload: remove secrets when workload is deleted

### DIFF
--- a/pkg/controller/compute/workload/workload.go
+++ b/pkg/controller/compute/workload/workload.go
@@ -274,8 +274,7 @@ func (r *Reconciler) _delete(instance *computev1alpha1.Workload, client kubernet
 	// delete resources secrets
 	for _, resource := range instance.Spec.Resources {
 		secretName := util.IfEmptyString(resource.SecretName, resource.Name)
-		err = client.CoreV1().Secrets(ns).Delete(secretName, &metav1.DeleteOptions{})
-		if err != nil {
+		if err := client.CoreV1().Secrets(ns).Delete(secretName, &metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
 			return r.fail(instance, errorDeleting, err.Error())
 		}
 	}

--- a/pkg/controller/compute/workload/workload.go
+++ b/pkg/controller/compute/workload/workload.go
@@ -271,6 +271,15 @@ func (r *Reconciler) _delete(instance *computev1alpha1.Workload, client kubernet
 		return r.fail(instance, errorDeleting, err.Error())
 	}
 
+	// delete resources secrets
+	for _, resource := range instance.Spec.Resources {
+		secretName := util.IfEmptyString(resource.SecretName, resource.Name)
+		err = client.CoreV1().Secrets(ns).Delete(secretName, &metav1.DeleteOptions{})
+		if err != nil {
+			return r.fail(instance, errorDeleting, err.Error())
+		}
+	}
+
 	// delete deployment
 	err = client.AppsV1().Deployments(ns).Delete(instance.Spec.TargetDeployment.Name, &metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {


### PR DESCRIPTION
This pull request fixes #244 by adding functionality that ensures workload-related secrets are deleted when the workload itself is deleted. It follows the process used in [`_create`](https://github.com/crossplaneio/crossplane/blob/master/pkg/controller/compute/workload/workload.go#L181) to generate secrets, but it swaps-out a few function calls.

I was able to run the demo Wordpress example and made sure that my changes fix the issue. It might be nice to write-up a testcase for this, but I didn't see any existing workload-related tests and wasn't exactly sure where to start. Is this something that can be skipped for now?