### PR TITLE
build: use cache helm tool for local clusters

### DIFF
--- a/cluster/local/local.sh
+++ b/cluster/local/local.sh
@@ -24,7 +24,7 @@ function copy_image_to_cluster() {
 case "${1:-}" in
   up)
     kubectl apply -f ${scriptdir}/helm-rbac.yaml
-    helm init --service-account tiller
+    ${HELM} init --service-account tiller
     kubectl -n kube-system rollout status deploy/tiller-deploy
     copy_image_to_cluster ${BUILD_IMAGE} ${FINAL_IMAGE}
     ;;
@@ -40,14 +40,14 @@ case "${1:-}" in
 
     [ "$2" ] && ns=$2 || ns="${DEFAULT_NAMESPACE}"
     echo "installing helm package(s) into \"$ns\" namespace"
-    helm install --name ${PROJECT_NAME} --namespace ${ns} ${projectdir}/cluster/charts/${PROJECT_NAME} --set image.pullPolicy=Never,imagePullSecrets=''
+    ${HELM} install --name ${PROJECT_NAME} --namespace ${ns} ${projectdir}/cluster/charts/${PROJECT_NAME} --set image.pullPolicy=Never,imagePullSecrets=''
     ;;
   helm-delete)
     echo "removing helm package"
-    helm del --purge ${PROJECT_NAME}
+    ${HELM} del --purge ${PROJECT_NAME}
     ;;
   helm-list)
-    helm list ${PROJECT_NAME} --all
+    ${HELM} list ${PROJECT_NAME} --all
     ;;
   *)
     echo "usage:" >&2

--- a/cluster/local/minikube.sh
+++ b/cluster/local/minikube.sh
@@ -64,7 +64,7 @@ case "${1:-}" in
     minikube addons enable ingress
 
     kubectl apply -f ${scriptdir}/helm-rbac.yaml
-    helm init --service-account tiller
+    ${HELM} init --service-account tiller
     kubectl -n kube-system rollout status deploy/tiller-deploy
     kubectl -n kube-system rollout status deploy/nginx-ingress-controller
     kubectl -n kube-system rollout status deploy/default-http-backend
@@ -99,20 +99,20 @@ case "${1:-}" in
 
     [ "$2" ] && ns=$2 || ns="${DEFAULT_NAMESPACE}"
     echo "installing helm package(s) into \"$ns\" namespace"
-    helm install --name ${PROJECT_NAME} --namespace ${ns} ${projectdir}/cluster/charts/${PROJECT_NAME} --set image.pullPolicy=Never,imagePullSecrets=''
+    ${HELM} install --name ${PROJECT_NAME} --namespace ${ns} ${projectdir}/cluster/charts/${PROJECT_NAME} --set image.pullPolicy=Never,imagePullSecrets=''
     ;;
   helm-upgrade)
     echo "copying image for helm"
     helm_tag="$(cat _output/version)"
     copy_image_to_cluster ${BUILD_IMAGE} "${DOCKER_REGISTRY}/${PROJECT_NAME}:${helm_tag}"
-    helm upgrade ${PROJECT_NAME} ${projectdir}/cluster/charts/${PROJECT_NAME}
+    ${HELM} upgrade ${PROJECT_NAME} ${projectdir}/cluster/charts/${PROJECT_NAME}
     ;;
   helm-delete)
     echo "removing helm package"
-    helm del --purge ${PROJECT_NAME}
+    ${HELM} del --purge ${PROJECT_NAME}
     ;;
   helm-list)
-    helm list ${PROJECT_NAME} --all
+    ${HELM} list ${PROJECT_NAME} --all
     ;;
   clean)
     minikube delete


### PR DESCRIPTION
Updated minikube.sh and local.sh to use the .cache folder helm tool so that there is no need for users to have helm installed on their host. This is consistent with the pattern followed in the crossplane build scripts.

Signed-off-by: HashedDan <daniel.mangum@slalom.com>

<!-- Please take a look at our [Contributing](../blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to Crossplane! -->

**Description of your changes:**
The local development scripts now use the helm tool in the .cache folder by determining OS / architecture of the local host and referencing the location of the tool in the minikube.sh and local.sh script.

**Which issue is resolved by this Pull Request:**
Resolves #187 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [ ] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [ ] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [ ] All related commits have been squashed to improve readability.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
