### PR TITLE
Use an absolute link to CONTRIBUTING.md in linter comments

### DIFF
--- a/hack/linter-violation.tmpl
+++ b/hack/linter-violation.tmpl
@@ -1,3 +1,3 @@
 `{{violation.rule}}`: {{violation.message}}
 
-Refer to Crossplane's [coding style documentation](CONTRIBUTING.md#coding-style-and-linting) for more information.
+Refer to Crossplane's [coding style documentation](https://github.com/crossplaneio/crossplane/blob/master/CONTRIBUTING.md#coding-style-and-linting) for more information.


### PR DESCRIPTION
https://github.com/crossplaneio/crossplane/pull/336

I raised the above PR to ensure linter comments were working as expected now that I've merged my changes to master, and noticed my attempt at a relative link failed. It links relative to either the base PR URL, or the PR's files URL, depending on where you view the link from.

I'd prefer to somehow have a stable link relative to the repo root, but failing that this seems like the next best option.