### PR TITLE
Fix bucket update/updateStatus bug: invalid object type. Introduced in #400

### DIFF
--- a/pkg/controller/gcp/storage/bucket_operations.go
+++ b/pkg/controller/gcp/storage/bucket_operations.go
@@ -110,11 +110,11 @@ func (bh *bucketHandler) failReconcile(ctx context.Context, reason, msg string) 
 // Controller-runtime Client operations
 //
 func (bh *bucketHandler) updateObject(ctx context.Context) error {
-	return bh.kube.Update(ctx, bh)
+	return bh.kube.Update(ctx, bh.Bucket)
 }
 
 func (bh *bucketHandler) updateStatus(ctx context.Context) error {
-	return bh.kube.Status().Update(ctx, bh)
+	return bh.kube.Status().Update(ctx, bh.Bucket)
 }
 
 func (bh *bucketHandler) getSecret(ctx context.Context, nn types.NamespacedName, s *corev1.Secret) error {

--- a/pkg/controller/gcp/storage/bucket_operations_test.go
+++ b/pkg/controller/gcp/storage/bucket_operations_test.go
@@ -369,7 +369,12 @@ func Test_bucketHandler_updateObject(t *testing.T) {
 	bc := &bucketHandler{
 		Bucket: bucket,
 		kube: &test.MockClient{
-			MockUpdate: func(ctx context.Context, obj runtime.Object) error { return nil },
+			MockUpdate: func(ctx context.Context, obj runtime.Object) error {
+				if _, ok := obj.(*v1alpha1.Bucket); !ok {
+					t.Errorf("bucketHandler.updateObject() unexpected type %T, want %T", obj, bucket)
+				}
+				return nil
+			},
 		},
 	}
 	if err := bc.updateObject(ctx); err != nil {
@@ -383,7 +388,12 @@ func Test_bucketHandler_updateStatus(t *testing.T) {
 	bc := &bucketHandler{
 		Bucket: bucket,
 		kube: &test.MockClient{
-			MockStatusUpdate: func(ctx context.Context, obj runtime.Object) error { return nil },
+			MockStatusUpdate: func(ctx context.Context, obj runtime.Object) error {
+				if _, ok := obj.(*v1alpha1.Bucket); !ok {
+					t.Errorf("bucketHandler.updateStatus() unexpected type %T, want %T", obj, bucket)
+				}
+				return nil
+			},
 		},
 	}
 	if err := bc.updateStatus(ctx); err != nil {


### PR DESCRIPTION
**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [ ] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [ ] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [ ] RBAC permissions in `clusterrole.yaml` have been updated to include new types, if necessary
- [ ] All related commits have been squashed to improve readability.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)