### PR TITLE
GCP Bucket - Service Account Secret Reference

### DIFF
--- a/cluster/charts/crossplane/crds/gcp/storage/v1alpha1/bucket.yaml
+++ b/cluster/charts/crossplane/crds/gcp/storage/v1alpha1/bucket.yaml
@@ -235,7 +235,7 @@ spec:
                   minimum: 0
                   type: integer
               type: object
-            serviceAccountRef:
+            serviceAccountSecretRef:
               description: ServiceAccountSecretRef contains GCP ServiceAccount secret
                 that will be used for bucket connection secret credentials
               type: object
@@ -275,7 +275,6 @@ spec:
                   type: string
               type: object
           required:
-          - serviceAccountRef
           - providerRef
           type: object
         status:

--- a/cluster/charts/crossplane/crds/gcp/storage/v1alpha1/bucket.yaml
+++ b/cluster/charts/crossplane/crds/gcp/storage/v1alpha1/bucket.yaml
@@ -235,6 +235,10 @@ spec:
                   minimum: 0
                   type: integer
               type: object
+            serviceAccountRef:
+              description: ServiceAccountSecretRef contains GCP ServiceAccount secret
+                that will be used for bucket connection secret credentials
+              type: object
             storageClass:
               description: StorageClass is the default storage class of the bucket.
                 This defines how objects in the bucket are stored and determines the
@@ -271,6 +275,7 @@ spec:
                   type: string
               type: object
           required:
+          - serviceAccountRef
           - providerRef
           type: object
         status:

--- a/cluster/examples/storage/gcp/sa-secret.yaml
+++ b/cluster/examples/storage/gcp/sa-secret.yaml
@@ -1,0 +1,11 @@
+## GCP Storage Service Account Credentials
+apiVersion: v1
+kind: Secret
+metadata:
+  name: demo-gcp-storage-service-account
+  namespace: crossplane-system
+type: Opaque
+data:
+  credentials.json: BASE64ENCODED_CREDS_FOR_SERICE_ACCOUNT
+  interopAccessKey: BASE64ENCODED_ACCESS_KEY
+  interopSecret: BASE64ENCODED_SECRET

--- a/pkg/apis/gcp/storage/v1alpha1/types.go
+++ b/pkg/apis/gcp/storage/v1alpha1/types.go
@@ -769,7 +769,7 @@ type BucketSpec struct {
 
 	// ServiceAccountSecretRef contains GCP ServiceAccount secret that will be used
 	// for bucket connection secret credentials
-	ServiceAccountSecretRef *corev1.LocalObjectReference `json:"serviceAccountRef"`
+	ServiceAccountSecretRef *corev1.LocalObjectReference `json:"serviceAccountSecretRef,omitempty"`
 
 	ConnectionSecretNameOverride string                      `json:"connectionSecretNameOverride,omitempty"`
 	ProviderRef                  corev1.LocalObjectReference `json:"providerRef"`
@@ -835,7 +835,6 @@ func (b *Bucket) ConnectionSecret() *corev1.Secret {
 		},
 		Data: map[string][]byte{
 			corev1alpha1.ResourceCredentialsSecretEndpointKey: []byte(b.GetBucketName()),
-			//corev1alpha1.ResourceCredentialsTokenKey
 		},
 	}
 }
@@ -887,8 +886,8 @@ func (b *Bucket) SetBound(state bool) {
 	}
 }
 
