### PR TITLE
Have upbound-bot add PR comments for linter warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,6 +108,7 @@ linters:
     - interfacer
     - goconst
     - goimports
+    - gofmt  # We enable this as well as goimports for its simplify mode.
     - prealloc
     - golint
   enable-all: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,17 +52,49 @@ This is a rough outline of what a contributor's workflow looks like:
 - Make your changes and arrange them in readable commits.
 - Make sure your commit messages are in the proper format (see below).
 - Push your changes to the branch in your fork of the repository.
-- Make sure all tests pass, and add any new tests as appropriate.
+- Make sure all linters and tests pass, and add any new tests as appropriate.
 - Submit a pull request to the original repository.
 
 ## Building
 
 Details about building crossplane can be found in [INSTALL.md](INSTALL.md).
 
-## Coding Style
+## Coding Style and Linting
 
-Crossplane projects are written in golang and follows the style guidelines dictated by
-the go fmt as well as go vet tools.
+Crossplane projects are written in Go. Coding style is enforced by
+[golangci-lint](https://github.com/golangci/golangci-lint). Crossplane's linter
+configuration is [documented here](.golangci.yml). Builds will fail locally and
+in CI if linter warnings are introduced:
+
+```bash
+$ make build
+==> Linting /REDACTED/go/src/github.com/crossplaneio/crossplane/cluster/charts/crossplane
+[INFO] Chart.yaml: icon is recommended
+
+1 chart(s) linted, no failures
+20:31:42 [ .. ] helm dep crossplane 0.1.0-136.g2dfb012.dirty
+No requirements found in /REDACTED/go/src/github.com/crossplaneio/crossplane/cluster/charts/crossplane/charts.
+20:31:42 [ OK ] helm dep crossplane 0.1.0-136.g2dfb012.dirty
+20:31:42 [ .. ] golangci-lint
+pkg/clients/azure/redis/redis.go:35:7: exported const `NamePrefix` should have comment or be unexported (golint)
+const NamePrefix = "acr"
+      ^
+20:31:55 [FAIL]
+make[2]: *** [go.lint] Error 1
+make[1]: *** [build.all] Error 2
+make: *** [build] Error 2
+```
+
+Note that Jenkins builds will not output linter warnings in the build log.
+Instead `upbound-bot` will leave comments on your pull request when a build
+fails due to linter warnings. You can run `make lint` locally to help determine
+whether you've fixed any linter warnings detected by Jenkins.
+
+In some cases linter warnings will be false positives. `golangci-lint` supports
+`//nolint[:lintername]` comment directives in order to quell them. Please
+include an explanatory comment if you must add a `//nolint` comment. You may
+also submit a PR against [`.golangci.yml`](.golangci.yml) if you feel
+particular linter warning should be permanently disabled.
 
 ## Comments
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@ pipeline {
     }
 
     environment {
+        RUNNING_IN_CI = 'true'
         DOCKER = credentials('dockerhub-upboundci')
         AWS = credentials('aws-upbound-bot')
         GITHUB_UPBOUND_BOT = credentials('github-upbound-jenkins')

--- a/hack/linter-violation.tmpl
+++ b/hack/linter-violation.tmpl
@@ -1,0 +1,3 @@
+`{{violation.rule}}`: {{violation.message}}
+
+Refer to Crossplane's [coding style documentation](CONTRIBUTING.md#coding-style-and-linting) for more information.


### PR DESCRIPTION
**Description of your changes:** This PR configures `upbound-bot` to leave a pull request comment for all linter warnings detected during a Jenkins build. Builds will fail, preventing PR merge, until all linter warnings are addressed. Here's an example of a linter warning:

<img width="718" alt="screen shot 2019-03-07 at 11 02 47 am" src="https://user-images.githubusercontent.com/1049349/53982574-1b790c00-40ca-11e9-81ff-deb4a4ecfb40.png">

**Note that this PR is dependent on https://github.com/upbound/build/pull/51**, which updates our makefile library to run the linter as part of `make build`, as well as having the linter generate checkstyle rather than human readable output when the `RUNNING_IN_CI` environment variable is `true`.

**Which issue is resolved by this Pull Request:** Resolves #327 (for reals this time)

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [ ] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [ ] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [x] All related commits have been squashed to improve readability.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

Below is the original approach I took before switching to the Github comments plugin.

---

This PR configures Jenkins to archive any checkstyle reports generated as part of the build, where they can be analysed via the [warnings-ng](https://github.com/jenkinsci/warnings-ng-plugin) Jenkins plugin. This plugin shows overall linter errors over time, as well as providing a commented source code view pointing out linter issues.

I introduced some artificial linter errors [in this build](https://jenkinsci.upbound.io/job/crossplane/job/build/job/PR-332/14/checkstyle/), resulting in the following:
<img width="1148" alt="screen shot 2019-03-06 at 8 18 09 pm" src="https://user-images.githubusercontent.com/1049349/53932184-47a27780-404d-11e9-9aa7-fad8a4536a5c.png">

Clicking through on a linter warning shows you where it is in the code:
<img width="1128" alt="screen shot 2019-03-06 at 8 19 04 pm" src="https://user-images.githubusercontent.com/1049349/53932199-5be67480-404d-11e9-9756-d7a0f50f32ff.png">


The main drawback to this approach is that `golangci-lint` can't output _both_ checkstyle XML and human readable output. This means that when a linter error is introduced it will be obvious from the build log that the build failed due to a linter warning, but it will not be immediately obvious how to diagnose the problem. The PR author must exist Jenkins "Blue Ocean" and select the "Checkstyle" menu item to the left of their build in the classic UI in order to see what the problem was. Alternatively they could just run `make lint` locally.

We could alternatively enable https://golangci.com/'s native Github integration, which runs the linter on their infrastructure and leaves easily discoverable Github comments. We're disinclined to take this route at the current time due to the fact that gitlabci requests _a lot_ of permissions (including read/write to all repository data and settings) before it can be enabled. We've raised https://github.com/golangci/golangci/issues/32 to follow up on this.