### PR TITLE
azure: typo correction in redis controller

### DIFF
--- a/pkg/controller/azure/cache/redis.go
+++ b/pkg/controller/azure/cache/redis.go
@@ -221,7 +221,7 @@ func (c *providerConnecter) Connect(ctx context.Context, r *v1alpha1.Redis) (cre
 	return &azureRedisCache{client: client}, errors.Wrap(err, "cannot create new Azure Cache client")
 }
 
-// Reconciler reconciles Rediss read from the Kubernetes API
+// Reconciler reconciles Redis read from the Kubernetes API
 // with an external store, typically the Azure API.
 type Reconciler struct {
 	connecter


### PR DESCRIPTION
Correction of minor typo in comment on Azure Redis controller.

Signed-off-by: HashedDan <georgedanielmangum@gmail.com>

<!-- Please take a look at our [Contributing](../blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to Crossplane! -->

**Description of your changes:** Misspelling of "Redis" in comment on Reconciler for Azure Redis controller

**Which issue is resolved by this Pull Request:** N/A

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [x] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [x] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [x] All related commits have been squashed to improve readability.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
