### PR TITLE
update recent object storage controllers to use consistent logging pattern

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,5 +14,6 @@ Resolves #
 - [ ] Code generation (`make generate`) has been run to update object specifications, if necessary.
 - [ ] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
 - [ ] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
+- [ ] RBAC permissions in `clusterrole.yaml` have been updated to include new types, if necessary
 - [ ] All related commits have been squashed to improve readability.
 - [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

--- a/cluster/charts/crossplane/templates/clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/clusterrole.yaml
@@ -61,6 +61,7 @@ rules:
   - cache.azure.crossplane.io
   - compute.azure.crossplane.io
   - database.azure.crossplane.io
+  - storage.azure.crossplane.io
   - gcp.crossplane.io
   - cache.gcp.crossplane.io
   - compute.gcp.crossplane.io

--- a/pkg/apis/azure/storage/v1alpha1/account.go
+++ b/pkg/apis/azure/storage/v1alpha1/account.go
@@ -18,12 +18,17 @@ package v1alpha1
 
 import (
 	"encoding/json"
-	"log"
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2017-06-01/storage"
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/Azure/go-autorest/autorest/to"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/crossplaneio/crossplane/pkg/logging"
+)
+
+var (
+	log = logging.Logger.WithName(Group)
 )
 
 // CustomDomain the custom domain assigned to this storage account.
@@ -50,6 +55,7 @@ func toStorageCustomDomain(c *CustomDomain) *storage.CustomDomain {
 	if c == nil {
 		return nil
 	}
+
 	return &storage.CustomDomain{
 		Name:             toStringPtr(c.Name),
 		UseSubDomainName: to.BoolPtr(c.UseSubDomainName),
@@ -675,7 +681,7 @@ func NewStorageAccountSpec(a *storage.Account) *StorageAccountSpec {
 func parseStorageAccountSpec(s string) *StorageAccountSpec {
 	sas := &StorageAccountSpec{}
 	if err := json.Unmarshal([]byte(s), sas); err != nil {
-		log.Printf("error parsing storage account spec: %v\n", err)
+		log.Error(err, "error parsing storage account spec")
 	}
 	return sas
 }

--- a/pkg/apis/azure/storage/v1alpha1/account_test.go
+++ b/pkg/apis/azure/storage/v1alpha1/account_test.go
@@ -1017,6 +1017,11 @@ func Test_parseStorageAccountSpec(t *testing.T) {
 			args: storageAccountSpecString,
 			want: storageAccountSpec,
 		},
+		{
+			name: "parse-failure",
+			args: `{`, // malformed JSON input
+			want: &StorageAccountSpec{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/azure/storage/v1alpha1/types_test.go
+++ b/pkg/apis/azure/storage/v1alpha1/types_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"log"
+	logcore "log"
 	"reflect"
 	"testing"
 
@@ -49,14 +49,14 @@ var (
 func TestMain(m *testing.M) {
 	err := SchemeBuilder.AddToScheme(scheme.Scheme)
 	if err != nil {
-		log.Fatal(err)
+		logcore.Fatal(err)
 	}
 
 	t := test.NewEnv(namespace, test.CRDs())
 	cfg = t.Start()
 
 	if c, err = client.New(cfg, client.Options{Scheme: scheme.Scheme}); err != nil {
-		log.Fatal(err)
+		logcore.Fatal(err)
 	}
 
 	t.StopAndExit(m.Run())

--- a/pkg/controller/azure/storage/account/account.go
+++ b/pkg/controller/azure/storage/account/account.go
@@ -19,7 +19,6 @@ package account
 import (
 	"context"
 	"fmt"
-	"log"
 	"reflect"
 	"time"
 
@@ -41,6 +40,7 @@ import (
 	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
 	"github.com/crossplaneio/crossplane/pkg/clients/azure"
 	azurestorage "github.com/crossplaneio/crossplane/pkg/clients/azure/storage"
+	"github.com/crossplaneio/crossplane/pkg/logging"
 	"github.com/crossplaneio/crossplane/pkg/util"
 )
 
@@ -74,6 +74,8 @@ var (
 	resultRequeue    = reconcile.Result{Requeue: true}
 	requeueOnSuccess = reconcile.Result{RequeueAfter: requeueAfterOnSuccess}
 	requeueOnWait    = reconcile.Result{RequeueAfter: requeueAfterOnWait}
+
+	log = logging.Logger.WithName("controller." + controllerName)
 )
 
 // Reconciler reconciles a GCP storage account acct
@@ -111,7 +113,7 @@ func Add(mgr manager.Manager) error {
 // Reconcile reads that state of the cluster for a Provider acct and makes changes based on the state read
 // and what is in the Provider.Spec
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	log.Printf("reconciling %s: %v", v1alpha1.AccountKindAPIVersion, request)
+	log.V(logging.Debug).Info("reconciling", "kind", v1alpha1.AccountKindAPIVersion, "request", request)
 
 	ctx, cancel := context.WithTimeout(context.Background(), reconcileTimeout)
 	defer cancel()

--- a/pkg/controller/azure/storage/account/account.go
+++ b/pkg/controller/azure/storage/account/account.go
@@ -78,7 +78,7 @@ var (
 	log = logging.Logger.WithName("controller." + controllerName)
 )
 
-// Reconciler reconciles a GCP storage account acct
+// Reconciler reconciles an Azure storage account
 type Reconciler struct {
 	client.Client
 	syncdeleterMaker

--- a/pkg/controller/azure/storage/container/container.go
+++ b/pkg/controller/azure/storage/container/container.go
@@ -18,7 +18,6 @@ package container
 
 import (
 	"context"
-	"log"
 	"reflect"
 	"time"
 
@@ -39,6 +38,7 @@ import (
 	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
 	"github.com/crossplaneio/crossplane/pkg/clients/azure"
 	"github.com/crossplaneio/crossplane/pkg/clients/azure/storage"
+	"github.com/crossplaneio/crossplane/pkg/logging"
 	"github.com/crossplaneio/crossplane/pkg/util"
 )
 
@@ -66,6 +66,8 @@ const (
 var (
 	resultRequeue    = reconcile.Result{Requeue: true}
 	requeueOnSuccess = reconcile.Result{RequeueAfter: requeueAfterOnSuccess}
+
+	log = logging.Logger.WithName("controller." + controllerName)
 )
 
 // Reconciler reconciles a GCP storage account acct
@@ -103,7 +105,7 @@ func Add(mgr manager.Manager) error {
 // Reconcile reads that state of the cluster for a Provider acct and makes changes based on the state read
 // and what is in the Provider.Spec
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	log.Printf("reconciling %s: %v", v1alpha1.ContainerKindAPIVersion, request)
+	log.V(logging.Debug).Info("reconciling", "kind", v1alpha1.ContainerKindAPIVersion, "request", request)
 
 	ctx, cancel := context.WithTimeout(context.Background(), reconcileTimeout)
 	defer cancel()

--- a/pkg/controller/azure/storage/container/container.go
+++ b/pkg/controller/azure/storage/container/container.go
@@ -43,7 +43,7 @@ import (
 )
 
 const (
-	controllerName = "account.storage.azure.crossplane.io"
+	controllerName = "container.storage.azure.crossplane.io"
 	finalizer      = "finalizer." + controllerName
 
 	reconcileTimeout      = 2 * time.Minute
@@ -70,7 +70,7 @@ var (
 	log = logging.Logger.WithName("controller." + controllerName)
 )
 
-// Reconciler reconciles a GCP storage account acct
+// Reconciler reconciles an Azure storage container
 type Reconciler struct {
 	client.Client
 	syncdeleterMaker

--- a/pkg/controller/gcp/storage/bucket.go
+++ b/pkg/controller/gcp/storage/bucket.go
@@ -18,7 +18,6 @@ package storage
 
 import (
 	"context"
-	"log"
 	"reflect"
 	"time"
 
@@ -40,6 +39,7 @@ import (
 	"github.com/crossplaneio/crossplane/pkg/apis/gcp/storage/v1alpha1"
 	gcpv1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/gcp/v1alpha1"
 	gcpstorage "github.com/crossplaneio/crossplane/pkg/clients/gcp/storage"
+	"github.com/crossplaneio/crossplane/pkg/logging"
 	"github.com/crossplaneio/crossplane/pkg/util"
 )
 
@@ -69,6 +69,8 @@ const (
 var (
 	resultRequeue    = reconcile.Result{Requeue: true}
 	requeueOnSuccess = reconcile.Result{RequeueAfter: requeueAfterOnSuccess}
+
+	log = logging.Logger.WithName("controller." + controllerName)
 )
 
 // Reconciler reconciles a GCP storage bucket bucket
@@ -106,7 +108,7 @@ func Add(mgr manager.Manager) error {
 // Reconcile reads that state of the cluster for a Provider bucket and makes changes based on the state read
 // and what is in the Provider.Spec
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	log.Printf("reconciling %s: %v", v1alpha1.BucketKindAPIVersion, request)
+	log.V(logging.Debug).Info("reconciling", "kind", v1alpha1.BucketKindAPIVersion, "request", request)
 
 	ctx, cancel := context.WithTimeout(context.Background(), reconcileTimeout)
 	defer cancel()


### PR DESCRIPTION
**Description of your changes:** This PR updates the most recent controllers so that all controllers in the repo are using the consistent logging pattern established in #354.

There is also a commit to update missed RBAC permissions for the new Azure object storage types. 
 The pull request template checklist has been updated with a reminder to update RBAC permissions with each PR.

**Which issue is resolved by this Pull Request:**
Resolves #7 

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [x] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [x] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [x] All related commits have been squashed to improve readability.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
