### PR TITLE
azure: minor typo in redis controller tests

### DIFF
--- a/pkg/controller/azure/cache/redis_test.go
+++ b/pkg/controller/azure/cache/redis_test.go
@@ -473,7 +473,7 @@ func TestSync(t *testing.T) {
 			gotRequeue := tc.csdk.Sync(ctx, tc.r)
 
 			if gotRequeue != tc.wantRequeue {
-				t.Errorf("tc.csd.Sync(...): want: %t got: %t", tc.wantRequeue, gotRequeue)
+				t.Errorf("tc.csdk.Sync(...): want: %t got: %t", tc.wantRequeue, gotRequeue)
 			}
 
 			if diff := deep.Equal(tc.want, tc.r); diff != nil {
@@ -548,7 +548,7 @@ func TestDelete(t *testing.T) {
 			gotRequeue := tc.csdk.Delete(ctx, tc.r)
 
 			if gotRequeue != tc.wantRequeue {
-				t.Errorf("tc.csd.Delete(...): want: %t got: %t", tc.wantRequeue, gotRequeue)
+				t.Errorf("tc.csdk.Delete(...): want: %t got: %t", tc.wantRequeue, gotRequeue)
 			}
 
 			if diff := deep.Equal(tc.want, tc.r); diff != nil {
@@ -602,7 +602,7 @@ func TestKey(t *testing.T) {
 			gotKey := tc.csdk.Key(ctx, tc.r)
 
 			if gotKey != tc.wantKey {
-				t.Errorf("tc.csd.Key(...): want: %s got: %s", tc.wantKey, gotKey)
+				t.Errorf("tc.csdk.Key(...): want: %s got: %s", tc.wantKey, gotKey)
 			}
 
 			if diff := deep.Equal(tc.want, tc.r); diff != nil {


### PR DESCRIPTION
Commit fixes a minor typo in error messages thrown in tests for azure redis controller.

Signed-off-by: HashedDan <georgedanielmangum@gmail.com>

<!-- Please take a look at our [Contributing](../blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to Crossplane! -->

**Description of your changes:**
Errors thrown in tests for azure redis controller displayed a function call that did not match the call actually being made by the test. `csd` (createsyncdeleter) was reported as being called while `csdk` (createsyncdeletekeyer) was actually being called.

**Which issue is resolved by this Pull Request:**
Resolves N/A

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [x] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [x] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [x] RBAC permissions in `clusterrole.yaml` have been updated to include new types, if necessary
- [x] All related commits have been squashed to improve readability.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
