### PR TITLE
Replace CodeCov with SonarCloud 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,6 +109,36 @@ pipeline {
             }
         }
 
+        stage('SonarQube Analysis') {
+            steps {
+                script {
+                    scannerHome = tool 'SonarQubeScanner'
+                    scannerParams = ''
+                    if (env.CHANGE_ID == null) {
+                        scannerParams = "-Dsonar.branch.name=${BRANCH_NAME} "
+
+                        if (BRANCH_NAME != 'master') {
+                            scannerParams = "${scannerParams} -Dsonar.branch.target=master"
+                        }
+                    } else {
+                        scannerParams = "-Dsonar.pullrequest.base=master " +
+                            "-Dsonar.pullrequest.branch=${env.BRANCH_NAME} " +
+                            "-Dsonar.pullrequest.key=${env.CHANGE_ID}  " +
+                            "-Dsonar.pullrequest.provider=github " +
+                            "-Dsonar.pullrequest.github.repository=crossplaneio/${env.REPOSITORY_NAME}"
+                    }
+                }
+
+                withSonarQubeEnv('SonarQubeCrossplane') {
+                  sh "${scannerHome}/bin/sonar-scanner " +
+                    "-Dsonar.projectKey=crossplaneio_${env.REPOSITORY_NAME} " +
+                    "-Dsonar.projectName=${env.REPOSITORY_NAME} " +
+                    "-Dsonar.organization=crossplane " +
+                    "-Dsonar.sources=. ${scannerParams} "
+                }
+            }
+        }
+
         stage('Publish') {
             when {
                 expression {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -155,9 +155,6 @@ pipeline {
                         }
                     }
                 }
-                script {
-                    sh 'curl -s https://codecov.io/bash | bash -s -- -c -f _output/tests/**/coverage.txt -F unittests'
-                }
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,7 +115,6 @@ pipeline {
                     scannerParams = ''
                     if (env.CHANGE_ID == null) {
                         scannerParams = "-Dsonar.branch.name=${BRANCH_NAME} "
-
                         if (BRANCH_NAME != 'master') {
                             scannerParams = "${scannerParams} -Dsonar.branch.target=master"
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,9 +25,8 @@ pipeline {
         stage('Prepare') {
             steps {
                 script {
-                    if (env.BRANCH_NAME =~ /^PR-\d+$/) {
-                        def pr_number = sh (script: "echo ${env.BRANCH_NAME} | grep -o -E '[0-9]+' ", returnStdout: true)
-                        def json = sh (script: "curl -s https://api.github.com/repos/crossplaneio/crossplane/pulls/${pr_number}", returnStdout: true).trim()
+                    if (env.CHANGE_ID == null) {
+                        def json = sh (script: "curl -s https://api.github.com/repos/crossplaneio/crossplane/pulls/${env.CHANGE_ID}", returnStdout: true).trim()
                         def body = evaluateJson(json,'${json.body}')
                         if (body.contains("[skip ci]")) {
                             echo ("'[skip ci]' spotted in PR body text.")


### PR DESCRIPTION
### Change 
Replace Codecov with Sonar[Cloud]

### Overview
Currently, `crossplane` is using [codecov](https://codecov.io/) SaaS for code coverage analysis and reporting.
This service is free for open source projects and requires minimal integration with CICD.
![image](https://user-images.githubusercontent.com/324803/55840069-f91a4a00-5ade-11e9-9f92-57c50bcfade2.png)

This PR replaces `codecov` with [sonarcloud](https://sonarcloud.io/about), also a SaaS code analysis service. Similar to `codecov` it is free for open source projects, and also provides code coverage report. 
Unlike `codecov`, `sonarcloud` provide additional code analysis reports: bugs, vulnerabilities, code smells, code duplication. 

![image](https://user-images.githubusercontent.com/324803/55840117-25ce6180-5adf-11e9-9c46-2da2dd5b4bd3.png)

SonarQube is integrated with CICD via Jenkins SonarScan plugin and invoked from the Jenksins pipeline. The invocation call is more detailed in terms of arguments (different set per PR vs Master).
In addition, SonarCloud provides additional (and very details) set of customization per project at the cloud interface.

### Run-time
SonarScan analysis is very quick, with duration 10-17 seconds, including uploading the report to the cloud.
```
15:36:59  INFO: ------------------------------------------------------------------------
15:36:59  INFO: EXECUTION SUCCESS
15:36:59  INFO: ------------------------------------------------------------------------
15:36:59  INFO: Total time: 16.883s
15:36:59  INFO: Final Memory: 42M/951M
```
Whereas, codecov runtime is typically 90 seconds+
```
15:37:14   / ____|        | |
15:37:14  | |     ___   __| | ___  ___ _____   __
15:37:14  | |    / _ \ / _` |/ _ \/ __/ _ \ \ / /
15:37:14  | |___| (_) | (_| |  __/ (_| (_) \ V /
15:37:14   \_____\___/ \__,_|\___|\___\___/ \_/
15:37:14                                Bash-8a28df4
15:37:14  
15:37:14  
15:37:14  [0;90m==>[0m Jenkins CI detected.
15:37:14      [0;90mproject root:[0m .
15:37:14  [0;90m-->[0m token set from env
15:37:14      [0;32mYaml not found, that's ok! Learn more at[0m [0;36mhttp://docs.codecov.io/docs/codecov-yaml[0m
15:37:14      [0;90m->[0m Found 1 reports
15:37:14  [0;90m==>[0m Detecting git/mercurial file structure
15:37:14  [0;90m==>[0m Reading reports
15:37:14      [0;32m+[0m _output/tests/linux_amd64/coverage.txt [0;90mbytes=293686[0m
15:37:14  [0;90m==>[0m Appending adjustments
15:37:14      [0;36mhttp://docs.codecov.io/docs/fixing-reports[0m
15:39:06      [0;32m+[0m Found adjustments
15:39:06  [0;90m==>[0m Gzipping contents
```

### Notifications
SonarCloud provides minimalist PR decorations in terms of PR check:
![image](https://user-images.githubusercontent.com/324803/55840404-1ef41e80-5ae0-11e9-81e0-b7455846f98d.png)
With additional details when expanded:
![image](https://user-images.githubusercontent.com/324803/55840483-5f539c80-5ae0-11e9-997a-b529dd0a3e44.png)
With further link to SonarCloud report (under SonarCloud account)

`codecov`  provide PR comment notification style with chart and changes summary
![image](https://user-images.githubusercontent.com/324803/55840544-945fef00-5ae0-11e9-94ff-341471d31e39.png)
With further link to Codecov report (under Codecov account)

### Change Justification

Codecov reports seem to be inconsistent in terms of coverage data they represent. This inconsistency is both in terms of different PR's or in terms of two different commits under the same PR.
For example, this PR changes limited to a single file `Jenkinsfile`, which have 0% impact on coverage, yet `codecov` currently reports:
![image](https://user-images.githubusercontent.com/324803/55840639-f882b300-5ae0-11e9-84d0-7a4b4bec1d66.png)

We have observed this behavior across multiple PR's.