-// NewBucketSpec constructs Spec for this resource from the properties map
-func NewBucketSpec(p map[string]string) *BucketSpec {
+// ParseBucketSpec constructs Spec for this resource from the properties map
+func ParseBucketSpec(p map[string]string) *BucketSpec {
 	var encryption *BucketEncryption
 	if v, found := p["encryptionDefaultKmsKeyName"]; found {
 		encryption = &BucketEncryption{DefaultKMSKeyName: v}
@@ -914,6 +913,11 @@ func NewBucketSpec(p map[string]string) *BucketSpec {
 		website = parseWebsite(v)
 	}
 
+	var serviceAccountSecretRef *corev1.LocalObjectReference
+	if v, found := p["serviceAccountSecretRef"]; found {
+		serviceAccountSecretRef = &corev1.LocalObjectReference{Name: v}
+	}
+
 	bua := BucketUpdatableAttrs{
 		BucketPolicyOnly:           BucketPolicyOnly{Enabled: util.ParseBool(p["bucketPolicyOnly"])},
 		CORS:                       parseCORSList(p["cors"]),
@@ -936,8 +940,9 @@ func NewBucketSpec(p map[string]string) *BucketSpec {
 	}
 
 	return &BucketSpec{
-		BucketSpecAttrs: bsa,
-		ReclaimPolicy:   corev1alpha1.ReclaimRetain,
+		BucketSpecAttrs:         bsa,
+		ReclaimPolicy:           corev1alpha1.ReclaimRetain,
+		ServiceAccountSecretRef: serviceAccountSecretRef,
 	}
 }
 

--- a/pkg/apis/gcp/storage/v1alpha1/types.go
+++ b/pkg/apis/gcp/storage/v1alpha1/types.go
@@ -767,6 +767,10 @@ type BucketSpec struct {
 	// If not provided, defaults to "%s", i.e. UID value
 	NameFormat string `json:"nameFormat,omitempty"`
 
+	// ServiceAccountSecretRef contains GCP ServiceAccount secret that will be used
+	// for bucket connection secret credentials
+	ServiceAccountSecretRef *corev1.LocalObjectReference `json:"serviceAccountRef"`
+
 	ConnectionSecretNameOverride string                      `json:"connectionSecretNameOverride,omitempty"`
 	ProviderRef                  corev1.LocalObjectReference `json:"providerRef"`
 	ClaimRef                     *corev1.ObjectReference     `json:"claimRef,omitempty"`
@@ -830,7 +834,8 @@ func (b *Bucket) ConnectionSecret() *corev1.Secret {
 			OwnerReferences: []metav1.OwnerReference{b.OwnerReference()},
 		},
 		Data: map[string][]byte{
-			corev1alpha1.ResourceCredentialsSecretEndpointKey: []byte(b.GetUID()),
+			corev1alpha1.ResourceCredentialsSecretEndpointKey: []byte(b.GetBucketName()),
+			//corev1alpha1.ResourceCredentialsTokenKey
 		},
 	}
 }

--- a/pkg/apis/gcp/storage/v1alpha1/types_test.go
+++ b/pkg/apis/gcp/storage/v1alpha1/types_test.go
@@ -59,6 +59,7 @@ func TestStorageGCPBucket(t *testing.T) {
 				Location:     "US",
 				StorageClass: "STANDARD",
 			},
+			ServiceAccountSecretRef: &corev1.LocalObjectReference{Name: "test"},
 		},
 	}
 	g := gomega.NewGomegaWithT(t)

