### PR TITLE
Update AKS to use constant value for AgenPoolProfileName to avoid unexpected failures during cluster create.

### DIFF
--- a/pkg/clients/azure/aks.go
+++ b/pkg/clients/azure/aks.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// AgentPoolProfileNameFmt is a format string for the name of the automatically created cluster agent pool profile
-	AgentPoolProfileNameFmt = "%s-nodepool"
+	AgentPoolProfileName = "agentpool"
 
 	maxClusterNameLen = 31
 )
@@ -118,7 +118,6 @@ func (c *AKSClusterClient) Get(ctx context.Context, instance computev1alpha1.AKS
 func (c *AKSClusterClient) CreateOrUpdateBegin(ctx context.Context, instance computev1alpha1.AKSCluster, clusterName, appID, spSecret string) ([]byte, error) {
 	spec := instance.Spec
 
-	agentPoolProfileName := fmt.Sprintf(AgentPoolProfileNameFmt, clusterName)
 	enableRBAC := !spec.DisableRBAC
 
 	nodeCount := int32(computev1alpha1.DefaultNodeCount)
@@ -134,7 +133,7 @@ func (c *AKSClusterClient) CreateOrUpdateBegin(ctx context.Context, instance com
 			DNSPrefix:         &spec.DNSNamePrefix,
 			AgentPoolProfiles: &[]containerservice.ManagedClusterAgentPoolProfile{
 				{
-					Name:   &agentPoolProfileName,
+					Name:   to.StringPtr(AgentPoolProfileName),
 					Count:  &nodeCount,
 					VMSize: containerservice.VMSizeTypes(spec.NodeVMSize),
 				},


### PR DESCRIPTION
Resolves #304

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [ ] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [ ] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [ ] All related commits have been squashed to improve readability.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)