### PR TITLE
Parametrize Controller manager syncInterval value, with default value set to 1h

### DIFF
--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -36,8 +36,9 @@ func main() {
 	var (
 		log = logging.Logger
 
-		app   = kingpin.New(filepath.Base(os.Args[0]), "An open source multicloud control plane.").DefaultEnvars()
-		debug = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
+		app         = kingpin.New(filepath.Base(os.Args[0]), "An open source multicloud control plane.").DefaultEnvars()
+		debug       = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
+		syncMinutes = app.Flag("sync", "Controller manager sync period in minutes").Short('s').Default("60").Uint()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
@@ -56,9 +57,9 @@ func main() {
 		kingpin.FatalIfError(err, "Cannot get config")
 	}
 
-	// Re-sync resources every minutes
-	// TODO: 1 minute could be too aggressive - we will update this in the future.
-	syncPeriod := 1 * time.Minute
+	// Re-sync resources based on provided duration
+	syncPeriod := time.Duration(*syncMinutes) * time.Minute
+	log.Info("Sync period", "duration", syncPeriod)
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{SyncPeriod: &syncPeriod})


### PR DESCRIPTION
Resolves #24

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [ ] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [ ] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [ ] RBAC permissions in `clusterrole.yaml` have been updated to include new types, if necessary
- [ ] All related commits have been squashed to improve readability.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)