--- a/pkg/apis/gcp/storage/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/gcp/storage/v1alpha1/zz_generated.deepcopy.go
@@ -182,6 +182,11 @@ func (in *BucketPolicyOnly) DeepCopy() *BucketPolicyOnly {
 func (in *BucketSpec) DeepCopyInto(out *BucketSpec) {
 	*out = *in
 	in.BucketSpecAttrs.DeepCopyInto(&out.BucketSpecAttrs)
+	if in.ServiceAccountSecretRef != nil {
+		in, out := &in.ServiceAccountSecretRef, &out.ServiceAccountSecretRef
+		*out = new(v1.LocalObjectReference)
+		**out = **in
+	}
 	out.ProviderRef = in.ProviderRef
 	if in.ClaimRef != nil {
 		in, out := &in.ClaimRef, &out.ClaimRef

--- a/pkg/controller/gcp/storage/bucket_operations.go
+++ b/pkg/controller/gcp/storage/bucket_operations.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+
+	"cloud.google.com/go/storage"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/apis/gcp/storage/v1alpha1"
+	gcpstorage "github.com/crossplaneio/crossplane/pkg/clients/gcp/storage"
+	"github.com/crossplaneio/crossplane/pkg/util"
+)
+
+type operations interface {
+	// Bucket object operations
+	addFinalizer()
+	removeFinalizer()
+	isReclaimDelete() bool
+	getSpecAttrs() v1alpha1.BucketUpdatableAttrs
+	setSpecAttrs(*storage.BucketAttrs)
+	setStatusAttrs(*storage.BucketAttrs)
+	setReady()
+	failReconcile(ctx context.Context, reason, msg string) error
+
+	// Controller-runtime operations
+	updateObject(ctx context.Context) error
+	updateStatus(ctx context.Context) error
+	updateSecret(ctx context.Context) error
+
+	// GCP Storage Client operations
+	createBucket(ctx context.Context, projectID string) error
+	deleteBucket(ctx context.Context) error
+	updateBucket(ctx context.Context, labels map[string]string) (*storage.BucketAttrs, error)
+	getAttributes(ctx context.Context) (*storage.BucketAttrs, error)
+}
+
+type bucketHandler struct {
+	*v1alpha1.Bucket
+	kube client.Client
+	gcp  gcpstorage.Client
+}
+
+var _ operations = &bucketHandler{}
+
+func newBucketClients(bucket *v1alpha1.Bucket, kube client.Client, gcp gcpstorage.Client) *bucketHandler {
+	return &bucketHandler{
+		Bucket: bucket,
+		kube:   kube,
+		gcp:    gcp,
+	}
+}
+
+//
+// Crossplane GCP Bucket object operations
+//
+func (bh *bucketHandler) addFinalizer() {
+	util.AddFinalizer(&bh.ObjectMeta, finalizer)
+}
+
+func (bh *bucketHandler) removeFinalizer() {
+	util.RemoveFinalizer(&bh.ObjectMeta, finalizer)
+}
+
+func (bh *bucketHandler) isReclaimDelete() bool {
+	return bh.Spec.ReclaimPolicy == corev1alpha1.ReclaimDelete
+}
+
+func (bh *bucketHandler) getSpecAttrs() v1alpha1.BucketUpdatableAttrs {
+	return bh.Spec.BucketUpdatableAttrs
+}
+
+func (bh *bucketHandler) setSpecAttrs(attrs *storage.BucketAttrs) {
+	bh.Spec.BucketSpecAttrs = v1alpha1.NewBucketSpecAttrs(attrs)
+}
+
+func (bh *bucketHandler) setStatusAttrs(attrs *storage.BucketAttrs) {
+	bh.Status.BucketOutputAttrs = v1alpha1.NewBucketOutputAttrs(attrs)
+}
+
+func (bh *bucketHandler) setReady() {
+	bh.Status.SetReady()
+}
+
+func (bh *bucketHandler) failReconcile(ctx context.Context, reason, msg string) error {
+	bh.Status.SetFailed(reason, msg)
+	return bh.updateStatus(ctx)
+}
+
+//
+// Controller-runtime Client operations
+//
+func (bh *bucketHandler) updateObject(ctx context.Context) error {
+	return bh.kube.Update(ctx, bh)
+}
+
+func (bh *bucketHandler) updateStatus(ctx context.Context) error {
+	return bh.kube.Status().Update(ctx, bh)
+}
+
+func (bh *bucketHandler) getSecret(ctx context.Context, nn types.NamespacedName, s *corev1.Secret) error {
+	return bh.kube.Get(ctx, nn, s)
+}
+
+const (
+	saSecretKeyAccessKey   = "interopAccessKey"
+	saSecretKeySecret      = "interopSecret"
+	saSecretKeyCredentials = "credentials.json"
+)
+
+func (bh *bucketHandler) updateSecret(ctx context.Context) error {
+	s := bh.ConnectionSecret()
+	if ref := bh.Spec.ServiceAccountSecretRef; ref != nil {
+		ss := &corev1.Secret{}
+		nn := types.NamespacedName{Namespace: bh.GetNamespace(), Name: ref.Name}
+		if err := bh.kube.Get(ctx, nn, ss); err != nil {
+			return errors.Wrapf(err, "failed to retrieve storage service account secret: %s", nn)
+		}
+		s.Data[corev1alpha1.ResourceCredentialsSecretUserKey] = ss.Data[saSecretKeyAccessKey]
+		s.Data[corev1alpha1.ResourceCredentialsSecretPasswordKey] = ss.Data[saSecretKeySecret]
+		s.Data[corev1alpha1.ResourceCredentialsTokenKey] = ss.Data[saSecretKeyCredentials]
+	}
+	s.Data[corev1alpha1.ResourceCredentialsSecretEndpointKey] = []byte(bh.GetBucketName())
+	return errors.Wrapf(util.Apply(ctx, bh.kube, s), "failed to apply connection secret: %s/%s", s.Namespace, s.Name)
+}
+
+//
+// GCP Storage Bucket operations
+//
+func (bh *bucketHandler) createBucket(ctx context.Context, projectID string) error {
+	return bh.gcp.Create(ctx, projectID, v1alpha1.CopyBucketSpecAttrs(&bh.Spec.BucketSpecAttrs))
+}
+
+func (bh *bucketHandler) deleteBucket(ctx context.Context) error {
+	return bh.gcp.Delete(ctx)
+}
+
+func (bh *bucketHandler) updateBucket(ctx context.Context, labels map[string]string) (*storage.BucketAttrs, error) {
+	return bh.gcp.Update(ctx, v1alpha1.CopyToBucketUpdateAttrs(bh.Spec.BucketUpdatableAttrs, labels))
+}
+
+func (bh *bucketHandler) getAttributes(ctx context.Context) (*storage.BucketAttrs, error) {
+	return bh.gcp.Attrs(ctx)
+}

--- a/pkg/controller/gcp/storage/bucket_operations_test.go
+++ b/pkg/controller/gcp/storage/bucket_operations_test.go
@@ -1,0 +1,609 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/go-test/deep"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/apis/gcp/storage/v1alpha1"
+	gcpstorage "github.com/crossplaneio/crossplane/pkg/clients/gcp/storage"
+	storagefake "github.com/crossplaneio/crossplane/pkg/clients/gcp/storage/fake"
+	"github.com/crossplaneio/crossplane/pkg/test"
+)
+
+type mockOperations struct {
+	mockIsReclaimDelete func() bool
+	mockAddFinalizer    func()
+	mockRemoveFinalizer func()
+	mockGetSpecAttrs    func() v1alpha1.BucketUpdatableAttrs
+	mockSetSpecAttrs    func(*storage.BucketAttrs)
+	mockSetStatusAttrs  func(*storage.BucketAttrs)
+	mockSetReady        func()
+	mockFailReconcile   func(ctx context.Context, reason, msg string) error
+
+	mockUpdateObject func(ctx context.Context) error
+	mockUpdateStatus func(ctx context.Context) error
+	mockUpdateSecret func(ctx context.Context) error
+
+	mockCreateBucket  func(ctx context.Context, projectID string) error
+	mockDeleteBucket  func(ctx context.Context) error
+	mockUpdateBucket  func(ctx context.Context, labels map[string]string) (*storage.BucketAttrs, error)
+	mockGetAttributes func(ctx context.Context) (*storage.BucketAttrs, error)
+}
+
+var _ operations = &mockOperations{}
+
+func (o *mockOperations) isReclaimDelete() bool {
+	return o.mockIsReclaimDelete()
+}
+
+func (o *mockOperations) addFinalizer() {
+	o.mockAddFinalizer()
+}
+
+func (o *mockOperations) removeFinalizer() {
+	o.mockRemoveFinalizer()
+}
+
+func (o *mockOperations) getSpecAttrs() v1alpha1.BucketUpdatableAttrs {
+	return o.mockGetSpecAttrs()
+}
+
+func (o *mockOperations) setSpecAttrs(attrs *storage.BucketAttrs) {
+	o.mockSetSpecAttrs(attrs)
+}
+
+func (o *mockOperations) setStatusAttrs(attrs *storage.BucketAttrs) {
+	o.mockSetStatusAttrs(attrs)
+}
+
+func (o *mockOperations) setReady() {
+	o.mockSetReady()
+}
+
+func (o *mockOperations) failReconcile(ctx context.Context, reason, msg string) error {
+	return o.mockFailReconcile(ctx, reason, msg)
+}
+
+//
+//
+func (o *mockOperations) updateObject(ctx context.Context) error {
+	return o.mockUpdateObject(ctx)
+}
+
+func (o *mockOperations) updateStatus(ctx context.Context) error {
+	return o.mockUpdateStatus(ctx)
+}
+
+func (o *mockOperations) updateSecret(ctx context.Context) error {
+	return o.mockUpdateSecret(ctx)
+}
+
+//
+//
+func (o *mockOperations) createBucket(ctx context.Context, projectID string) error {
+	return o.mockCreateBucket(ctx, projectID)
+}
+
+func (o *mockOperations) deleteBucket(ctx context.Context) error {
+	return o.mockDeleteBucket(ctx)
+}
+
+func (o *mockOperations) updateBucket(ctx context.Context, labels map[string]string) (*storage.BucketAttrs, error) {
+	return o.mockUpdateBucket(ctx, labels)
+}
+
+func (o *mockOperations) getAttributes(ctx context.Context) (*storage.BucketAttrs, error) {
+	return o.mockGetAttributes(ctx)
+}
+
+//
+//
+func Test_bucketHandler_addFinalizer(t *testing.T) {
+	type fields struct {
+		bucket *v1alpha1.Bucket
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []string
+	}{
+		{
+			name:   "test",
+			fields: fields{bucket: &v1alpha1.Bucket{}},
+			want:   []string{finalizer},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bc := &bucketHandler{
+				Bucket: tt.fields.bucket,
+			}
+			bc.addFinalizer()
+			got := tt.fields.bucket.Finalizers
+			if diff := deep.Equal(got, tt.want); diff != nil {
+				t.Errorf("bucketHandler.addFinalizer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_bucketHandler_removeFinalizer(t *testing.T) {
+	type fields struct {
+		bucket *v1alpha1.Bucket
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []string
+	}{
+		{
+			name: "test",
+			fields: fields{bucket: &v1alpha1.Bucket{
+				ObjectMeta: metav1.ObjectMeta{Finalizers: []string{finalizer}},
+			}},
+			want: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bc := &bucketHandler{
+				Bucket: tt.fields.bucket,
+			}
+			bc.removeFinalizer()
+			got := tt.fields.bucket.Finalizers
+			if diff := deep.Equal(got, tt.want); diff != nil {
+				t.Errorf("bucketHandler.removeFinalizer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_bucketHandler_isReclaimDelete(t *testing.T) {
+	type fields struct {
+		bucket *v1alpha1.Bucket
+		kube   client.Client
+		gcp    gcpstorage.Client
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name:   "default",
+			fields: fields{bucket: &v1alpha1.Bucket{}},
+			want:   false,
+		},
+		{
+			name:   "delete",
+			fields: fields{bucket: &v1alpha1.Bucket{Spec: v1alpha1.BucketSpec{ReclaimPolicy: corev1alpha1.ReclaimDelete}}},
+			want:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bc := &bucketHandler{
+				Bucket: tt.fields.bucket,
+				kube:   tt.fields.kube,
+				gcp:    tt.fields.gcp,
+			}
+			if got := bc.isReclaimDelete(); got != tt.want {
+				t.Errorf("bucketHandler.isReclaimDelete() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_bucketHandler_getSpecAttrs(t *testing.T) {
+	testBucketSpecAttrs := v1alpha1.BucketUpdatableAttrs{RequesterPays: true}
+	type fields struct {
+		bucket *v1alpha1.Bucket
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   v1alpha1.BucketUpdatableAttrs
+	}{
+		{
+			name: "test",
+			fields: fields{bucket: &v1alpha1.Bucket{
+				Spec: v1alpha1.BucketSpec{
+					BucketSpecAttrs: v1alpha1.BucketSpecAttrs{BucketUpdatableAttrs: testBucketSpecAttrs},
+				},
+			}},
+			want: testBucketSpecAttrs,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bh := &bucketHandler{
+				Bucket: tt.fields.bucket,
+			}
+			got := bh.getSpecAttrs()
+			if diff := deep.Equal(got, tt.want); diff != nil {
+				t.Errorf("bucketHandler.getSpecAttrs() = %v, want %v\n%s", got, tt.want, diff)
+			}
+		})
+	}
+}
+
+func Test_bucketHandler_setSpecAttrs(t *testing.T) {
+	testSpecAttrs := v1alpha1.BucketSpecAttrs{Location: "foo"}
+	type fields struct {
+		bucket *v1alpha1.Bucket
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   *storage.BucketAttrs
+		want   v1alpha1.BucketSpecAttrs
+	}{
+		{
+			name:   "test",
+			fields: fields{bucket: &v1alpha1.Bucket{}},
+			args:   &storage.BucketAttrs{Location: "foo"},
+			want:   testSpecAttrs,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bh := &bucketHandler{
+				Bucket: tt.fields.bucket,
+			}
+			bh.setSpecAttrs(tt.args)
+			got := tt.fields.bucket.Spec.BucketSpecAttrs
+			if diff := deep.Equal(got, tt.want); diff != nil {
+				t.Errorf("bucketHandler.setSpecAttrs() = %v, want %v\n%s", got, tt.want, diff)
+			}
+		})
+	}
+}
+
+func Test_bucketHandler_setStatusAttrs(t *testing.T) {
+	type fields struct {
+		bucket *v1alpha1.Bucket
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   *storage.BucketAttrs
+		want   v1alpha1.BucketOutputAttrs
+	}{
+		{
+			name:   "test",
+			fields: fields{bucket: &v1alpha1.Bucket{}},
+			args:   &storage.BucketAttrs{Name: "foo"},
+			want:   v1alpha1.BucketOutputAttrs{Name: "foo"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bh := &bucketHandler{
+				Bucket: tt.fields.bucket,
+			}
+			bh.setStatusAttrs(tt.args)
+			got := tt.fields.bucket.Status.BucketOutputAttrs
+			if diff := deep.Equal(got, tt.want); diff != nil {
+				t.Errorf("bucketHandler.setStatusAttrs() = %v, want %v\n%s", got, tt.want, diff)
+			}
+		})
+	}
+}
+
+func Test_bucketHandler_setReady(t *testing.T) {
+	type fields struct {
+		bucket *v1alpha1.Bucket
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name:   "test",
+			fields: fields{bucket: &v1alpha1.Bucket{}},
+			want:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bh := &bucketHandler{
+				Bucket: tt.fields.bucket,
+			}
+			bh.setReady()
+			if got := tt.fields.bucket.Status.IsReady(); got != tt.want {
+				t.Errorf("bucketHandler.setReady() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_bucketHandler_failReconcile(t *testing.T) {
+	ctx := context.TODO()
+	bucket := newBucket(testNamespace, testBucketName).Bucket
+	want := newBucket(testNamespace, testBucketName).withFailedCondition("foo", "bar").Bucket
+	bc := &bucketHandler{
+		Bucket: bucket,
+		kube: &test.MockClient{
+			MockStatusUpdate: func(ctx context.Context, obj runtime.Object) error { return nil },
+		},
+	}
+	if err := bc.failReconcile(ctx, "foo", "bar"); err != nil {
+		t.Errorf("bucketHandler.failReconcile() unexpected error %v", err)
+	}
+	if diff := deep.Equal(bucket, want); diff != nil {
+		t.Errorf("bucketHandler.failReconcile() got = %v, want %v\n%s", bucket, want, diff)
+	}
+
+}
+
+func Test_bucketHandler_updateObject(t *testing.T) {
+	ctx := context.TODO()
+	bucket := &v1alpha1.Bucket{}
+	bc := &bucketHandler{
+		Bucket: bucket,
+		kube: &test.MockClient{
+			MockUpdate: func(ctx context.Context, obj runtime.Object) error { return nil },
+		},
+	}
+	if err := bc.updateObject(ctx); err != nil {
+		t.Errorf("bucketHandler.updateObject() unexpected error %v", err)
+	}
+}
+
+func Test_bucketHandler_updateStatus(t *testing.T) {
+	ctx := context.TODO()
+	bucket := &v1alpha1.Bucket{}
+	bc := &bucketHandler{
+		Bucket: bucket,
+		kube: &test.MockClient{
+			MockStatusUpdate: func(ctx context.Context, obj runtime.Object) error { return nil },
+		},
+	}
+	if err := bc.updateStatus(ctx); err != nil {
+		t.Errorf("bucketHandler.updateStatus() unexpected error %v", err)
+	}
+}
+
+func Test_bucketHandler_getSecret(t *testing.T) {
+	ctx := context.TODO()
+	nn := types.NamespacedName{Namespace: "foo", Name: "bar"}
+	s := &corev1.Secret{}
+	bc := &bucketHandler{
+		kube: &test.MockClient{
+			MockGet: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				if key != nn {
+					t.Errorf("bucketHandler.getSecret() key = %v, want %v", key, nn)
+				}
+				if _, ok := obj.(*corev1.Secret); !ok {
+					t.Errorf("bucketHandler.getSecret() type = %T, want %T", obj, &corev1.Secret{})
+				}
+				return nil
+			},
+		},
+	}
+	if err := bc.getSecret(ctx, nn, s); err != nil {
+		t.Errorf("bucketHandler.getSecret() unexpected error %v", err)
+	}
+}
+
+func Test_bucketHandler_updateSecret(t *testing.T) {
+	ctx := context.TODO()
+	testError := errors.New("test-error")
+	bucketUID := "test-uid"
+	saSecretName := "test-sa-secret"
+	saSecretUser := "test-user"
+	saSecretPass := "test-pass"
+	saSecretCreds := "test-creds"
+
+	assertSecretData := func(data map[string][]byte, key, want string) {
+		if v := data[key]; string(v) != want {
+			t.Errorf("bucketHandler.updateSecret() data = %v, want %v", v, want)
+		}
+	}
+
+	type fields struct {
+		Bucket *v1alpha1.Bucket
+		kube   client.Client
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   error
+	}{
+		{
+			name: "without service account secret reference",
+			fields: fields{
+				Bucket: newBucket(testNamespace, testBucketName).Bucket,
+				kube:   test.NewMockClient(),
+			},
+		},
+		{
+			name: "failure to retrieve secret",
+			fields: fields{
+				Bucket: newBucket(testNamespace, testBucketName).withServiceAccountSecretRef(saSecretName).Bucket,
+				kube: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+						return testError
+					},
+				},
+			},
+			want: errors.Wrapf(testError,
+				"failed to retrieve storage service account secret: %s/%s", testNamespace, saSecretName),
+		},
+		{
+			name: "failure to update secret",
+			fields: fields{
+				Bucket: newBucket(testNamespace, testBucketName).
+					withServiceAccountSecretRef(saSecretName).
+					withUID(bucketUID).
+					Bucket,
+				kube: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+						s, ok := obj.(*corev1.Secret)
+						if !ok {
+							t.Errorf("bucketHandler.updateSecret() invalid type = %T, want %T",
+								obj, &corev1.Secret{})
+						}
+						s.Name = saSecretName
+						s.Data = map[string][]byte{
+							saSecretKeyAccessKey:   []byte(saSecretUser),
+							saSecretKeySecret:      []byte(saSecretPass),
+							saSecretKeyCredentials: []byte(saSecretCreds),
+						}
+						return nil
+					},
+					MockCreate: func(ctx context.Context, obj runtime.Object) error {
+						// assert secret
+						s, ok := obj.(*corev1.Secret)
+						if !ok {
+							t.Errorf("bucketHandler.updateSecret() invalid type = %T, want %T",
+								obj, &corev1.Secret{})
+						}
+						// assert secret data
+						assertSecretData(s.Data, corev1alpha1.ResourceCredentialsSecretEndpointKey, bucketUID)
+						assertSecretData(s.Data, corev1alpha1.ResourceCredentialsSecretUserKey, saSecretUser)
+						assertSecretData(s.Data, corev1alpha1.ResourceCredentialsSecretPasswordKey, saSecretPass)
+						assertSecretData(s.Data, corev1alpha1.ResourceCredentialsTokenKey, saSecretCreds)
+						return testError
+					},
+				},
+			},
+			want: errors.Wrapf(testError,
+				"failed to apply connection secret: %s/%s", testNamespace, testBucketName),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bh := &bucketHandler{
+				Bucket: tt.fields.Bucket,
+				kube:   tt.fields.kube,
+			}
+			err := bh.updateSecret(ctx)
+			if diff := deep.Equal(err, tt.want); diff != nil {
+				t.Errorf("bucketHandler.updateSecret() error = %v, wantErr %v\n%s", err, tt.want, diff)
+			}
+		})
+	}
+}
+
+func Test_bucketHandler_createBucket(t *testing.T) {
+	ctx := context.TODO()
+	testProjectID := "foo"
+	actualProjectID := "bar"
+	bc := &bucketHandler{
+		Bucket: &v1alpha1.Bucket{},
+		gcp: &storagefake.MockBucketClient{
+			MockCreate: func(ctx context.Context, s string, attrs *storage.BucketAttrs) error {
+				actualProjectID = s
+				return nil
+			},
+		},
+	}
+	if err := bc.createBucket(ctx, testProjectID); err != nil {
+		t.Errorf("bucketHandler.createBucket() unexpected error %v", err)
+	}
+	if actualProjectID != testProjectID {
+		t.Errorf("bucketHandler.createBucket() projectID = %s, want %v", actualProjectID, testProjectID)
+	}
+}
+
+func Test_bucketHandler_deleteBucket(t *testing.T) {
+	ctx := context.TODO()
+	bc := &bucketHandler{
+		Bucket: &v1alpha1.Bucket{},
+		gcp: &storagefake.MockBucketClient{
+			MockDelete: func(ctx context.Context) error { return nil },
+		},
+	}
+	if err := bc.deleteBucket(ctx); err != nil {
+		t.Errorf("bucketHandler.deleteBucket() unexpected error %v", err)
+	}
+}
+
+func Test_bucketHandler_updateBucket(t *testing.T) {
+	ctx := context.TODO()
+	bc := &bucketHandler{
+		Bucket: &v1alpha1.Bucket{},
+		gcp: &storagefake.MockBucketClient{
+			MockUpdate: func(ctx context.Context, update storage.BucketAttrsToUpdate) (attrs *storage.BucketAttrs, e error) {
+				return &storage.BucketAttrs{}, nil
+			},
+		},
+	}
+	labels := map[string]string{"Foo": "bar"}
+	want := &storage.BucketAttrs{}
+	got, err := bc.updateBucket(ctx, labels)
+	if err != nil {
+		t.Errorf("bucketHandler.updateBucket() unexpected error %v", err)
+	}
+	if diff := deep.Equal(got, want); diff != nil {
+		t.Errorf("bucketHandler.updateBucket() got = %v, want %v\n%s", got, want, diff)
+	}
+}
+
+func Test_bucketHandler_getAttributes(t *testing.T) {
+	ctx := context.TODO()
+	type fields struct {
+		gcp gcpstorage.Client
+	}
+	type want struct {
+		err   error
+		attrs *storage.BucketAttrs
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   want
+	}{
+		{
+			name: "test",
+			fields: fields{
+				gcp: &storagefake.MockBucketClient{
+					MockAttrs: func(ctx context.Context) (*storage.BucketAttrs, error) { return nil, nil },
+				},
+			},
+			want: want{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bh := &bucketHandler{
+				gcp: tt.fields.gcp,
+			}
+			got, err := bh.getAttributes(ctx)
+			if diff := deep.Equal(err, tt.want.err); diff != nil {
+				t.Errorf("bucketHandler.getAttributes() error = %v, want.err %v\n%s", err, tt.want.err, diff)
+			}
+			if diff := deep.Equal(got, tt.want.attrs); diff != nil {
+				t.Errorf("bucketHandler.getAttributes() = %v, want %v\n%s", got, tt.want.attrs, diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/storage/bucket/gcp_handler.go
+++ b/pkg/controller/storage/bucket/gcp_handler.go
@@ -45,7 +45,7 @@ func (h *GCSBucketHandler) Find(n types.NamespacedName, c client.Client) (corev1
 
 // Provision a new GCS Bucket resource.
 func (h *GCSBucketHandler) Provision(class *corev1alpha1.ResourceClass, claim corev1alpha1.ResourceClaim, c client.Client) (corev1alpha1.Resource, error) {
-	spec := v1alpha1.NewBucketSpec(class.Parameters)
+	spec := v1alpha1.ParseBucketSpec(class.Parameters)
 
 	spec.ProviderRef = class.ProviderRef
 	spec.ReclaimPolicy = class.ReclaimPolicy

--- a/pkg/util/googleapi/googleapi.go
+++ b/pkg/util/googleapi/googleapi.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package googleapi
+
+import (
+	"net/http"
+
+	"google.golang.org/api/googleapi"
+)
+
+// IsErrorNotFound returns true if error of type *googleapi.Error and
+// error Code = 404
+func IsErrorNotFound(err error) bool {
+	apiErr, ok := err.(*googleapi.Error)
+	if !ok {
+		return false
+	}
+	return apiErr.Code == http.StatusNotFound
+}

--- a/pkg/util/googleapi/googleapi_test.go
+++ b/pkg/util/googleapi/googleapi_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package googleapi
+
+import (
+	"net/http"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+
+	"github.com/pkg/errors"
+)
+
+func TestIsErrorNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		args error
+		want bool
+	}{
+		{name: "nil", args: nil, want: false},
+		{name: "other", args: errors.New("foo"), want: false},
+		{name: "404", args: &googleapi.Error{Code: http.StatusNotFound}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsErrorNotFound(tt.args); got != tt.want {
+				t.Errorf("IsErrorBucketNotFound() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adding support for GCP Storage ServiceAccount Secret Reference.

Currently, GCP Bucket connection secret contains only a single data element: `Endpoint`,  with its value derived from the Bucket name. 
The remaining "credentials" data is missing from the connection secret.
This implementation was driven primarily by the lack of clarity when it comes to consuming GCP Bucket resources. 

Since then, we have an actual use case - GitLab initiative, which has specific requirements to use GCP buckets. Moreover, GitLab has particular requirements to bucket credentials format using GCP key in JSON format, as well as using Cloud Storage Interoperability.

There are several ways crossplane can address secret connection information for GCP buckets. This PR proposes to use GCP Service Account which is created separately and beforehand and manifests as Kubernetes secret in the Crossplane environment, similarly to the GCP Provider secret.
Crossplane currently does not support GCP Service Account types; hence this functionality falls into the "bootstrapping" phase of the Crossplane environment setup. 

```yaml
## GCP Storage Service Account Credentials
apiVersion: v1
kind: Secret
metadata:
  name: demo-gcp-storage-service-account
  namespace: crossplane-system
type: Opaque
data:
  credentials.json: BASE64ENCODED_CREDS_FOR_SERICE_ACCOUNT
  interopAccessKey: BASE64ENCODED_ACCESS_KEY
  interopSecret: BASE64ENCODED_SECRET
```
credentials.json - Service Account Key json file. Users can use the same key.json as in GCP Provider Secret; however, this not recommended due to Provider Service Account typically has a broader range of the permissions in GCP project (typically Project Admin/Owner). It is recommended to create a separate Storage Service Account and limit it's permissions to Bucket data related operations [Read, Write, Append, etc.].

interopAccessKey and interopSecret - provide support for interoperability with AWS S3 standard. It appears GCP offers this functionality in "Data Migration" context, i.e., helping users to migrate from AWS to GCP, and not as a "prominent" feature of GCP (or GCS). Thus, it appears, the only way to manage (generate/delete) these Key/Secret values is via the GCP Web UI console.  For more information see: https://cloud.google.com/storage/docs/migrating?hl=en_US#keys

Functional flow: GCP Bucket controller will test if `serviceAccountSecretRef` value provided, if so - it will copy credentials from the secret identified by the reference name and save it as Bucket connection secret; otherwise, it will proceed to create a secret with current "empty" credentials data.

Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from the previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [ ] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [ ] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [ ] RBAC permissions in `clusterrole.yaml` have been updated to include new types, if necessary
- [ ] All related commits have been squashed to improve readability.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)