### PR TITLE
core: comment correction for SetDeleting

### DIFF
--- a/pkg/apis/core/v1alpha1/condition.go
+++ b/pkg/apis/core/v1alpha1/condition.go
@@ -136,7 +136,7 @@ func (c *ConditionedStatus) SetPending() {
 	c.SetCondition(NewCondition(Pending, "", ""))
 }
 
-// SetDeleting set creating as an active condition
+// SetDeleting set deleting as an active condition
 func (c *ConditionedStatus) SetDeleting() {
 	c.SetCondition(NewCondition(Deleting, "", ""))
 }


### PR DESCRIPTION
Comment describing SetDeleting stated that function sets creating as active condition.

Signed-off-by: HashedDan <georgedanielmangum@gmail.com>

<!-- Please take a look at our [Contributing](../blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to Crossplane! -->

**Description of your changes:**
Minor typo in core api for `SetDeleting()` function where it stated that the function would set `Creating` as the active condition instead of `Deleting`.

**Which issue is resolved by this Pull Request:**
Resolves N/A

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [x] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [x] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [x] RBAC permissions in `clusterrole.yaml` have been updated to include new types, if necessary
- [x] All related commits have been squashed to improve readability.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
