### PR TITLE
Add Code coverage reporting to crossplane project.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,7 +112,7 @@ pipeline {
                     }
                 }
                 script {
-                    sh 'curl -s https://codecov.collibra.com/bash | bash -s -- -c -f _output/tests/**/coverage.txt'
+                    sh 'curl -s https://codecov.collibra.com/bash | bash -s -- -c -f _output/tests/**/coverage.txt -F unittests'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@ pipeline {
         DOCKER = credentials('dockerhub-upboundci')
         AWS = credentials('aws-upbound-bot')
         GITHUB_UPBOUND_BOT = credentials('github-upbound-jenkins')
+        CODECOV_TOKEN = credentials('codecov-crossplane')
     }
 
     stages {
@@ -109,6 +110,9 @@ pipeline {
                             sh "./build/run make -j\$(nproc) promote BRANCH_NAME=master CHANNEL=master AWS_ACCESS_KEY_ID=${AWS_USR} AWS_SECRET_ACCESS_KEY=${AWS_PSW}"
                         }
                     }
+                }
+                script {
+                    sh 'curl -s https://codecov.collibra.com/bash | bash -s -- -c -f _output/tests/**/coverage.txt'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,7 +90,21 @@ pipeline {
                 always {
                     archiveArtifacts "_output/tests/**/*"
                     junit "_output/tests/**/unit-tests.xml"
-                    cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: '_output/tests/**/coverage.xml', enableNewApi: false, failUnhealthy: false, failUnstable: false, maxNumberOfBuilds: 0, onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false, classCoverageTargets: '50, 0, 0', conditionalCoverageTargets: '70, 0, 0', lineCoverageTargets: '40, 0, 0', methodCoverageTargets: '30, 0, 0', packageCoverageTargets: '80, 0, 0'
+                    cobertura coberturaReportFile: '_output/tests/**/coverage.xml',
+                            classCoverageTargets: '50, 0, 0',
+                            conditionalCoverageTargets: '70, 0, 0',
+                            lineCoverageTargets: '40, 0, 0',
+                            methodCoverageTargets: '30, 0, 0',
+                            packageCoverageTargets: '80, 0, 0',
+                            autoUpdateHealth: false,
+                            autoUpdateStability: false,
+                            enableNewApi: false,
+                            failUnhealthy: false,
+                            failUnstable: false,
+                            maxNumberOfBuilds: 0,
+                            onlyStable: false,
+                            sourceEncoding: 'ASCII',
+                            zoomCoverageChart: false
                 }
             }
         }
@@ -112,7 +126,7 @@ pipeline {
                     }
                 }
                 script {
-                    sh 'curl -s https://codecov.collibra.com/bash | bash -s -- -c -f _output/tests/**/coverage.txt -F unittests'
+                    sh 'curl -s https://codecov.io/bash | bash -s -- -c -f _output/tests/**/coverage.txt -F unittests'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,6 +89,7 @@ pipeline {
                 always {
                     archiveArtifacts "_output/tests/**/*"
                     junit "_output/tests/**/unit-tests.xml"
+                    cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: '_output/tests/**/coverage.xml', enableNewApi: false, failUnhealthy: false, failUnstable: false, maxNumberOfBuilds: 0, onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false, classCoverageTargets: '50, 0, 0', conditionalCoverageTargets: '70, 0, 0', lineCoverageTargets: '40, 0, 0', methodCoverageTargets: '30, 0, 0', packageCoverageTargets: '80, 0, 0'
                 }
             }
         }


### PR DESCRIPTION
Add code coverage reporting to the project:
- CICD: leveraging Cobertura reports 
![image](https://user-images.githubusercontent.com/324803/53992802-9f3ef280-40e2-11e9-933a-0d1a3ea7b479.png)
![image](https://user-images.githubusercontent.com/324803/53992843-ac5be180-40e2-11e9-9b65-6e3f6d413624.png)
- GitHub PR: leveraging `codecov.io` integration