### PR TITLE
Update GKE Cluster to support additional properties.

### DIFF
--- a/pkg/clients/gcp/gke/gke.go
+++ b/pkg/clients/gcp/gke/gke.go
@@ -62,14 +62,22 @@ func NewClusterClient(creds *google.Credentials) (*ClusterClient, error) {
 func (c *ClusterClient) CreateCluster(name string, spec computev1alpha1.GKEClusterSpec) (*container.Cluster, error) {
 	zone := spec.Zone
 
+	var ipAllocationPolicy *container.IPAllocationPolicy
+	if spec.EnableIPAlias {
+		ipAllocationPolicy = &container.IPAllocationPolicy{UseIpAliases: spec.EnableIPAlias}
+	}
+
 	cl := &container.Cluster{
 		Name:                  name,
-		Zone:                  zone,
 		InitialClusterVersion: spec.ClusterVersion,
 		InitialNodeCount:      spec.NumNodes,
+		IpAllocationPolicy:    ipAllocationPolicy,
 		NodeConfig: &container.NodeConfig{
 			MachineType: spec.MachineType,
+			OauthScopes: spec.Scopes,
 		},
+
+		Zone: zone,
 	}
 
 	cr := &container.CreateClusterRequest{

--- a/pkg/clients/gcp/gke/gke_test.go
+++ b/pkg/clients/gcp/gke/gke_test.go
@@ -19,14 +19,33 @@ package gke
 import (
 	"testing"
 
-	. "github.com/onsi/gomega"
+	"github.com/go-test/deep"
+
 	"golang.org/x/oauth2/google"
 )
 
 func TestNewClusterClient(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	c, err := NewClusterClient(&google.Credentials{})
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(c).NotTo(BeNil())
+	type want struct {
+		err error
+		res *ClusterClient
+	}
+	tests := []struct {
+		name string
+		args *google.Credentials
+		want want
+	}{
+		{name: "test", args: &google.Credentials{}, want: want{res: &ClusterClient{}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewClusterClient(tt.args)
+			if diff := deep.Equal(err, tt.want.err); diff != nil {
+				t.Errorf("NewClusterClient() error = %v, want.err %v\n%s", err, tt.want.err, diff)
+				return
+			}
+			if diff := deep.Equal(got, tt.want.res); diff != nil {
+				t.Errorf("NewClusterClient() = %v, want %v\n%s", got, tt.want.res, diff)
+			}
+		})
+	}
 }

--- a/pkg/controller/compute/kubernetes/gcp_handler_test.go
+++ b/pkg/controller/compute/kubernetes/gcp_handler_test.go
@@ -1,0 +1,268 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/go-test/deep"
+	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	computev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/compute/v1alpha1"
+	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/apis/gcp/compute/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/test"
+)
+
+func TestGKEClusterHandler_Find(t *testing.T) {
+	type args struct {
+		name types.NamespacedName
+		c    client.Client
+	}
+	type want struct {
+		err error
+		res corev1alpha1.Resource
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "failed",
+			args: args{
+				name: types.NamespacedName{Namespace: "foo", Name: "bar"},
+				c: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+						return errors.New("test-get-error")
+					},
+				},
+			},
+			want: want{
+				err: errors.Wrapf(errors.New("test-get-error"),
+					"failed to retrieve %s: foo/bar", v1alpha1.GKEClusterKind),
+			},
+		},
+		{
+			name: "success",
+			args: args{
+				name: types.NamespacedName{Namespace: "foo", Name: "bar"},
+				c:    test.NewMockClient(),
+			},
+			want: want{
+				res: &v1alpha1.GKECluster{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &GKEClusterHandler{}
+			got, err := r.Find(tt.args.name, tt.args.c)
+			if diff := deep.Equal(err, tt.want.err); diff != nil {
+				t.Errorf("GKEClusterHandler.Find() error = %v, want.err %v\n%s", err, tt.want.err, diff)
+			}
+			if diff := deep.Equal(got, tt.want.res); diff != nil {
+				t.Errorf("GKEClusterHandler.Find() = %v, want.res %v\n%s", got, tt.want.res, diff)
+			}
+		})
+	}
+}
+
+func TestGKEClusterHandler_Provision(t *testing.T) {
+	class := &corev1alpha1.ResourceClass{}
+	claim := &computev1alpha1.KubernetesCluster{
+		ObjectMeta: v1.ObjectMeta{
+			UID: "test-claim-uid",
+		},
+	}
+	createError := errors.New("test-cluster-create-error")
+	type args struct {
+		class *corev1alpha1.ResourceClass
+		claim corev1alpha1.ResourceClaim
+		c     client.Client
+	}
+	type want struct {
+		err error
+		res corev1alpha1.Resource
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "success",
+			args: args{
+				class: class,
+				claim: claim,
+				c:     test.NewMockClient(),
+			},
+			want: want{
+				res: &v1alpha1.GKECluster{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace:       class.Namespace,
+						Name:            "gke-test-claim-uid",
+						OwnerReferences: []v1.OwnerReference{claim.OwnerReference()},
+					},
+					Spec: v1alpha1.GKEClusterSpec{
+						ClassRef: class.ObjectReference(),
+						ClaimRef: claim.ObjectReference(),
+					},
+				},
+			},
+		},
+		{
+			name: "failure",
+			args: args{
+				class: class,
+				claim: claim,
+				c: &test.MockClient{
+					MockCreate: func(ctx context.Context, obj runtime.Object) error {
+						return createError
+					},
+				},
+			},
+			want: want{
+				err: errors.Wrapf(createError,
+					"failed to create cluster %s/%s", class.Namespace, "gke-"+claim.UID),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &GKEClusterHandler{}
+			got, err := r.Provision(tt.args.class, tt.args.claim, tt.args.c)
+			if diff := deep.Equal(err, tt.want.err); diff != nil {
+				t.Errorf("GKEClusterHandler.Provision() error = %v, want.err %v\n%s", err, tt.want.err, diff)
+				return
+			}
+			if diff := deep.Equal(got, tt.want.res); diff != nil {
+				t.Errorf("GKEClusterHandler.Provision() = \n%v, want.res \n%v\n%s", got, tt.want.res, diff)
+			}
+		})
+	}
+}
+
+func TestGKEClusterHandler_SetBindStatus(t *testing.T) {
+	name := types.NamespacedName{Namespace: "foo", Name: "bar"}
+
+	getError := errors.New("test-get-error")
+	getErrorNotFound := kerrors.NewNotFound(schema.GroupResource{}, name.String())
+	updateError := errors.New("test-update-error")
+
+	type args struct {
+		name  types.NamespacedName
+		c     client.Client
+		bound bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want error
+	}{
+		{
+			name: "failure",
+			args: args{
+				name: name,
+				c: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+						return getError
+					},
+				},
+			},
+			want: errors.Wrapf(getError, "failed to retrieve cluster %s", name),
+		},
+		{
+			name: "failure - not found, bound",
+			args: args{
+				name: name,
+				c: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+						return getErrorNotFound
+					},
+				},
+				bound: true,
+			},
+			want: errors.Wrapf(getErrorNotFound, "failed to retrieve cluster %s", name),
+		},
+		{
+			name: "failure - not found, not bound",
+			args: args{
+				name: name,
+				c: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+						return getErrorNotFound
+					},
+				},
+			},
+		},
+		{
+			name: "failed to update",
+			args: args{
+				name: name,
+				c: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+						return nil
+					},
+					MockUpdate: func(ctx context.Context, obj runtime.Object) error {
+						return updateError
+					},
+				},
+			},
+			want: errors.Wrapf(updateError, "failed to update cluster %s", name),
+		},
+		{
+			name: "successful set bound",
+			args: args{
+				name: name,
+				c: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+						return nil
+					},
+					MockUpdate: func(ctx context.Context, obj runtime.Object) error {
+						cls, ok := obj.(*v1alpha1.GKECluster)
+						if !ok {
+							t.Errorf("GKEClusterHandler.SetBindStatus() unexpected object type: %T", obj)
+						}
+						if !cls.Status.IsBound() {
+							t.Errorf("GKEClusterHandler.SetBindStatus() expected to be bound")
+						}
+						return nil
+					},
+				},
+				bound: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := GKEClusterHandler{}
+			err := r.SetBindStatus(tt.args.name, tt.args.c, tt.args.bound)
+			if diff := deep.Equal(err, tt.want); diff != nil {
+				t.Errorf("GKEClusterHandler.SetBindStatus() error = %v, want %v\n%s", err, tt.want, diff)
+			}
+		})
+	}
+}

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -42,6 +42,24 @@ func StringValue(v *string) string {
 	return ""
 }
 
