### PR TITLE
Extract endpoints for Replication Groups with cluster mode disabled

### DIFF
--- a/pkg/controller/aws/cache/replicationgroup.go
+++ b/pkg/controller/aws/cache/replicationgroup.go
@@ -168,10 +168,9 @@ func (e *elastiCache) Sync(ctx context.Context, g *v1alpha1.ReplicationGroup) bo
 		return true
 	}
 
-	if replicationGroup.ConfigurationEndpoint != nil {
-		g.Status.Endpoint = aws.StringValue(replicationGroup.ConfigurationEndpoint.Address)
-		g.Status.Port = aws.Int64Value(replicationGroup.ConfigurationEndpoint.Port)
-	}
+	ep := elasticache.ConnectionEndpoint(replicationGroup)
+	g.Status.Endpoint = ep.Address
+	g.Status.Port = ep.Port
 	g.Status.ProviderID = aws.StringValue(replicationGroup.ReplicationGroupId)
 	g.Status.ClusterEnabled = aws.BoolValue(replicationGroup.ClusterEnabled)
 	g.Status.MemberClusters = replicationGroup.MemberClusters

--- a/pkg/controller/aws/cache/replicationgroup_test.go
+++ b/pkg/controller/aws/cache/replicationgroup_test.go
@@ -155,6 +155,9 @@ func replicationGroup(rm ...replicationGroupModifier) *v1alpha1.ReplicationGroup
 			ProviderRef:                corev1.LocalObjectReference{Name: providerName},
 			ConnectionSecretRef:        corev1.LocalObjectReference{Name: connectionSecretName},
 		},
+		Status: v1alpha1.ReplicationGroupStatus{
+			ClusterEnabled: true,
+		},
 	}
 
 	for _, m := range rm {
@@ -343,6 +346,7 @@ func TestSync(t *testing.T) {
 									CacheNodeType:          aws.String(cacheNodeType),
 									SnapshotRetentionLimit: aws.Int64(snapshotRetentionLimit),
 									SnapshotWindow:         aws.String(snapshotWindow),
+									ClusterEnabled:         aws.Bool(true),
 									ConfigurationEndpoint:  &elasticache.Endpoint{Address: aws.String(host), Port: aws.Int64(port)},
 								}},
 							},
@@ -395,6 +399,7 @@ func TestSync(t *testing.T) {
 									CacheNodeType:          aws.String(cacheNodeType),
 									SnapshotRetentionLimit: aws.Int64(snapshotRetentionLimit),
 									SnapshotWindow:         aws.String(snapshotWindow),
+									ClusterEnabled:         aws.Bool(true),
 									ConfigurationEndpoint:  &elasticache.Endpoint{Address: aws.String(host), Port: aws.Int64(port)},
 								}},
 							},
@@ -452,6 +457,7 @@ func TestSync(t *testing.T) {
 									CacheNodeType:          aws.String(cacheNodeType),
 									SnapshotRetentionLimit: aws.Int64(snapshotRetentionLimit),
 									SnapshotWindow:         aws.String(snapshotWindow),
+									ClusterEnabled:         aws.Bool(true),
 									ConfigurationEndpoint:  &elasticache.Endpoint{Address: aws.String(host), Port: aws.Int64(port)},
 								}},
 							},
@@ -531,6 +537,7 @@ func TestSync(t *testing.T) {
 							Data: &elasticache.DescribeReplicationGroupsOutput{
 								ReplicationGroups: []elasticache.ReplicationGroup{{
 									Status:         aws.String(v1alpha1.StatusAvailable),
+									ClusterEnabled: aws.Bool(true),
 									MemberClusters: []string{cacheClusterID},
 								}},
 							},
@@ -579,6 +586,7 @@ func TestSync(t *testing.T) {
 									CacheNodeType:          aws.String(cacheNodeType),
 									SnapshotRetentionLimit: aws.Int64(snapshotRetentionLimit),
 									SnapshotWindow:         aws.String(snapshotWindow),
+									ClusterEnabled:         aws.Bool(true),
 									ConfigurationEndpoint:  &elasticache.Endpoint{Address: aws.String(host), Port: aws.Int64(port)},
 								}},
 							},


### PR DESCRIPTION
**Description of your changes:** The AWS API returns the endpoint(s) you should use to connect to an ElastiCache Replication Group in different places depending on how the Replication Group is configured. This PR handles the case in which cluster mode is disabled.

**Which issue is resolved by this Pull Request:** This is a _partial_ fix for #345.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [ ] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [ ] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [ ] All related commits have been squashed to improve readability.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
