### PR TITLE
Reconcile Log and Ready

### DIFF
--- a/pkg/apis/aws/v1alpha1/register.go
+++ b/pkg/apis/aws/v1alpha1/register.go
@@ -30,10 +30,11 @@ import (
 )
 
 const (
-	Group        = "aws.crossplane.io"
-	Version      = "v1alpha1"
-	APIVersion   = Group + "/" + Version
-	ProviderKind = "provider"
+	Group                  = "aws.crossplane.io"
+	Version                = "v1alpha1"
+	APIVersion             = Group + "/" + Version
+	ProviderKind           = "provider"
+	ProviderKindAPIVersion = ProviderKind + "." + APIVersion
 )
 
 var (

--- a/pkg/apis/azure/v1alpha1/register.go
+++ b/pkg/apis/azure/v1alpha1/register.go
@@ -35,7 +35,9 @@ const (
 	// Version is the version of the API group
 	Version = "v1alpha1"
 	// APIVersion is the full version of this API group
-	APIVersion = Group + "/" + Version
+	APIVersion             = Group + "/" + Version
+	ProviderKind           = "provider"
+	ProviderKindAPIVersion = ProviderKind + "." + APIVersion
 )
 
 var (

--- a/pkg/apis/compute/v1alpha1/register.go
+++ b/pkg/apis/compute/v1alpha1/register.go
@@ -30,11 +30,13 @@ import (
 )
 
 const (
-	Group                  = "compute.crossplane.io"
-	Version                = "v1alpha1"
-	APIVersion             = Group + "/" + Version
-	KubernetesInstanceKind = "kubernetesclusters"
-	WorkloadKind           = "workloads"
+	Group                            = "compute.crossplane.io"
+	Version                          = "v1alpha1"
+	APIVersion                       = Group + "/" + Version
+	KubernetesInstanceKind           = "kubernetescluster"
+	KubernetesInstanceKindAPIVersion = KubernetesInstanceKind + "." + APIVersion
+	WorkloadKind                     = "workload"
+	WorkloadKindAPIVersion           = WorkloadKind + "." + APIVersion
 )
 
 var (

--- a/pkg/apis/gcp/v1alpha1/register.go
+++ b/pkg/apis/gcp/v1alpha1/register.go
@@ -30,9 +30,11 @@ import (
 )
 
 const (
-	Group      = "gcp.crossplane.io"
-	Version    = "v1alpha1"
-	APIVersion = Group + "/" + Version
+	Group                  = "gcp.crossplane.io"
+	Version                = "v1alpha1"
+	APIVersion             = Group + "/" + Version
+	ProviderKind           = "provider"
+	ProviderKindAPIVersion = ProviderKind + "." + APIVersion
 )
 
 var (

--- a/pkg/apis/storage/v1alpha1/register.go
+++ b/pkg/apis/storage/v1alpha1/register.go
@@ -30,11 +30,13 @@ import (
 )
 
 const (
-	Group             = "storage.crossplane.io"
-	Version           = "v1alpha1"
-	APIVersion        = Group + "/" + Version
-	MySQLInstanceKind = "mysqlinstance"
-	BucketKind        = "bucket"
+	Group                       = "storage.crossplane.io"
+	Version                     = "v1alpha1"
+	APIVersion                  = Group + "/" + Version
+	MySQLInstanceKind           = "mysqlinstance"
+	MySQLInstanceKindAPIVersion = MySQLInstanceKind + "." + APIVersion
+	BucketKind                  = "bucket"
+	BucketKindApiVersion        = BucketKind + "." + APIVersion
 )
 
 var (

--- a/pkg/controller/aws/compute/eks.go
+++ b/pkg/controller/aws/compute/eks.go
@@ -20,11 +20,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log"
 	"strings"
-
-	"github.com/ghodss/yaml"
-	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	awscomputev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/aws/compute/v1alpha1"
 	awsv1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/aws/v1alpha1"
@@ -33,8 +30,11 @@ import (
 	cloudformationclient "github.com/crossplaneio/crossplane/pkg/clients/aws/cloudformation"
 	"github.com/crossplaneio/crossplane/pkg/clients/aws/eks"
 	"github.com/crossplaneio/crossplane/pkg/util"
+	"github.com/ghodss/yaml"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -356,6 +356,7 @@ func (r *Reconciler) _delete(instance *awscomputev1alpha1.EKSCluster, client eks
 // Reconcile reads that state of the cluster for a Provider object and makes changes based on the state read
 // and what is in the Provider.Spec
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	log.Printf("reconciling %s: %v", awscomputev1alpha1.EKSClusterKindAPIVersion, request)
 	// Fetch the Provider instance
 	instance := &awscomputev1alpha1.EKSCluster{}
 	err := r.Get(ctx, request.NamespacedName, instance)

--- a/pkg/controller/aws/rds/rdsinstance.go
+++ b/pkg/controller/aws/rds/rdsinstance.go
@@ -261,6 +261,7 @@ func (r *Reconciler) _delete(instance *databasev1alpha1.RDSInstance, client rds.
 // Reconcile reads that state of the cluster for a Instance object and makes changes based on the state read
 // and what is in the Instance.Spec
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	log.Printf("reconciling %s: %v", databasev1alpha1.RDSInstanceKindAPIVersion, request)
 	// Fetch the CRD instance
 	instance := &databasev1alpha1.RDSInstance{}
 

--- a/pkg/controller/aws/s3/s3bucket.go
+++ b/pkg/controller/aws/s3/s3bucket.go
@@ -272,6 +272,8 @@ func (r *Reconciler) _delete(bucket *bucketv1alpha1.S3Bucket, client s3.Service)
 // Reconcile reads that state of the bucket for an Instance object and makes changes based on the state read
 // and what is in the Instance.Spec
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	log.Printf("reconciling %s: %v", bucketv1alpha1.S3BucketKindAPIVersion, request)
+
 	// Fetch the CRD instance
 	bucket := &bucketv1alpha1.S3Bucket{}
 

--- a/pkg/controller/azure/compute/akscluster.go
+++ b/pkg/controller/azure/compute/akscluster.go
@@ -116,6 +116,7 @@ func AddAKSClusterReconciler(mgr manager.Manager, r reconcile.Reconciler) error 
 // Reconcile reads that state of the cluster for a AKSCluster object and makes changes based on the state read
 // and what is in its spec.
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	log.Printf("reconciling %s: %v", computev1alpha1.AKSClusterKindAPIVersion, request)
 	// Fetch the CRD instance
 	instance := &computev1alpha1.AKSCluster{}
 	err := r.Get(ctx, request.NamespacedName, instance)
@@ -319,7 +320,8 @@ func (r *Reconciler) sync(instance *computev1alpha1.AKSCluster, aksClient *azure
 	if cluster.Fqdn != nil {
 		instance.Status.Endpoint = *cluster.Fqdn
 	}
-	if instance.IsAvailable() {
+
+	if !instance.Status.IsReady() {
 		instance.Status.UnsetAllConditions()
 		instance.Status.SetReady()
 	}

--- a/pkg/controller/azure/database/mysqlserver.go
+++ b/pkg/controller/azure/database/mysqlserver.go
@@ -21,9 +21,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/Azure/go-autorest/autorest/to"
-
 	"github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2017-12-01/mysql"
+	"github.com/Azure/go-autorest/autorest/to"
 	databasev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/azure/database/v1alpha1"
 	azurev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/azure/v1alpha1"
 	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
@@ -120,6 +119,7 @@ type Reconciler struct {
 // Reconcile reads that state of the cluster for a MysqlServer object and makes changes based on the state read
 // and what is in the MysqlServer.Spec
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	log.Printf("reconciling %s: %v", databasev1alpha1.MysqlServerKindAPIVersion, request)
 	instance := &databasev1alpha1.MysqlServer{}
 	ctx := context.Background()
 

--- a/pkg/controller/azure/provider/provider.go
+++ b/pkg/controller/azure/provider/provider.go
@@ -18,6 +18,7 @@ package provider
 
 import (
 	"context"
+	"log"
 
 	"github.com/crossplaneio/crossplane/pkg/apis/azure/v1alpha1"
 	azureclient "github.com/crossplaneio/crossplane/pkg/clients/azure"
@@ -104,6 +105,7 @@ func (r *Reconciler) _validate(client *azureclient.Client) error {
 // Reconcile reads that state of the cluster for a Provider object and makes changes based on the state read
 // and what is in the Provider.Spec
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	log.Printf("reconciling %s: %v", v1alpha1.ProviderKindAPIVersion, request)
 	ctx := context.TODO()
 
 	// Fetch the Provider instance

--- a/pkg/controller/compute/workload/workload.go
+++ b/pkg/controller/compute/workload/workload.go
@@ -293,6 +293,7 @@ func (r *Reconciler) _delete(instance *computev1alpha1.Workload, client kubernet
 // Reconcile reads that state of the cluster for a Instance object and makes changes based on the state read
 // and what is in the Instance.Spec
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	log.Printf("reconciling %s: %v", computev1alpha1.WorkloadKindAPIVersion, request)
 	// fetch the CRD instance
 	instance := &computev1alpha1.Workload{}
 

--- a/pkg/controller/gcp/compute/gke.go
+++ b/pkg/controller/gcp/compute/gke.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log"
 
 	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
 	gcpcomputev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/gcp/compute/v1alpha1"
@@ -240,6 +241,7 @@ func (r *Reconciler) _delete(instance *gcpcomputev1alpha1.GKECluster, client gke
 // Reconcile reads that state of the cluster for a Provider object and makes changes based on the state read
 // and what is in the Provider.Spec
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	log.Printf("reconciling %s: %v", gcpcomputev1alpha1.GKEClusterKindAPIVersion, request)
 	// Fetch the Provider instance
 	instance := &gcpcomputev1alpha1.GKECluster{}
 	err := r.Get(ctx, request.NamespacedName, instance)

--- a/pkg/controller/gcp/database/cloudsql_instance.go
+++ b/pkg/controller/gcp/database/cloudsql_instance.go
@@ -130,6 +130,7 @@ func NewReconcilerOptions() ReconcilerOptions {
 // Reconcile reads that state of the cluster for a CloudsqlInstance object and makes changes based on the state read
 // and what is in the CloudsqlInstance.Spec
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	log.Printf("reconciling %s: %v", databasev1alpha1.CloudsqlInstanceKindAPIVersion, request)
 	instance := &databasev1alpha1.CloudsqlInstance{}
 	var cloudSQLInstance *sqladmin.DatabaseInstance
 

--- a/pkg/controller/gcp/provider/provider.go
+++ b/pkg/controller/gcp/provider/provider.go
@@ -18,6 +18,7 @@ package provider
 
 import (
 	"context"
+	"log"
 
 	gcpv1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/gcp/v1alpha1"
 	"github.com/crossplaneio/crossplane/pkg/clients/gcp"
@@ -112,6 +113,7 @@ func (r *Reconciler) _validate(creds *google.Credentials, permissions []string) 
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=gcp.crossplane.io,resources=provider,verbs=get;list;watch;create;update;patch;delete
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	log.Printf("reconciling %s: %v", gcpv1alpha1.ProviderKindAPIVersion, request)
 	// Fetch the Provider instance
 	instance := &gcpv1alpha1.Provider{}
 	err := r.Get(ctx, request.NamespacedName, instance)

--- a/pkg/controller/storage/bucket/bucket.go
+++ b/pkg/controller/storage/bucket/bucket.go
@@ -19,6 +19,7 @@ package bucket
 import (
 	"context"
 	"fmt"
+	"log"
 
 	awsbucketv1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/aws/storage/v1alpha1"
 	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
@@ -274,6 +275,8 @@ func namespaceNameFromObjectRef(or *v1.ObjectReference) types.NamespacedName {
 // Reconcile reads that state of the cluster for a Instance object and makes changes based on the state read
 // and what is in the Instance.Spec
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	log.Printf("reconciling %s: %v", bucketv1alpha1.BucketKindApiVersion, request)
+
 	// fetch the CRD instance
 	bucket := &bucketv1alpha1.Bucket{}
 


### PR DESCRIPTION
**Description of your changes:**
* Add `log` message to the top of the every reconcile loop to gain visibility (at the log level) at reconciliation frequency of every reconcilable type
```
2018/12/15 14:04:23 reconciling provider.azure.crossplane.io/v1alpha1: crossplane-system/demo-azure
2018/12/15 14:04:24 reconciling provider.azure.crossplane.io/v1alpha1: crossplane-system/demo-azure
```

**Which issue is resolved by this Pull Request:**
Related to #136, #86

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from the previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [x] CRD manifests generation (`make manifests`) has been run to update CRD manifests YAML file specifications, if necessary.
- [x] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [x] All related commits have been squashed to improve readability.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
