### PR TITLE
Enable the unconvert, misspell, and nakedret linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -111,12 +111,9 @@ linters:
     - gofmt  # We enable this as well as goimports for its simplify mode.
     - prealloc
     - golint
-  enable-all: false
-
-  disable:
-    - maligned
-    # - prealloc
-  disable-all: false
+    - unconvert
+    - misspell
+    - nakedret
 
   presets:
     - bugs

--- a/pkg/clients/aws/aws_test.go
+++ b/pkg/clients/aws/aws_test.go
@@ -38,13 +38,13 @@ func TestCredentialsIdSecret(t *testing.T) {
 	credentials := []byte(fmt.Sprintf(awsCredentialsFileFormat, testProfile, testID, testSecret))
 
 	// valid profile
-	id, secret, err := CredentialsIDSecret([]byte(credentials), testProfile)
+	id, secret, err := CredentialsIDSecret(credentials, testProfile)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(id).To(Equal(testID))
 	g.Expect(secret).To(Equal(testSecret))
 
 	// invalid profile - foo does not exist
-	id, secret, err = CredentialsIDSecret([]byte(credentials), "foo")
+	id, secret, err = CredentialsIDSecret(credentials, "foo")
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(id).To(Equal(""))
 	g.Expect(secret).To(Equal(""))
@@ -59,7 +59,7 @@ func TestLoadConfig(t *testing.T) {
 	testRegion := "us-west-2"
 	credentials := []byte(fmt.Sprintf(awsCredentialsFileFormat, testProfile, testID, testSecret))
 
-	config, err := LoadConfig([]byte(credentials), testProfile, testRegion)
+	config, err := LoadConfig(credentials, testProfile, testRegion)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(config).NotTo(BeNil())
 }

--- a/pkg/clients/aws/s3/s3.go
+++ b/pkg/clients/aws/s3/s3.go
@@ -104,7 +104,7 @@ func (c *Client) UpdateBucketACL(spec *v1alpha1.S3BucketSpec) error {
 	var err error
 	if spec.CannedACL != nil {
 		input := &s3.PutBucketAclInput{
-			ACL:    s3.BucketCannedACL(*spec.CannedACL),
+			ACL:    *spec.CannedACL,
 			Bucket: &spec.Name,
 		}
 		_, err = c.s3.PutBucketAclRequest(input).Send()
@@ -186,7 +186,7 @@ func CreateBucketInput(spec *v1alpha1.S3BucketSpec) *s3.CreateBucketInput {
 		Bucket:                    &spec.Name,
 	}
 	if spec.CannedACL != nil {
-		bucketInput.ACL = s3.BucketCannedACL(*spec.CannedACL)
+		bucketInput.ACL = *spec.CannedACL
 	}
 	return bucketInput
 }

--- a/pkg/clients/azure/sql.go
+++ b/pkg/clients/azure/sql.go
@@ -482,7 +482,7 @@ func SQLServerStatusMessage(instanceName string, state string) string {
 	case mysql.ServerStateReady:
 		return fmt.Sprintf("SQL Server instance %s is ready", instanceName)
 	default:
-		return fmt.Sprintf("SQL Server instance %s is in an unknown state %s", instanceName, string(state))
+		return fmt.Sprintf("SQL Server instance %s is in an unknown state %s", instanceName, state)
 	}
 }
 

--- a/pkg/controller/aws/cache/replicationgroup.go
+++ b/pkg/controller/aws/cache/replicationgroup.go
@@ -58,8 +58,8 @@ const (
 	maxAuthTokenData = 32
 )
 
-// A creater can create resources in an external store - e.g. the AWS API.
-type creater interface {
+// A creator can create resources in an external store - e.g. the AWS API.
+type creator interface {
 	// Create the supplied resource in the external store. Returns true if the
 	// resource requires further reconciliation.
 	Create(ctx context.Context, r *v1alpha1.ReplicationGroup) (requeue bool)
@@ -89,7 +89,7 @@ type keyer interface {
 // store - e.g. the AWS API. It can also return keys (i.e. credentials) for
 // resources.
 type createsyncdeletekeyer interface {
-	creater
+	creator
 	syncer
 	deleter
 	keyer

--- a/pkg/controller/aws/provider/provider_test.go
+++ b/pkg/controller/aws/provider/provider_test.go
@@ -154,7 +154,7 @@ func TestReconcileSecretKeyNotFound(t *testing.T) {
 func TestReconcileInvalidationPassed(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ts := testSecret([]byte(testSecretData("default", "test-id", "test-secret")))
+	ts := testSecret(testSecretData("default", "test-id", "test-secret"))
 	tp := testProvider()
 
 	r := &Reconciler{
@@ -206,7 +206,7 @@ func TestReconcileInvalidCredentialsFormat(t *testing.T) {
 func TestReconcileValidationFailed(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	ts := testSecret([]byte(testSecretData("default", "test-id", "test-secret")))
+	ts := testSecret(testSecretData("default", "test-id", "test-secret"))
 	tp := testProvider()
 
 	r := &Reconciler{

--- a/pkg/controller/azure/cache/redis.go
+++ b/pkg/controller/azure/cache/redis.go
@@ -55,8 +55,8 @@ const (
 	reconcileTimeout = 1 * time.Minute
 )
 
-// A creater can create resources in an external store - e.g. the Azure API.
-type creater interface {
+// A creator can create resources in an external store - e.g. the Azure API.
+type creator interface {
 	// Create the supplied resource in the external store. Returns true if the
 	// resource requires further reconciliation.
 	Create(ctx context.Context, r *v1alpha1.Redis) (requeue bool)
@@ -86,7 +86,7 @@ type keyer interface {
 // store - e.g. the Azure API. It can also return keys (i.e. credentials) for
 // resources.
 type createsyncdeletekeyer interface {
-	creater
+	creator
 	syncer
 	deleter
 	keyer

--- a/pkg/controller/azure/database/sqlserver.go
+++ b/pkg/controller/azure/database/sqlserver.go
@@ -132,7 +132,7 @@ func (r *SQLReconciler) handleReconcile(instance azuredbv1alpha1.SQLServer) (rec
 	}
 
 	// SQL Server instance exists, update the CRD status now with its latest status
-	stateChanged := instance.GetStatus().State != string(server.State)
+	stateChanged := instance.GetStatus().State != server.State
 	conditionType := azureclients.SQLServerConditionType(server.State)
 	if err := r.updateStatus(instance, azureclients.SQLServerStatusMessage(instance.GetName(), server.State), server); err != nil {
 		// updating the CRD status failed, return the error and try the next reconcile loop
@@ -333,7 +333,7 @@ func (r *SQLReconciler) updateStatus(instance azuredbv1alpha1.SQLServer, message
 		ConditionedStatus:    oldStatus.ConditionedStatus,
 		BindingStatusPhase:   oldStatus.BindingStatusPhase,
 		Message:              message,
-		State:                string(server.State),
+		State:                server.State,
 		ProviderID:           server.ID,
 		Endpoint:             server.FQDN,
 		RunningOperation:     oldStatus.RunningOperation,

--- a/pkg/controller/compute/workload/workload.go
+++ b/pkg/controller/compute/workload/workload.go
@@ -231,8 +231,7 @@ func propagateDeployment(k kubernetes.Interface, d *appsv1.Deployment, ns, uid s
 		return k.AppsV1().Deployments(d.Namespace).Create(d)
 	}
 
-	l := getWorkloadReferenceLabel(dd.ObjectMeta)
-	if l == string(uid) {
+	if getWorkloadReferenceLabel(dd.ObjectMeta) == uid {
 		return k.AppsV1().Deployments(d.Namespace).Update(d)
 	}
 
@@ -260,8 +259,7 @@ func propagateService(k kubernetes.Interface, s *corev1.Service, ns, uid string)
 		return k.CoreV1().Services(s.Namespace).Create(s)
 	}
 
-	l := getWorkloadReferenceLabel(ss.ObjectMeta)
-	if l == string(uid) {
+	if getWorkloadReferenceLabel(ss.ObjectMeta) == uid {
 		return k.CoreV1().Services(s.Namespace).Update(s)
 	}
 

--- a/pkg/controller/compute/workload/workload_test.go
+++ b/pkg/controller/compute/workload/workload_test.go
@@ -343,7 +343,7 @@ func Test_addWorkloadReferenceLabel(t *testing.T) {
 			addWorkloadReferenceLabel(tt.args.m, tt.args.uid)
 		})
 		g.Expect(tt.args.m.Labels).ShouldNot(BeNil())
-		g.Expect(tt.args.m.Labels).Should(HaveKeyWithValue(workloadReferenceLabelKey, string(tt.args.uid)))
+		g.Expect(tt.args.m.Labels).Should(HaveKeyWithValue(workloadReferenceLabelKey, tt.args.uid))
 	}
 }
 

--- a/pkg/controller/gcp/cache/cloudmemorystore_instance.go
+++ b/pkg/controller/gcp/cache/cloudmemorystore_instance.go
@@ -53,8 +53,8 @@ const (
 	reconcileTimeout = 1 * time.Minute
 )
 
-// A creater can create instances in an external store - e.g. the GCP API.
-type creater interface {
+// A creator can create instances in an external store - e.g. the GCP API.
+type creator interface {
 	// Create the supplied instance in the external store. Returns true if the
 	// instance requires further reconciliation.
 	Create(ctx context.Context, i *v1alpha1.CloudMemorystoreInstance) (requeue bool)
@@ -77,7 +77,7 @@ type deleter interface {
 // A createsyncdeleter an create, sync, and delete instances in an external
 // store - e.g. the GCP API.
 type createsyncdeleter interface {
-	creater
+	creator
 	syncer
 	deleter
 }

--- a/pkg/test/fake.go
+++ b/pkg/test/fake.go
@@ -26,7 +26,7 @@ import (
 var _ client.Client = &MockClient{}
 
 // MockClient implements controller-runtime's Client interface, allowing each
-// method to be overriden for testing. The controller-runtime provides a fake
+// method to be overridden for testing. The controller-runtime provides a fake
 // client, but it is has surprising side effects (e.g. silently calling
 // os.Exit(1)) and does not allow us control over the errors it returns.
 type MockClient struct {


### PR DESCRIPTION
**Description of your changes:** This PR enables a few more linters. The removed lines are no-ops - they matched the default settings and were in my opinion a little confusing. We now have the following linters enabled:

```
$ golangci-lint linters
Enabled by your configuration linters:
govet (vet, vetshadow): Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string [fast: true, auto-fix: false]
interfacer: Linter that suggests narrower interface types [fast: false, auto-fix: false]
golint: Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes [fast: true, auto-fix: false]
unconvert: Remove unnecessary type conversions [fast: true, auto-fix: false]
gocritic: The most opinionated Go source code linter [fast: true, auto-fix: false]
goimports: Goimports does everything that gofmt does. Additionally it checks unused imports [fast: true, auto-fix: true]
gofmt: Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification [fast: true, auto-fix: true]
staticcheck: Staticcheck is a go vet on steroids, applying a ton of static analysis checks [fast: false, auto-fix: false]
scopelint: Scopelint checks for unpinned variables in go programs [fast: true, auto-fix: false]
varcheck: Finds unused global variables and constants [fast: true, auto-fix: false]
deadcode: Finds unused code [fast: true, auto-fix: false]
misspell: Finds commonly misspelled English words in comments [fast: true, auto-fix: true]
nakedret: Finds naked returns in functions greater than a specified function length [fast: true, auto-fix: false]
gosec (gas): Inspects source code for security problems [fast: true, auto-fix: false]
structcheck: Finds an unused struct fields [fast: true, auto-fix: false]
unparam: Reports unused function parameters [fast: false, auto-fix: false]
gosimple: Linter for Go source code that specializes in simplifying a code [fast: false, auto-fix: false]
gocyclo: Computes and checks the cyclomatic complexity of functions [fast: true, auto-fix: false]
goconst: Finds repeated strings that could be replaced by a constant [fast: true, auto-fix: false]
prealloc: Finds slice declarations that could potentially be preallocated [fast: true, auto-fix: false]
errcheck: Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases [fast: true, auto-fix: false]
typecheck: Like the front-end of a Go compiler, parses and type-checks Go code [fast: true, auto-fix: false]
unused: Checks Go code for unused constants, variables, functions and types [fast: false, auto-fix: false]
ineffassign: Detects when assignments to existing variables are not used [fast: true, auto-fix: false]

Disabled by your configuration linters:
stylecheck: Stylecheck is a replacement for golint [fast: false, auto-fix: false]
dupl: Tool for code clone detection [fast: true, auto-fix: false]
maligned: Tool to detect Go structs that would take less memory if their fields were sorted [fast: true, auto-fix: false]
depguard: Go linter that checks if package imports are in a list of acceptable packages [fast: true, auto-fix: false]
lll: Reports long lines [fast: true, auto-fix: false]
gochecknoinits: Checks that no init functions are present in Go code [fast: true, auto-fix: false]
gochecknoglobals: Checks that no globals are present in Go code [fast: true, auto-fix: false]
```

**Which issue is resolved by this Pull Request:** N/A

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [ ] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [ ] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [x] All related commits have been squashed to improve readability.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