+// Split function helper will return an empty slice on empty string and
+// removing empty entries and trimming leading and trailing spaces
+// Example: Split("a ,, b") results in []string{"a","b"}
+func Split(s, sep string) []string {
+	rs := make([]string, 0)
+	if s == "" {
+		return rs
+	}
+
+	for _, r := range strings.Split(s, sep) {
+		if rr := strings.TrimSpace(r); rr != "" {
+			rs = append(rs, rr)
+		}
+	}
+
+	return rs
+}
+
 // ParseMap string encoded map values
 // example: "foo:bar,one:two" -> map[string]string{"foo":"bar","one":"two"}
 func ParseMap(s string) map[string]string {

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -161,3 +161,27 @@ func TestConditionalStringFormat(t *testing.T) {
 		})
 	}
 }
+
+func TestSplit(t *testing.T) {
+	type args struct {
+		s   string
+		sep string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{name: "empty", args: args{s: "", sep: ","}, want: []string{}},
+		{name: "comma", args: args{s: ",", sep: ","}, want: []string{}},
+		{name: "values", args: args{s: " a,,b ", sep: ","}, want: []string{"a", "b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Split(tt.args.s, tt.args.sep)
+			if diff := deep.Equal(got, tt.want); diff != nil {
+				t.Errorf("Split() = %v, want %v\n%s", got, tt.want, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
While GKE Cluster type provided definition for vast properties set available.
The GKE client and ResourceClass property parser support only a limited sub-set.

The limited property support is due to GKE Cluster evolved from the 
prototype GKE Operator. 
GKE Type/Client/Controller in need of larger overhaul to provide more comprehensive 
support for additional properties, which is tracked by #392.

Resolves #393

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [ ] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [ ] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [ ] RBAC permissions in `clusterrole.yaml` have been updated to include new types, if necessary
- [ ] All related commits have been squashed to improve readability.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)