### PR TITLE
Update Workload propagation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /config
 cover.out
 /vendor
+/.vendor-new

--- a/cluster/charts/crossplane/crds/compute/v1alpha1/workload.yaml
+++ b/cluster/charts/crossplane/crds/compute/v1alpha1/workload.yaml
@@ -100,13 +100,16 @@ spec:
           - targetNamespace
           - targetDeployment
           - targetService
-          - resources
           type: object
         status:
           properties:
             deployment:
               type: object
+            deploymentRef:
+              type: object
             service:
+              type: object
+            serviceRef:
               type: object
             state:
               type: string

--- a/pkg/apis/compute/v1alpha1/types.go
+++ b/pkg/apis/compute/v1alpha1/types.go
@@ -121,7 +121,7 @@ type WorkloadSpec struct {
 	TargetService    *corev1.Service        `json:"targetService"`
 
 	// Resources
-	Resources []ResourceReference `json:"resources"`
+	Resources []ResourceReference `json:"resources,omitempty"`
 }
 
 // WorkloadStatus
@@ -129,7 +129,9 @@ type WorkloadStatus struct {
 	corev1alpha1.ConditionedStatus
 	appsv1.DeploymentStatus `json:"deployment,omitempty"`
 	corev1.ServiceStatus    `json:"service,omitempty"`
-	State                   WorkloadState `json:"state,omitempty"`
+	State                   WorkloadState           `json:"state,omitempty"`
+	Deployment              *corev1.ObjectReference `json:"deploymentRef,omitempty"`
+	Service                 *corev1.ObjectReference `json:"serviceRef,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/compute/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/compute/v1alpha1/zz_generated.deepcopy.go
@@ -248,6 +248,16 @@ func (in *WorkloadStatus) DeepCopyInto(out *WorkloadStatus) {
 	in.ConditionedStatus.DeepCopyInto(&out.ConditionedStatus)
 	in.DeploymentStatus.DeepCopyInto(&out.DeploymentStatus)
 	in.ServiceStatus.DeepCopyInto(&out.ServiceStatus)
+	if in.Deployment != nil {
+		in, out := &in.Deployment, &out.Deployment
+		*out = new(v1.ObjectReference)
+		**out = **in
+	}
+	if in.Service != nil {
+		in, out := &in.Service, &out.Service
+		*out = new(v1.ObjectReference)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/core/v1alpha1/condition_testing.go
+++ b/pkg/apis/core/v1alpha1/condition_testing.go
@@ -59,11 +59,11 @@ func (cm *ConditionMatcher) Match(actual interface{}) (success bool, err error) 
 }
 
 func (cm *ConditionMatcher) FailureMessage(actual interface{}) (message string) {
-	return fmt.Sprintf("Expected\n\t%#v\nto mach, actual\n\t%#v", cm.expected, actual)
+	return fmt.Sprintf("Expected\n\t%#v\nto match, actual\n\t%#v", cm.expected, actual)
 }
 
 func (cm *ConditionMatcher) NegatedFailureMessage(actual interface{}) (message string) {
-	return fmt.Sprintf("Expected\n\t%#v\nnot to mach, actual\n\t%#v", cm.expected, actual)
+	return fmt.Sprintf("Expected\n\t%#v\nnot to match, actual\n\t%#v", cm.expected, actual)
 }
 
 func MatchCondition(expected interface{}) types.GomegaMatcher {

--- a/pkg/controller/compute/workload/workload_test.go
+++ b/pkg/controller/compute/workload/workload_test.go
@@ -1,0 +1,356 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workload
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/crossplaneio/crossplane/pkg/apis/compute"
+	computev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/compute/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	. "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	. "k8s.io/client-go/testing"
+	. "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	name      = "test-workload"
+	namespace = "default"
+)
+
+func init() {
+	_ = compute.AddToScheme(scheme.Scheme)
+}
+
+func testWorkload() *computev1alpha1.Workload {
+	return &computev1alpha1.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+func testDeployment() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "deployment",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "test-deployment",
+			UID:       "test-deployment-uid",
+		},
+	}
+}
+
+func testService() *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "test-service",
+			UID:       "test-service-uid",
+		},
+	}
+}
+
+func Test_addWorkloadReferenceLabel(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// test workload with test testUid value
+	testUid := "test-testUid"
+
+	type args struct {
+		m   *metav1.ObjectMeta
+		uid string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{"Nil labels", args{&metav1.ObjectMeta{}, testUid}},
+		{"Empty labels", args{&metav1.ObjectMeta{Labels: make(map[string]string)}, testUid}},
+		{"Label added", args{&metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}}, testUid}},
+		{"Label updated", args{&metav1.ObjectMeta{Labels: map[string]string{workloadReferenceLabelKey: "foo-bar"}}, testUid}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addWorkloadReferenceLabel(tt.args.m, tt.args.uid)
+		})
+		g.Expect(tt.args.m.Labels).ShouldNot(BeNil())
+		g.Expect(tt.args.m.Labels).Should(HaveKeyWithValue(workloadReferenceLabelKey, string(tt.args.uid)))
+	}
+}
+
+func Test_getWorkloadReferenceLabel(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type args struct {
+		m metav1.ObjectMeta
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"Nil labels", args{metav1.ObjectMeta{}}, ""},
+		{"Empty labels", args{metav1.ObjectMeta{Labels: make(map[string]string)}}, ""},
+		{"Label not found", args{metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}}}, ""},
+		{"Label found", args{metav1.ObjectMeta{Labels: map[string]string{workloadReferenceLabelKey: "test-uid"}}}, "test-uid"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g.Expect(getWorkloadReferenceLabel(tt.args.m)).Should(Equal(tt.want))
+		})
+	}
+}
+
+func Test_propagateDeployment(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	testName := "test-name"
+	targetNamespace := "test-ns"
+	workloadUID := "test-uid"
+
+	td := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testName,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"foo": "bar"}, // to test selector update
+				},
+			},
+		},
+	}
+
+	// propagate create deployment without namespace value
+	client := NewSimpleClientset()
+	rd, err := propagateDeployment(client, td, targetNamespace, workloadUID)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(rd).ShouldNot(BeNil())
+	g.Expect(rd.Labels).Should(HaveKeyWithValue(workloadReferenceLabelKey, workloadUID))
+	g.Expect(rd.Spec.Selector).ShouldNot(BeNil())
+	g.Expect(rd.Spec.Selector.MatchLabels).Should(HaveKeyWithValue("foo", "bar"))
+
+	// propagate create deployment with name collision
+	_, err = propagateDeployment(client, td, targetNamespace, workloadUID+"-2")
+	g.Expect(err).Should(MatchError(fmt.Errorf("cannot propagate, deployment %s/%s already exists", td.Namespace, td.Name)))
+
+	// propagate update deployment: add a new label to target deployment to test the update
+	td.Labels["foo"] = "bar"
+	rd, err = propagateDeployment(client, td, targetNamespace, workloadUID)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(rd.Labels).Should(HaveKeyWithValue("foo", "bar"))
+
+	// propagate create deployment with the namespace value different from the workload's target namespace
+	td.Namespace = "default"
+	client = NewSimpleClientset()
+	rd, err = propagateDeployment(client, td, targetNamespace, workloadUID)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	_, err = client.AppsV1().Deployments(targetNamespace).Get(td.Name, metav1.GetOptions{})
+	g.Expect(err).Should(HaveOccurred())
+	g.Expect(errors.IsNotFound(err)).Should(BeTrue())
+	g.Expect(rd.Labels).Should(HaveKeyWithValue(workloadReferenceLabelKey, workloadUID))
+
+	// test client errors
+	// GET deployment error
+	client = NewSimpleClientset()
+	client.PrependReactor("get", "deployments", func(action Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, fmt.Errorf("test client get error")
+	})
+	_, err = propagateDeployment(client, td, targetNamespace, workloadUID)
+	g.Expect(err).Should(MatchError("test client get error"))
+
+	// CREATE deployment error
+	client = NewSimpleClientset()
+	client.PrependReactor("create", "deployments", func(action Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, fmt.Errorf("test client create error")
+	})
+	_, err = propagateDeployment(client, td, targetNamespace, workloadUID)
+	g.Expect(err).Should(MatchError("test client create error"))
+
+	// UPDATE deployment error
+	client = NewSimpleClientset(td)
+	client.PrependReactor("update", "deployments", func(action Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, fmt.Errorf("test client update error")
+	})
+	_, err = propagateDeployment(client, td, targetNamespace, workloadUID)
+	g.Expect(err).Should(MatchError("test client update error"))
+}
+
+func Test_propagateService(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	testName := "test-name"
+	targetNamespace := "test-ns"
+	workloadUID := "test-uid"
+
+	ts := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testName,
+		},
+	}
+
+	// propagate create service without namespace value
+	client := NewSimpleClientset()
+	rs, err := propagateService(client, ts, targetNamespace, workloadUID)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(rs.Labels).Should(HaveKeyWithValue(workloadReferenceLabelKey, workloadUID))
+
+	// propagate create service with name collision
+	_, err = propagateService(client, ts, targetNamespace, workloadUID+"-2")
+	g.Expect(err).Should(MatchError(fmt.Errorf("cannot propagate, service %s/%s already exists", ts.Namespace, ts.Name)))
+
+	// propagate update service: add a new label to target service to test the update
+	ts.Labels["foo"] = "bar"
+	rs, err = propagateService(client, ts, targetNamespace, workloadUID)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(rs.Labels).Should(HaveKeyWithValue("foo", "bar"))
+
+	// propagate create service with the namespace value different from the workload's target namespace
+	ts.Namespace = "default"
+	client = NewSimpleClientset()
+	rs, err = propagateService(client, ts, targetNamespace, workloadUID)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(rs.Namespace).ShouldNot(Equal(targetNamespace))
+	g.Expect(rs.Labels).Should(HaveKeyWithValue(workloadReferenceLabelKey, workloadUID))
+
+	// test client errors
+	// GET service error
+	client = NewSimpleClientset()
+	client.PrependReactor("get", "services", func(action Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, fmt.Errorf("test client get error")
+	})
+	_, err = propagateService(client, ts, targetNamespace, workloadUID)
+	g.Expect(err).Should(MatchError("test client get error"))
+
+	// CREATE service error
+	client = NewSimpleClientset()
+	client.PrependReactor("create", "services", func(action Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, fmt.Errorf("test client create error")
+	})
+	_, err = propagateService(client, ts, targetNamespace, workloadUID)
+	g.Expect(err).Should(MatchError("test client create error"))
+
+	// UPDATE service error
+	client = NewSimpleClientset(ts)
+	client.PrependReactor("update", "services", func(action Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, fmt.Errorf("test client update error")
+	})
+	_, err = propagateService(client, ts, targetNamespace, workloadUID)
+	g.Expect(err).Should(MatchError("test client update error"))
+
+}
+
+func Test_create(t *testing.T) {
+	g := NewGomegaWithT(t)
+	tw := testWorkload()
+	td := testDeployment()
+	ts := testService()
+
+	client := NewSimpleClientset()
+
+	r := &Reconciler{
+		Client: NewFakeClient(tw),
+		propagateDeployment: func(i kubernetes.Interface, deployment *appsv1.Deployment, s string, s2 string) (*appsv1.Deployment, error) {
+			return td, nil
+		},
+		propagateService: func(i kubernetes.Interface, service *corev1.Service, s string, s2 string) (*corev1.Service, error) {
+			return ts, nil
+		},
+	}
+	expStatus := tw.Status.ConditionedStatus
+	expStatus.SetCreating()
+
+	rs, err := r._create(tw, client)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(rs).Should(Equal(result))
+	g.Expect(tw.Status.ConditionedStatus).Should(v1alpha1.MatchConditionedStatus(expStatus))
+	g.Expect(tw.Status.Deployment.UID).Should(Equal(td.UID))
+	g.Expect(tw.Status.Service.UID).Should(Equal(ts.UID))
+}
+
+func Test_create_Failures(t *testing.T) {
+	g := NewGomegaWithT(t)
+	tw := testWorkload()
+	client := NewSimpleClientset()
+
+	expStatus := tw.Status.ConditionedStatus
+	expStatus.SetCreating()
+
+	// Target namespace error
+	testError := "test error creating target namespace"
+	client.PrependReactor("create", "namespaces", func(action Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, fmt.Errorf(testError)
+	})
+	expStatus.SetFailed(errorCreating, testError)
+	r := &Reconciler{
+		Client: NewFakeClient(tw),
+	}
+	rs, err := r._create(tw, client)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(rs).Should(Equal(resultRequeue))
+	g.Expect(tw.Status.ConditionedStatus).Should(v1alpha1.MatchConditionedStatus(expStatus))
+	client.ReactionChain = client.ReactionChain[:0]
+
+	// Deployment propagation failure
+	testError = "test deployment propagation error"
+	r = &Reconciler{
+		Client: NewFakeClient(tw),
+		propagateDeployment: func(i kubernetes.Interface, deployment *appsv1.Deployment, s string, s2 string) (*appsv1.Deployment, error) {
+			return nil, fmt.Errorf(testError)
+		},
+	}
+
+	expStatus.SetFailed(errorCreating, "test deployment propagation error")
+
+	rs, err = r._create(tw, client)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(rs).Should(Equal(resultRequeue))
+	g.Expect(tw.Status.ConditionedStatus).Should(v1alpha1.MatchConditionedStatus(expStatus))
+
+	// Service propagation failure
+	testError = "test service propagation error"
+	r.propagateDeployment = func(i kubernetes.Interface, deployment *appsv1.Deployment, s string, s2 string) (*appsv1.Deployment, error) {
+		return testDeployment(), nil
+	}
+	r.propagateService = func(i kubernetes.Interface, deployment *corev1.Service, s string, s2 string) (*corev1.Service, error) {
+		return nil, fmt.Errorf(testError)
+	}
+	expStatus.SetFailed(errorCreating, "test deployment propagation error")
+
+	rs, err = r._create(tw, client)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(rs).Should(Equal(resultRequeue))
+	g.Expect(tw.Status.ConditionedStatus).Should(v1alpha1.MatchConditionedStatus(expStatus))
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -77,36 +77,6 @@ func ObjectToOwnerReference(r *corev1.ObjectReference) *metav1.OwnerReference {
 	}
 }
 
-// ApplyDeployment creates or updates existing deployment
-func ApplyDeployment(c kubernetes.Interface, d *appsv1.Deployment) (*appsv1.Deployment, error) {
-	dd, err := c.AppsV1().Deployments(d.Namespace).Create(d)
-	if err != nil {
-		if errors.IsAlreadyExists(err) {
-			return c.AppsV1().Deployments(d.Namespace).Update(d)
-		}
-		return nil, err
-	}
-	return dd, nil
-}
-
-// ApplyService creates or updates existing service
-func ApplyService(c kubernetes.Interface, s *corev1.Service) (*corev1.Service, error) {
-	ss, err := c.CoreV1().Services(s.Namespace).Create(s)
-	if err != nil {
-		if errors.IsAlreadyExists(err) {
-			// retrieve the existing server to grab `ClusterIP` value
-			ss, err := c.CoreV1().Services(s.Namespace).Get(s.Name, metav1.GetOptions{})
-			if err != nil {
-				return nil, err
-			}
-			s.Spec.ClusterIP = ss.Spec.ClusterIP
-			return c.CoreV1().Services(s.Namespace).Update(s)
-		}
-		return nil, err
-	}
-	return ss, nil
-}
-
 // ApplySecret creates or updates if exist kubernetes secret
 func ApplySecret(c kubernetes.Interface, s *corev1.Secret) (*corev1.Secret, error) {
 	_, err := c.CoreV1().Secrets(s.Namespace).Get(s.Name, metav1.GetOptions{})


### PR DESCRIPTION
Update Workload type to reflect references to target artifacts (deployment and service)
Update Target artifacts, by adding Workload reference label 
Update Workload controller to handle target artifacts collisions.

Resolves #305

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [ ] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [ ] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [ ] All related commits have been squashed to improve readability.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
