### PR TITLE
Use the minimal set of properties required to connect to AKS clusters

### DIFF
--- a/pkg/apis/core/v1alpha1/resource.go
+++ b/pkg/apis/core/v1alpha1/resource.go
@@ -39,8 +39,6 @@ const (
 	ResourceCredentialsSecretClientKeyKey = "clientKey"
 	// ResourceCredentialsTokenKey is the key inside a connection secret for the bearer token value
 	ResourceCredentialsTokenKey = "token"
-	// ResourceCredentialsSecretKubeconfigFileKey is the key inside a connection secret for the full kubeconfig file
-	ResourceCredentialsSecretKubeconfigFileKey = "kubeconfig"
 )
 
 // Resource defines a concrete resource that can be provisioned and bound to a resource claim.


### PR DESCRIPTION
**Description of your changes:**
Previously we passed on the entire kubeconfig file when authenticating to AKS, as opposed to EKS AND GKE where we pass only the endpoint, CA data, and user credentials. We're now consistent across controller.s

**Which issue is resolved by this Pull Request:**
Resolves #273

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [ ] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [ ] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [ ] All related commits have been squashed to improve readability.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
