### PR TITLE
test: all table driven test names converted to camel case

### DIFF
--- a/pkg/apis/apis_test.go
+++ b/pkg/apis/apis_test.go
@@ -32,7 +32,7 @@ func TestAddToScheme(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "test",
+			name:    "Test",
 			args:    args{s: runtime.NewScheme()},
 			wantErr: false,
 		},

--- a/pkg/apis/gcp/compute/v1alpha1/types_test.go
+++ b/pkg/apis/gcp/compute/v1alpha1/types_test.go
@@ -85,17 +85,17 @@ func TestParseClusterSpec(t *testing.T) {
 		want *GKEClusterSpec
 	}{
 		{
-			name: "nil properties",
+			name: "NilProperties",
 			args: nil,
 			want: &GKEClusterSpec{ReclaimPolicy: DefaultReclaimPolicy},
 		},
 		{
-			name: "empty properties",
+			name: "EmptyProperties",
 			args: map[string]string{},
 			want: &GKEClusterSpec{ReclaimPolicy: DefaultReclaimPolicy},
 		},
 		{
-			name: "valid values",
+			name: "ValidValues",
 			args: map[string]string{
 				"enableIPAlias": "true",
 				"machineType":   "test-machine",
@@ -113,7 +113,7 @@ func TestParseClusterSpec(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid values",
+			name: "InvalidValues",
 			args: map[string]string{
 				"enableIPAlias": "really",
 				"machineType":   "test-machine",
@@ -131,7 +131,7 @@ func TestParseClusterSpec(t *testing.T) {
 			},
 		},
 		{
-			name: "defaults",
+			name: "Defaults",
 			args: map[string]string{
 				"machineType": "test-machine",
 				"zone":        "test-zone",
@@ -162,8 +162,8 @@ func Test_parseNodesNumber(t *testing.T) {
 		args string
 		want int64
 	}{
-		{name: "empty", args: "", want: DefaultNumberOfNodes},
-		{name: "invalid", args: "foo", want: DefaultNumberOfNodes},
+		{name: "Empty", args: "", want: DefaultNumberOfNodes},
+		{name: "Invalid", args: "foo", want: DefaultNumberOfNodes},
 		{name: "0", args: "0", want: int64(0)},
 		{name: "44", args: "44", want: int64(44)},
 		{name: "-44", args: "-44", want: DefaultNumberOfNodes},

--- a/pkg/apis/gcp/storage/v1alpha1/types_test.go
+++ b/pkg/apis/gcp/storage/v1alpha1/types_test.go
@@ -95,8 +95,8 @@ func TestProjectTeam(t *testing.T) {
 		args *ProjectTeam
 		want *storage.ProjectTeam
 	}{
-		{"nil", nil, nil},
-		{"val", testProjectTeam, testStorageProjectTeam},
+		{"Nil", nil, nil},
+		{"Val", testProjectTeam, testStorageProjectTeam},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -139,8 +139,8 @@ func TestNewBucketPolicyOnly(t *testing.T) {
 		args storage.BucketPolicyOnly
 		want BucketPolicyOnly
 	}{
-		{name: "default", args: storage.BucketPolicyOnly{}, want: BucketPolicyOnly{}},
-		{name: "values", args: storage.BucketPolicyOnly{Enabled: true}, want: BucketPolicyOnly{Enabled: true}},
+		{name: "Default", args: storage.BucketPolicyOnly{}, want: BucketPolicyOnly{}},
+		{name: "Values", args: storage.BucketPolicyOnly{Enabled: true}, want: BucketPolicyOnly{Enabled: true}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -158,8 +158,8 @@ func TestCopyToBucketPolicyOnly(t *testing.T) {
 		args BucketPolicyOnly
 		want storage.BucketPolicyOnly
 	}{
-		{name: "default", args: BucketPolicyOnly{}, want: storage.BucketPolicyOnly{}},
-		{name: "values", args: BucketPolicyOnly{Enabled: true}, want: storage.BucketPolicyOnly{Enabled: true}},
+		{name: "Default", args: BucketPolicyOnly{}, want: storage.BucketPolicyOnly{}},
+		{name: "Values", args: BucketPolicyOnly{Enabled: true}, want: storage.BucketPolicyOnly{Enabled: true}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -177,8 +177,8 @@ func TestACLRule(t *testing.T) {
 		args ACLRule
 		want storage.ACLRule
 	}{
-		{"default value args", ACLRule{}, storage.ACLRule{}},
-		{"values", testACLRule, testStorageACLRule},
+		{"DefaultValueArgs", ACLRule{}, storage.ACLRule{}},
+		{"Values", testACLRule, testStorageACLRule},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -200,9 +200,9 @@ func TestNewACLRules(t *testing.T) {
 		args []storage.ACLRule
 		want []ACLRule
 	}{
-		{"nil", nil, nil},
-		{"empty", []storage.ACLRule{}, nil},
-		{"values", []storage.ACLRule{testStorageACLRule}, []ACLRule{testACLRule}},
+		{"Nil", nil, nil},
+		{"Empty", []storage.ACLRule{}, nil},
+		{"Values", []storage.ACLRule{testStorageACLRule}, []ACLRule{testACLRule}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -220,9 +220,9 @@ func TestCopyToACLRules(t *testing.T) {
 		args []ACLRule
 		want []storage.ACLRule
 	}{
-		{"nil", nil, nil},
-		{"empty", []ACLRule{}, nil},
-		{"values", []ACLRule{testACLRule}, []storage.ACLRule{testStorageACLRule}},
+		{"Nil", nil, nil},
+		{"Empty", []ACLRule{}, nil},
+		{"Values", []ACLRule{testACLRule}, []storage.ACLRule{testStorageACLRule}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -252,7 +252,7 @@ func TestNewLifecyleAction(t *testing.T) {
 		args storage.LifecycleAction
 		want LifecycleAction
 	}{
-		{"val", testStorageLifecyleAction, testLifecycleAction},
+		{"Val", testStorageLifecyleAction, testLifecycleAction},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -270,7 +270,7 @@ func TestCopyToLifecyleAction(t *testing.T) {
 		args LifecycleAction
 		want storage.LifecycleAction
 	}{
-		{"test", testLifecycleAction, testStorageLifecyleAction},
+		{"Test", testLifecycleAction, testStorageLifecyleAction},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -308,7 +308,7 @@ func TestNewLifecycleCondition(t *testing.T) {
 		args storage.LifecycleCondition
 		want LifecycleCondition
 	}{
-		{"test", testStorageLifecycleCondition, testLifecycleCondition},
+		{"Test", testStorageLifecycleCondition, testLifecycleCondition},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -326,7 +326,7 @@ func TestCopyToLifecycleCondition(t *testing.T) {
 		args LifecycleCondition
 		want storage.LifecycleCondition
 	}{
-		{"test", testLifecycleCondition, testStorageLifecycleCondition},
+		{"Test", testLifecycleCondition, testStorageLifecycleCondition},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -356,7 +356,7 @@ func TestNewLifecycleRule(t *testing.T) {
 		args storage.LifecycleRule
 		want LifecycleRule
 	}{
-		{"test", testStorageLifecycleRule, testLifecycleRule},
+		{"Test", testStorageLifecycleRule, testLifecycleRule},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -374,7 +374,7 @@ func TestCopyToLifecyleRule(t *testing.T) {
 		args LifecycleRule
 		want storage.LifecycleRule
 	}{
-		{"test", testLifecycleRule, testStorageLifecycleRule},
+		{"Test", testLifecycleRule, testStorageLifecycleRule},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -397,8 +397,8 @@ func TestNewLifecycle(t *testing.T) {
 		args storage.Lifecycle
 		want Lifecycle
 	}{
-		{"rules-nil", storage.Lifecycle{Rules: nil}, Lifecycle{Rules: nil}},
-		{"rules-val", testStorageLifecycle, testLifecycle},
+		{"RulesNil", storage.Lifecycle{Rules: nil}, Lifecycle{Rules: nil}},
+		{"RulesVal", testStorageLifecycle, testLifecycle},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -416,8 +416,8 @@ func TestCopyToLifecycle(t *testing.T) {
 		args Lifecycle
 		want storage.Lifecycle
 	}{
-		{"rules-nil", Lifecycle{Rules: nil}, storage.Lifecycle{Rules: nil}},
-		{"rules-val", Lifecycle{Rules: []LifecycleRule{testLifecycleRule}},
+		{"RulesNil", Lifecycle{Rules: nil}, storage.Lifecycle{Rules: nil}},
+		{"RulesVal", Lifecycle{Rules: []LifecycleRule{testLifecycleRule}},
 			storage.Lifecycle{Rules: []storage.LifecycleRule{testStorageLifecycleRule}}},
 	}
 	for _, tt := range tests {
@@ -451,8 +451,8 @@ func TestNewRetentionPolicy(t *testing.T) {
 		args *storage.RetentionPolicy
 		want *RetentionPolicy
 	}{
-		{"nil", nil, nil},
-		{"val", testStorageRetentionPolicy, testRetentionPolicy},
+		{"Nil", nil, nil},
+		{"Val", testStorageRetentionPolicy, testRetentionPolicy},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -476,8 +476,8 @@ func TestCopyToRetentionPolicy(t *testing.T) {
 		args *RetentionPolicy
 		want *storage.RetentionPolicy
 	}{
-		{"nil", nil, &storage.RetentionPolicy{RetentionPeriod: time.Duration(0)}},
-		{"val", testRetentionPolicy, testStorageRetentionPolicy},
+		{"Nil", nil, &storage.RetentionPolicy{RetentionPeriod: time.Duration(0)}},
+		{"Val", testRetentionPolicy, testStorageRetentionPolicy},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -501,8 +501,8 @@ func TestNewRetentionPolicyStatus(t *testing.T) {
 		args *storage.RetentionPolicy
 		want *RetentionPolicyStatus
 	}{
-		{"nil", nil, nil},
-		{"val", testStorageRetentionPolicy, testRetentionPolicyStatus},
+		{"Nil", nil, nil},
+		{"Val", testStorageRetentionPolicy, testRetentionPolicyStatus},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -525,8 +525,8 @@ func TestNewBucketEncryption(t *testing.T) {
 		args *storage.BucketEncryption
 		want *BucketEncryption
 	}{
-		{"nil", nil, nil},
-		{"val", testStorageBucketEncryption, testBucketEncryption},
+		{"Nil", nil, nil},
+		{"Val", testStorageBucketEncryption, testBucketEncryption},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -544,8 +544,8 @@ func TestCopyToBucketEncryption(t *testing.T) {
 		args *BucketEncryption
 		want *storage.BucketEncryption
 	}{
-		{"nil", nil, nil},
-		{"val", testBucketEncryption, testStorageBucketEncryption},
+		{"Nil", nil, nil},
+		{"Val", testBucketEncryption, testStorageBucketEncryption},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -575,8 +575,8 @@ func TestNewBucketLogging(t *testing.T) {
 		args *storage.BucketLogging
 		want *BucketLogging
 	}{
-		{"nil", nil, nil},
-		{"val", testStorageBucketLogging, testBucketLogging},
+		{"Nil", nil, nil},
+		{"Val", testStorageBucketLogging, testBucketLogging},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -594,8 +594,8 @@ func TestCopyToBucketLogging(t *testing.T) {
 		args *BucketLogging
 		want *storage.BucketLogging
 	}{
-		{"nil", nil, nil},
-		{"val", testBucketLogging, testStorageBucketLogging},
+		{"Nil", nil, nil},
+		{"Val", testBucketLogging, testStorageBucketLogging},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -629,7 +629,7 @@ func TestNewCORS(t *testing.T) {
 		args storage.CORS
 		want CORS
 	}{
-		{"test", testStorageCORS, testCORS},
+		{"Test", testStorageCORS, testCORS},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -647,7 +647,7 @@ func TestCopyToCORS(t *testing.T) {
 		args CORS
 		want storage.CORS
 	}{
-		{"test", testCORS, testStorageCORS},
+		{"Test", testCORS, testStorageCORS},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -665,9 +665,9 @@ func TestNewCORSs(t *testing.T) {
 		args []storage.CORS
 		want []CORS
 	}{
-		{"nil", nil, nil},
-		{"empty", []storage.CORS{}, []CORS{}},
-		{"val", []storage.CORS{testStorageCORS}, []CORS{testCORS}},
+		{"Nil", nil, nil},
+		{"Empty", []storage.CORS{}, []CORS{}},
+		{"Val", []storage.CORS{testStorageCORS}, []CORS{testCORS}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -685,9 +685,9 @@ func TestCopyToCORSs(t *testing.T) {
 		args []CORS
 		want []storage.CORS
 	}{
-		{"nil", nil, nil},
-		{"empty", []CORS{}, []storage.CORS{}},
-		{"val", []CORS{testCORS}, []storage.CORS{testStorageCORS}},
+		{"Nil", nil, nil},
+		{"Empty", []CORS{}, []storage.CORS{}},
+		{"Val", []CORS{testCORS}, []storage.CORS{testStorageCORS}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -710,8 +710,8 @@ func TestNewBucketWebsite(t *testing.T) {
 		args *storage.BucketWebsite
 		want *BucketWebsite
 	}{
-		{"nil", nil, nil},
-		{"val", testStorageBucketWebsite, testBucketWebsite},
+		{"Nil", nil, nil},
+		{"Val", testStorageBucketWebsite, testBucketWebsite},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -729,8 +729,8 @@ func TestCopyToBucketWebsite(t *testing.T) {
 		args *BucketWebsite
 		want *storage.BucketWebsite
 	}{
-		{"nil", nil, nil},
-		{"val", testBucketWebsite, testStorageBucketWebsite},
+		{"Nil", nil, nil},
+		{"Val", testBucketWebsite, testStorageBucketWebsite},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -795,8 +795,8 @@ func TestNewBucketUpdateAttrs(t *testing.T) {
 		args *storage.BucketAttrs
 		want *BucketUpdatableAttrs
 	}{
-		{"nil", nil, nil},
-		{"val", testStorageBucketAttrs, testBucketUpdateAttrs},
+		{"Nil", nil, nil},
+		{"Val", testStorageBucketAttrs, testBucketUpdateAttrs},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -814,8 +814,8 @@ func TestCopyToBucketAttrs(t *testing.T) {
 		args *BucketUpdatableAttrs
 		want *storage.BucketAttrs
 	}{
-		{"nil", nil, nil},
-		{"val", testBucketUpdateAttrs, testStorageBucketAttrs},
+		{"Nil", nil, nil},
+		{"Val", testBucketUpdateAttrs, testStorageBucketAttrs},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -845,7 +845,7 @@ func TestCopyToBucketUpdateAttrs(t *testing.T) {
 		want storage.BucketAttrsToUpdate
 	}{
 		{
-			name: "test",
+			name: "Test",
 			args: args{*testBucketUpdateAttrs, map[string]string{"application": "crossplane", "foo": "bar"}},
 			want: testStorageBucketAttrsToUpdate,
 		},
@@ -897,8 +897,8 @@ func TestNewBucketSpecAttrs(t *testing.T) {
 		args *storage.BucketAttrs
 		want BucketSpecAttrs
 	}{
-		{"nil", nil, BucketSpecAttrs{}},
-		{"val", testStorageBucketAttrs2, *testBucketSpecAttrs},
+		{"Nil", nil, BucketSpecAttrs{}},
+		{"Val", testStorageBucketAttrs2, *testBucketSpecAttrs},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -916,8 +916,8 @@ func TestCopyBucketSpecAttrs(t *testing.T) {
 		args *BucketSpecAttrs
 		want *storage.BucketAttrs
 	}{
-		{"nil", nil, nil},
-		{"val", testBucketSpecAttrs, testStorageBucketAttrs2},
+		{"Nil", nil, nil},
+		{"Val", testBucketSpecAttrs, testStorageBucketAttrs2},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -952,8 +952,8 @@ func TestNewBucketOutputAttrs(t *testing.T) {
 		args *storage.BucketAttrs
 		want BucketOutputAttrs
 	}{
-		{"nil", nil, BucketOutputAttrs{}},
-		{"val", testStorageBucketAttrs3, testBucketOutputAttrs},
+		{"Nil", nil, BucketOutputAttrs{}},
+		{"Val", testStorageBucketAttrs3, testBucketOutputAttrs},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -971,9 +971,9 @@ func TestBucket_ConnectionSecretName(t *testing.T) {
 		bucket Bucket
 		want   string
 	}{
-		{"default", Bucket{}, ""},
-		{"named", Bucket{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}, "foo"},
-		{"override",
+		{"Default", Bucket{}, ""},
+		{"Named", Bucket{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}, "foo"},
+		{"Override",
 			Bucket{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Spec:       BucketSpec{ConnectionSecretNameOverride: "bar"}}, "bar"},
@@ -1031,7 +1031,7 @@ func TestBucket_ObjectReference(t *testing.T) {
 		bucket Bucket
 		want   *corev1.ObjectReference
 	}{
-		{"test", Bucket{}, &corev1.ObjectReference{APIVersion: APIVersion, Kind: BucketKind}},
+		{"Test", Bucket{}, &corev1.ObjectReference{APIVersion: APIVersion, Kind: BucketKind}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1049,7 +1049,7 @@ func TestBucket_OwnerReference(t *testing.T) {
 		bucket Bucket
 		want   metav1.OwnerReference
 	}{
-		{"test", Bucket{}, metav1.OwnerReference{APIVersion: APIVersion, Kind: BucketKind}},
+		{"Test", Bucket{}, metav1.OwnerReference{APIVersion: APIVersion, Kind: BucketKind}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1078,10 +1078,10 @@ func TestBucket_IsAvailable(t *testing.T) {
 		bucket Bucket
 		want   bool
 	}{
-		{"no conditions", b, false},
-		{"running active", bReady, true},
-		{"running and failed active", bReadyAndFailed, true},
-		{"not running and failed active", bNotReadyAndFailed, false},
+		{"NoConditions", b, false},
+		{"RunningActive", bReady, true},
+		{"RunningAndFailedActive", bReadyAndFailed, true},
+		{"NotRunningAndFailedActive", bNotReadyAndFailed, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1098,8 +1098,8 @@ func TestBucket_IsBound(t *testing.T) {
 		phase v1alpha1.BindingState
 		want  bool
 	}{
-		{"bound", v1alpha1.BindingStateBound, true},
-		{"not-bound", v1alpha1.BindingStateUnbound, false},
+		{"Bound", v1alpha1.BindingStateBound, true},
+		{"NotBound", v1alpha1.BindingStateUnbound, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1123,8 +1123,8 @@ func TestBucket_SetBound(t *testing.T) {
 		state bool
 		want  v1alpha1.BindingState
 	}{
-		{"not-bound", false, v1alpha1.BindingStateUnbound},
-		{"bound", true, v1alpha1.BindingStateBound},
+		{"NotBound", false, v1alpha1.BindingStateUnbound},
+		{"Bound", true, v1alpha1.BindingStateBound},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1143,10 +1143,10 @@ func Test_parseCORSList(t *testing.T) {
 		args string
 		want []CORS
 	}{
-		{name: "empty", args: "", want: nil},
-		{name: "invalid", args: "foo", want: nil},
+		{name: "Empty", args: "", want: nil},
+		{name: "Invalid", args: "foo", want: nil},
 		{
-			name: "valid",
+			name: "Valid",
 			args: `[{"maxAge":"1s","methods":["GET","POST"],"origins":["foo","bar"]}]`,
 			want: []CORS{
 				{
@@ -1178,10 +1178,10 @@ func Test_parseLifecycle(t *testing.T) {
 		args string
 		want *Lifecycle
 	}{
-		{name: "empty", args: "", want: &Lifecycle{}},
-		{name: "invalid", args: "foo", want: &Lifecycle{}},
+		{name: "Empty", args: "", want: &Lifecycle{}},
+		{name: "Invalid", args: "foo", want: &Lifecycle{}},
 		{
-			name: "valid",
+			name: "Valid",
 			args: `{"rules":[{"action":{"storageClass":"test-storage-class","type":"test-action-type"},` +
 				`"condition":{"ageInDays":10,"createdBefore":"2019-03-26T21:58:58Z",` +
 				`"liveness":3,"matchesStorageClasses":["foo","bar"],"numNewerVersions":42}}]}`,
@@ -1220,10 +1220,10 @@ func Test_parseLogging(t *testing.T) {
 		args string
 		want *BucketLogging
 	}{
-		{name: "empty", args: "", want: &BucketLogging{}},
-		{name: "invalid", args: "foo", want: &BucketLogging{}},
+		{name: "Empty", args: "", want: &BucketLogging{}},
+		{name: "Invalid", args: "foo", want: &BucketLogging{}},
 		{
-			name: "valid",
+			name: "Valid",
 			args: "logBucket:foo,logObjectPrefix:bar",
 			want: &BucketLogging{LogBucket: "foo", LogObjectPrefix: "bar"},
 		},
@@ -1244,10 +1244,10 @@ func Test_parseWebsite(t *testing.T) {
 		args string
 		want *BucketWebsite
 	}{
-		{name: "empty", args: "", want: &BucketWebsite{}},
-		{name: "invalid", args: "foo", want: &BucketWebsite{}},
+		{name: "Empty", args: "", want: &BucketWebsite{}},
+		{name: "Invalid", args: "foo", want: &BucketWebsite{}},
 		{
-			name: "valid",
+			name: "Valid",
 			args: "mainPageSuffix:foo,notFoundPage:bar",
 			want: &BucketWebsite{MainPageSuffix: "foo", NotFoundPage: "bar"},
 		},
@@ -1269,17 +1269,17 @@ func Test_parseACLRules(t *testing.T) {
 		want []ACLRule
 	}{
 		{
-			name: "empty",
+			name: "Empty",
 			args: "",
 			want: nil,
 		},
 		{
-			name: "invalid",
+			name: "Invalid",
 			args: "foo",
 			want: nil,
 		},
 		{
-			name: "single rule",
+			name: "SingleRule",
 			args: `[{"Entity":"test-entity","EntityID":"42","Role":"test-role","Domain":"test-domain","Email":"test-email","ProjectTeam":{"ProjectNumber":"test-project-number","Team":"test-team"}}]`,
 			want: []ACLRule{
 				{
@@ -1296,7 +1296,7 @@ func Test_parseACLRules(t *testing.T) {
 			},
 		},
 		{
-			name: "single rule",
+			name: "SingleRule",
 			args: `[{"Entity":"test-entity","EntityID":"42","Role":"test-role","Domain":"test-domain","Email":"test-email","ProjectTeam":{"ProjectNumber":"test-project-number","Team":"test-team"}},` +
 				`{"Entity":"another-entity","EntityID":"42","Role":"test-role","Domain":"test-domain","Email":"test-email","ProjectTeam":{"ProjectNumber":"test-project-number","Team":"test-team"}}]`,
 			want: []ACLRule{
@@ -1345,10 +1345,10 @@ func TestParseBucketSpec(t *testing.T) {
 		args map[string]string
 		want *BucketSpec
 	}{
-		{name: "empty", args: map[string]string{}, want: &BucketSpec{ReclaimPolicy: v1alpha1.ReclaimRetain}},
-		{name: "invalid", args: map[string]string{"foo": "bar"}, want: &BucketSpec{ReclaimPolicy: v1alpha1.ReclaimRetain}},
+		{name: "Empty", args: map[string]string{}, want: &BucketSpec{ReclaimPolicy: v1alpha1.ReclaimRetain}},
+		{name: "Invalid", args: map[string]string{"foo": "bar"}, want: &BucketSpec{ReclaimPolicy: v1alpha1.ReclaimRetain}},
 		{
-			name: "valid",
+			name: "Valid",
 			args: map[string]string{
 				"bucketPolicyOnly":            "true",
 				"cors":                        `[{"maxAge":"1s","methods":["GET","POST"],"origins":["foo","bar"]}]`,
@@ -1454,7 +1454,7 @@ func TestBucket_GetBucketName(t *testing.T) {
 		want   string
 	}{
 		{
-			name: "no name format",
+			name: "NoNameFormat",
 			fields: fields{
 				ObjectMeta: om,
 				Spec:       BucketSpec{},
@@ -1462,7 +1462,7 @@ func TestBucket_GetBucketName(t *testing.T) {
 			want: "test-uid",
 		},
 		{
-			name: "format string",
+			name: "FormatString",
 			fields: fields{
 				ObjectMeta: om,
 				Spec: BucketSpec{
@@ -1472,7 +1472,7 @@ func TestBucket_GetBucketName(t *testing.T) {
 			want: "foo-test-uid",
 		},
 		{
-			name: "constant string",
+			name: "ConstantString",
 			fields: fields{
 				ObjectMeta: om,
 				Spec: BucketSpec{
@@ -1482,7 +1482,7 @@ func TestBucket_GetBucketName(t *testing.T) {
 			want: "foo-bar",
 		},
 		{
-			name: "invalid: multiple substitutions",
+			name: "InvalidMultipleSubstitutions",
 			fields: fields{
 				ObjectMeta: om,
 				Spec: BucketSpec{

--- a/pkg/clients/azure/storage/account_test.go
+++ b/pkg/clients/azure/storage/account_test.go
@@ -32,13 +32,13 @@ func TestNewStorageAccountClient(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name:    "empty-data",
+			name:    "EmptyData",
 			args:    []byte{},
 			wantRes: nil,
 			wantErr: errors.WithStack(errors.New("cannot unmarshal Azure client secret data: unexpected end of JSON input")),
 		},
 		{
-			name: "success",
+			name: "Success",
 			args: []byte(`{"clientId": "0f32e96b-b9a4-49ce-a857-243a33b20e5c",
 	"clientSecret": "49d8cab5-d47a-4d1a-9133-5c5db29c345d",
 	"subscriptionId": "bf1b0e59-93da-42e0-82c6-5a1d94227911",
@@ -81,7 +81,7 @@ func TestNewAccountHandle(t *testing.T) {
 		want *AccountHandle
 	}{
 		{
-			name: "test",
+			name: "Test",
 			args: args{
 				client:      &storage.AccountsClient{},
 				groupName:   "test-group",

--- a/pkg/clients/gcp/gke/gke_test.go
+++ b/pkg/clients/gcp/gke/gke_test.go
@@ -34,7 +34,7 @@ func TestNewClusterClient(t *testing.T) {
 		args *google.Credentials
 		want want
 	}{
-		{name: "test", args: &google.Credentials{}, want: want{res: &ClusterClient{}}},
+		{name: "Test", args: &google.Credentials{}, want: want{res: &ClusterClient{}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controller/azure/storage/account/account_test.go
+++ b/pkg/controller/azure/storage/account/account_test.go
@@ -257,12 +257,12 @@ func TestReconciler_Reconcile(t *testing.T) {
 		want   want
 	}{
 		{
-			name:   "get-err-not-found",
+			name:   "GetErrNotFound",
 			fields: fields{client: fake.NewFakeClient(), maker: nil},
 			want:   want{res: rsDone},
 		},
 		{
-			name: "get-error-other",
+			name: "GetErrorOther",
 			fields: fields{
 				client: &test.MockClient{
 					MockGet: func(context.Context, client.ObjectKey, runtime.Object) error {
@@ -273,7 +273,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			want: want{res: rsDone, err: errors.New("test-get-error")},
 		},
 		{
-			name: "account-handler-error",
+			name: "AccountHandlerError",
 			fields: fields{
 				client: fake.NewFakeClient(v1alpha1test.NewMockAccount(ns, name).WithFinalizer("foo.bar").Account),
 				maker:  newMockAccountHandleMaker(nil, errors.New("handler-syncdeleterMaker-error")),
@@ -286,7 +286,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 		},
 		{
-			name: "reconcile-delete",
+			name: "ReconcileDelete",
 			fields: fields{
 				client: fake.NewFakeClient(v1alpha1test.NewMockAccount(ns, name).
 					WithDeleteTimestamp(metav1.NewTime(time.Now())).Account),
@@ -295,7 +295,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			want: want{res: rsDone},
 		},
 		{
-			name: "reconcile-sync",
+			name: "ReconcileSync",
 			fields: fields{
 				client: fake.NewFakeClient(v1alpha1test.NewMockAccount(ns, name).Account),
 				maker:  newMockAccountHandleMaker(newMockAccountSyncDeleter(), nil),
@@ -357,7 +357,7 @@ func Test_accountHandleMaker_newHandler(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "err provider is not found",
+			name: "ErrProviderIsNotFound",
 			kube: fake.NewFakeClient(),
 			acct: v1alpha1test.NewMockAccount(ns, bucketName).WithSpecProvider(providerName).Account,
 			wantErr: kerrors.NewNotFound(schema.GroupResource{
@@ -365,14 +365,14 @@ func Test_accountHandleMaker_newHandler(t *testing.T) {
 				Resource: "providers"}, "test-provider"),
 		},
 		{
-			name: "provider is not ready",
+			name: "ProviderIsNotReady",
 			kube: fake.NewFakeClient(newProvider(ns, providerName).
 				withCondition(corev1alpha1.NewCondition(corev1alpha1.Failed, "", "")).Provider),
 			acct:    v1alpha1test.NewMockAccount(ns, bucketName).WithSpecProvider("test-provider").Account,
 			wantErr: errors.Errorf("provider: %s is not ready", ns+"/test-provider"),
 		},
 		{
-			name: "provider secret is not found",
+			name: "ProviderSecretIsNotFound",
 			kube: fake.NewFakeClient(newProvider(ns, providerName).
 				withCondition(corev1alpha1.NewReadyCondition()).
 				withSecret(secretName, secretKey).Provider),
@@ -381,7 +381,7 @@ func Test_accountHandleMaker_newHandler(t *testing.T) {
 				errors.Errorf("cannot get provider's secret %s/%s: secrets \"%s\" not found", ns, secretName, secretName)),
 		},
 		{
-			name: "invalid credentials",
+			name: "InvalidCredentials",
 			kube: fake.NewFakeClient(newProvider(ns, providerName).
 				withCondition(corev1alpha1.NewReadyCondition()).
 				withSecret(secretName, secretKey).Provider,
@@ -391,7 +391,7 @@ func Test_accountHandleMaker_newHandler(t *testing.T) {
 				errors.Errorf("cannot create storageClient from json: cannot unmarshal Azure client secret data: unexpected end of JSON input")),
 		},
 		{
-			name: "kube created",
+			name: "KubeCreated",
 			kube: fake.NewFakeClient(newProvider(ns, providerName).
 				withCondition(corev1alpha1.NewReadyCondition()).
 				withSecret(secretName, secretKey).Provider,
@@ -437,7 +437,7 @@ func Test_syncdeleter_delete(t *testing.T) {
 		want   want
 	}{
 		{
-			name: "retain-policy",
+			name: "RetainPolicy",
 			fields: fields{
 				acct: v1alpha1test.NewMockAccount(ns, bucketName).WithSpecReclaimPolicy(corev1alpha1.ReclaimRetain).
 					WithFinalizers([]string{finalizer, "test"}).Account,
@@ -455,7 +455,7 @@ func Test_syncdeleter_delete(t *testing.T) {
 			},
 		},
 		{
-			name: "delete-successful",
+			name: "DeleteSuccessful",
 			fields: fields{
 				acct: v1alpha1test.NewMockAccount(ns, bucketName).WithSpecReclaimPolicy(corev1alpha1.ReclaimDelete).
 					WithFinalizer(finalizer).Account,
@@ -475,7 +475,7 @@ func Test_syncdeleter_delete(t *testing.T) {
 			},
 		},
 		{
-			name: "delete-failed",
+			name: "DeleteFailed",
 			fields: fields{
 				acct: v1alpha1test.NewMockAccount(ns, bucketName).WithSpecReclaimPolicy(corev1alpha1.ReclaimDelete).
 					WithFinalizer(finalizer).Account,
@@ -500,7 +500,7 @@ func Test_syncdeleter_delete(t *testing.T) {
 			},
 		},
 		{
-			name: "delete-non-existent",
+			name: "DeleteNonExistent",
 			fields: fields{
 				acct: v1alpha1test.NewMockAccount(ns, bucketName).WithSpecReclaimPolicy(corev1alpha1.ReclaimDelete).
 					WithFinalizer(finalizer).Account,
@@ -564,7 +564,7 @@ func Test_syncdeleter_sync(t *testing.T) {
 		want   want
 	}{
 		{
-			name: "attrs error",
+			name: "AttrsError",
 			fields: fields{
 				ao: &azurestoragefake.MockAccountOperations{
 					MockGet: func(i context.Context) (attrs *storage.Account, e error) {
@@ -585,7 +585,7 @@ func Test_syncdeleter_sync(t *testing.T) {
 			},
 		},
 		{
-			name: "attrs not found (create)",
+			name: "AttrsNotFoundCreate",
 			fields: fields{
 				kube: &test.MockClient{
 					MockCreate: func(ctx context.Context, obj runtime.Object) error { return nil },
@@ -605,7 +605,7 @@ func Test_syncdeleter_sync(t *testing.T) {
 			},
 		},
 		{
-			name: "update",
+			name: "Update",
 			fields: fields{
 				kube: &test.MockClient{
 					MockCreate: func(ctx context.Context, obj runtime.Object) error { return nil },
@@ -672,7 +672,7 @@ func Test_createupdater_create(t *testing.T) {
 		want   want
 	}{
 		{
-			name: "create failed",
+			name: "CreateFailed",
 			fields: fields{
 				ao: &azurestoragefake.MockAccountOperations{
 					MockCreate: func(ctx context.Context, params storage.AccountCreateParameters) (*storage.Account, error) {
@@ -702,7 +702,7 @@ func Test_createupdater_create(t *testing.T) {
 			},
 		},
 		{
-			name: "create successful",
+			name: "CreateSuccessful",
 			fields: fields{
 				sb: &MockAccountSyncbacker{
 					MockSyncback: func(ctx context.Context, a *storage.Account) (result reconcile.Result, e error) {
@@ -780,7 +780,7 @@ func Test_bucketCreateUpdater_update(t *testing.T) {
 		want   want
 	}{
 		{
-			name: "not ready",
+			name: "NotReady",
 			attrs: newStorageAccount().
 				withAccountProperties(newStorageAccountProperties().
 					withProvisioningStage(storage.Creating).AccountProperties).Account,
@@ -796,7 +796,7 @@ func Test_bucketCreateUpdater_update(t *testing.T) {
 			},
 		},
 		{
-			name: "no changes and not ready",
+			name: "NoChangesAndNotReady",
 			attrs: &storage.Account{
 				AccountProperties: &storage.AccountProperties{ProvisioningState: storage.Succeeded},
 			},
@@ -811,7 +811,7 @@ func Test_bucketCreateUpdater_update(t *testing.T) {
 			},
 		},
 		{
-			name: "no changes and ready",
+			name: "NoChangesAndReady",
 			attrs: &storage.Account{
 				AccountProperties: &storage.AccountProperties{ProvisioningState: storage.Succeeded},
 			},
@@ -827,7 +827,7 @@ func Test_bucketCreateUpdater_update(t *testing.T) {
 			},
 		},
 		{
-			name: "update failed",
+			name: "UpdateFailed",
 			attrs: &storage.Account{
 				AccountProperties: &storage.AccountProperties{ProvisioningState: storage.Succeeded},
 				Location:          to.StringPtr("test-location"),
@@ -851,7 +851,7 @@ func Test_bucketCreateUpdater_update(t *testing.T) {
 			},
 		},
 		{
-			name: "update success",
+			name: "UpdateSuccess",
 			attrs: &storage.Account{
 				AccountProperties: &storage.AccountProperties{ProvisioningState: storage.Succeeded},
 				Location:          to.StringPtr("test-location"),
@@ -922,7 +922,7 @@ func Test_accountSyncBacker_syncback(t *testing.T) {
 		want   want
 	}{
 		{
-			name: "update-failed",
+			name: "UpdateDailed",
 			fields: fields{
 				secretupdater: &MockAccountSecretupdater{},
 				acct:          v1alpha1test.NewMockAccount(ns, name).Account,
@@ -940,7 +940,7 @@ func Test_accountSyncBacker_syncback(t *testing.T) {
 			},
 		},
 		{
-			name: "provision status is not succeeded",
+			name: "ProvisionStatusIsNotSucceeded",
 			fields: fields{
 				acct: v1alpha1test.NewMockAccount(ns, name).Account,
 				kube: test.NewMockClient(),
@@ -956,7 +956,7 @@ func Test_accountSyncBacker_syncback(t *testing.T) {
 			},
 		},
 		{
-			name: "update secret failed",
+			name: "UpdateSecretFailed",
 			fields: fields{
 				secretupdater: &MockAccountSecretupdater{
 					MockUpdateSecret: func(ctx context.Context, a *storage.Account) error {
@@ -977,7 +977,7 @@ func Test_accountSyncBacker_syncback(t *testing.T) {
 			},
 		},
 		{
-			name: "success not ready",
+			name: "SuccessNotReady",
 			fields: fields{
 				secretupdater: &MockAccountSecretupdater{
 					MockUpdateSecret: func(ctx context.Context, a *storage.Account) error { return nil },
@@ -995,7 +995,7 @@ func Test_accountSyncBacker_syncback(t *testing.T) {
 			},
 		},
 		{
-			name: "success and ready",
+			name: "SuccessAndReady",
 			fields: fields{
 				secretupdater: &MockAccountSecretupdater{
 					MockUpdateSecret: func(ctx context.Context, a *storage.Account) error { return nil },
@@ -1055,7 +1055,7 @@ func Test_accountSecretUpdater_updatesecret(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "failed-list-keys",
+			name: "FailedListKeys",
 			fields: fields{
 				ops: &azurestoragefake.MockAccountOperations{
 					MockListKeys: func(ctx context.Context) (keys []storage.AccountKey, e error) {
@@ -1079,7 +1079,7 @@ func Test_accountSecretUpdater_updatesecret(t *testing.T) {
 			wantErr: errors.Wrapf(errors.New("test-list-keys-error"), "failed to list account keys"),
 		},
 		{
-			name: "account-keys-list-empty",
+			name: "AccountKeysListEmpty",
 			fields: fields{
 				ops: &azurestoragefake.MockAccountOperations{
 					MockListKeys: func(ctx context.Context) (keys []storage.AccountKey, e error) {
@@ -1103,7 +1103,7 @@ func Test_accountSecretUpdater_updatesecret(t *testing.T) {
 			wantErr: errors.New("account keys are empty"),
 		},
 		{
-			name: "create-new-secret",
+			name: "CreateNewSecret",
 			fields: fields{
 				ops: &azurestoragefake.MockAccountOperations{
 					MockListKeys: func(ctx context.Context) (keys []storage.AccountKey, e error) {
@@ -1134,7 +1134,7 @@ func Test_accountSecretUpdater_updatesecret(t *testing.T) {
 			},
 		},
 		{
-			name: "create-new-secret-failed",
+			name: "CreateNewSecretFailed",
 			fields: fields{
 				ops: &azurestoragefake.MockAccountOperations{
 					MockListKeys: func(ctx context.Context) (keys []storage.AccountKey, e error) {
@@ -1166,7 +1166,7 @@ func Test_accountSecretUpdater_updatesecret(t *testing.T) {
 			wantErr: errors.Wrapf(errors.New("test-create-secret-error"), "failed to create secret: %s/%s", ns, name),
 		},
 		{
-			name: "update-existing-secret",
+			name: "UpdateExistingSecret",
 			fields: fields{
 				ops: &azurestoragefake.MockAccountOperations{
 					MockListKeys: func(ctx context.Context) (keys []storage.AccountKey, e error) {

--- a/pkg/controller/azure/storage/container/container_test.go
+++ b/pkg/controller/azure/storage/container/container_test.go
@@ -156,7 +156,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		want   want
 	}{
 		{
-			name: "get err not-found",
+			name: "GetErrNotFound",
 			fields: fields{
 				Client: &test.MockClient{
 					MockGet: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
@@ -170,7 +170,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 		},
 		{
-			name: "get err other",
+			name: "GetErrOther",
 			fields: fields{
 				Client: &test.MockClient{
 					MockGet: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
@@ -185,7 +185,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 		},
 		{
-			name: "syncdelete maker error",
+			name: "SyncdeleteMakerError",
 			fields: fields{
 				Client: fake.NewFakeClient(v1alpha1test.NewMockContainer(testNamespace, testContainerName).
 					WithFinalizer("foo.bar").Container),
@@ -204,7 +204,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 		},
 		{
-			name: "delete",
+			name: "Delete",
 			fields: fields{
 				Client: fake.NewFakeClient(v1alpha1test.NewMockContainer(testNamespace, testContainerName).
 					WithDeleteTimestamp(time.Now()).Container),
@@ -223,7 +223,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 		},
 		{
-			name: "sync",
+			name: "Sync",
 			fields: fields{
 				Client: fake.NewFakeClient(v1alpha1test.NewMockContainer(testNamespace, testContainerName).Container),
 				syncdeleterMaker: &mockSyncdeleteMaker{
@@ -300,7 +300,7 @@ func Test_containerSyncdeleterMaker_newSyncdeleter(t *testing.T) {
 		want   want
 	}{
 		{
-			name: "failed to get account - not found, no delete",
+			name: "FailedToGetAccountNotFoundNoDelete",
 			fields: fields{
 				Client: &test.MockClient{
 					MockGet: func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
@@ -318,7 +318,7 @@ func Test_containerSyncdeleterMaker_newSyncdeleter(t *testing.T) {
 			},
 		},
 		{
-			name: "failed to get account - not found, yes delete",
+			name: "FailedToGetAccountNotFoundYesDelete",
 			fields: fields{
 				Client: fake.NewFakeClient(newCont().WithSpecAccountRef(testAccountName).
 					WithFinalizer(finalizer).
@@ -336,7 +336,7 @@ func Test_containerSyncdeleterMaker_newSyncdeleter(t *testing.T) {
 			},
 		},
 		{
-			name: "account reference secret not found",
+			name: "AccountReferenceSecretNotFound",
 			fields: fields{
 				Client: fake.NewFakeClient(
 					v1alpha1test.NewMockAccount(testNamespace, testAccountName).WithStatusConnectionRef(testAccountName).Account,
@@ -353,7 +353,7 @@ func Test_containerSyncdeleterMaker_newSyncdeleter(t *testing.T) {
 			},
 		},
 		{
-			name: "failed to create container handle",
+			name: "FailedToCreateContainerHandle",
 			fields: fields{
 				Client: fake.NewFakeClient(
 					newCont().WithSpecAccountRef(testAccountName).WithFinalizer(finalizer).Container,
@@ -376,7 +376,7 @@ func Test_containerSyncdeleterMaker_newSyncdeleter(t *testing.T) {
 			},
 		},
 		{
-			name: "success",
+			name: "Success",
 			fields: fields{
 				Client: fake.NewFakeClient(
 					newCont().WithSpecAccountRef(testAccountName).WithFinalizer(finalizer).Container,
@@ -460,7 +460,7 @@ func Test_containerSyncdeleter_delete(t *testing.T) {
 		want   want
 	}{
 		{
-			name: "reclaim: retain",
+			name: "ReclaimRetain",
 			fields: fields{
 				kube: test.NewMockClient(),
 				container: v1alpha1test.NewMockContainer(testNamespace, testContainerName).
@@ -476,7 +476,7 @@ func Test_containerSyncdeleter_delete(t *testing.T) {
 			},
 		},
 		{
-			name: "delete error: not found",
+			name: "DeleteErrorNotFound",
 			fields: fields{
 				kube: test.NewMockClient(),
 				ContainerOperations: &azurestoragefake.MockContainerOperations{
@@ -497,7 +497,7 @@ func Test_containerSyncdeleter_delete(t *testing.T) {
 			},
 		},
 		{
-			name: "delete error: other",
+			name: "DeleteErrorOther",
 			fields: fields{
 				kube: test.NewMockClient(),
 				ContainerOperations: &azurestoragefake.MockContainerOperations{
@@ -566,7 +566,7 @@ func Test_containerSyncdeleter_sync(t *testing.T) {
 		want   want
 	}{
 		{
-			name: "get error: not-found",
+			name: "GetErrorNotFound",
 			fields: fields{
 				createupdater: newMockCreateUpdater(),
 				ContainerOperations: &azurestoragefake.MockContainerOperations{
@@ -579,7 +579,7 @@ func Test_containerSyncdeleter_sync(t *testing.T) {
 			want: want{},
 		},
 		{
-			name: "get error: other",
+			name: "GetErrorOther",
 			fields: fields{
 				createupdater: newMockCreateUpdater(),
 				ContainerOperations: &azurestoragefake.MockContainerOperations{
@@ -598,7 +598,7 @@ func Test_containerSyncdeleter_sync(t *testing.T) {
 			},
 		},
 		{
-			name: "create",
+			name: "Create",
 			fields: fields{
 				createupdater: newMockCreateUpdater(),
 				ContainerOperations: &azurestoragefake.MockContainerOperations{
@@ -616,7 +616,7 @@ func Test_containerSyncdeleter_sync(t *testing.T) {
 			},
 		},
 		{
-			name: "update",
+			name: "Update",
 			fields: fields{
 				createupdater: newMockCreateUpdater(),
 				ContainerOperations: &azurestoragefake.MockContainerOperations{
@@ -678,7 +678,7 @@ func Test_containerCreateUpdater_create(t *testing.T) {
 		want   want
 	}{
 		{
-			name: "update finalizer failed",
+			name: "UpdateFinalizerFailed",
 			fields: fields{
 				container: v1alpha1test.NewMockContainer(testNamespace, testContainerName).Container,
 				kube: &test.MockClient{
@@ -695,7 +695,7 @@ func Test_containerCreateUpdater_create(t *testing.T) {
 			},
 		},
 		{
-			name: "create failed",
+			name: "CreateFailed",
 			fields: fields{
 				container: v1alpha1test.NewMockContainer(testNamespace, testContainerName).Container,
 				ContainerOperations: &azurestoragefake.MockContainerOperations{
@@ -714,7 +714,7 @@ func Test_containerCreateUpdater_create(t *testing.T) {
 			},
 		},
 		{
-			name: "create successful, initial status not ready",
+			name: "CreateSuccessfulInitialStatusNotReady",
 			fields: fields{
 				container: v1alpha1test.NewMockContainer(testNamespace, testContainerName).
 					WithFailedCondition(failedToCreate, "test-error").Container,
@@ -733,7 +733,7 @@ func Test_containerCreateUpdater_create(t *testing.T) {
 			},
 		},
 		{
-			name: "create successful",
+			name: "CreateSuccessful",
 			fields: fields{
 				container:           v1alpha1test.NewMockContainer(testNamespace, testContainerName).Container,
 				ContainerOperations: azurestoragefake.NewMockContainerOperations(),
@@ -794,7 +794,7 @@ func Test_containerCreateUpdater_update(t *testing.T) {
 		want   want
 	}{
 		{
-			name: "no change, not ready",
+			name: "NoChangeNotReady",
 			fields: fields{
 				container: v1alpha1test.NewMockContainer(testNamespace, testContainerName).
 					WithSpecPAC(azblob.PublicAccessContainer).Container,
@@ -812,7 +812,7 @@ func Test_containerCreateUpdater_update(t *testing.T) {
 			},
 		},
 		{
-			name: "no change, is ready",
+			name: "NoChangeIsReady",
 			fields: fields{
 				container: v1alpha1test.NewMockContainer(testNamespace, testContainerName).
 					WithSpecPAC(azblob.PublicAccessContainer).
@@ -830,7 +830,7 @@ func Test_containerCreateUpdater_update(t *testing.T) {
 			},
 		},
 		{
-			name: "container update failed",
+			name: "ContainerUpdateFailed",
 			fields: fields{
 				container: v1alpha1test.NewMockContainer(testNamespace, testContainerName).
 					WithSpecPAC(azblob.PublicAccessContainer).
@@ -858,7 +858,7 @@ func Test_containerCreateUpdater_update(t *testing.T) {
 			},
 		},
 		{
-			name: "container update successful",
+			name: "ContainerUpdateSuccessful",
 			fields: fields{
 				container: v1alpha1test.NewMockContainer(testNamespace, testContainerName).
 					WithSpecPAC(azblob.PublicAccessContainer).

--- a/pkg/controller/compute/kubernetes/aws_handler_test.go
+++ b/pkg/controller/compute/kubernetes/aws_handler_test.go
@@ -50,7 +50,7 @@ func TestEKSClusterHandler_Find(t *testing.T) {
 		want want
 	}{
 		{
-			name: "failed",
+			name: "Failed",
 			args: args{
 				name: types.NamespacedName{Namespace: "foo", Name: "bar"},
 				c: &test.MockClient{
@@ -65,7 +65,7 @@ func TestEKSClusterHandler_Find(t *testing.T) {
 			},
 		},
 		{
-			name: "success",
+			name: "Success",
 			args: args{
 				name: types.NamespacedName{Namespace: "foo", Name: "bar"},
 				c:    test.NewMockClient(),
@@ -112,7 +112,7 @@ func TestEKSClusterHandler_Provision(t *testing.T) {
 		want want
 	}{
 		{
-			name: "success",
+			name: "Success",
 			args: args{
 				class: class,
 				claim: claim,
@@ -134,7 +134,7 @@ func TestEKSClusterHandler_Provision(t *testing.T) {
 			},
 		},
 		{
-			name: "failure",
+			name: "Failure",
 			args: args{
 				class: class,
 				claim: claim,
@@ -183,7 +183,7 @@ func TestEKSClusterHandler_SetBindStatus(t *testing.T) {
 		want error
 	}{
 		{
-			name: "failure",
+			name: "Failure",
 			args: args{
 				name: name,
 				c: &test.MockClient{
@@ -195,7 +195,7 @@ func TestEKSClusterHandler_SetBindStatus(t *testing.T) {
 			want: errors.Wrapf(getError, "failed to retrieve cluster %s", name),
 		},
 		{
-			name: "failure - not found, bound",
+			name: "FailureNotFoundBound",
 			args: args{
 				name: name,
 				c: &test.MockClient{
@@ -208,7 +208,7 @@ func TestEKSClusterHandler_SetBindStatus(t *testing.T) {
 			want: errors.Wrapf(getErrorNotFound, "failed to retrieve cluster %s", name),
 		},
 		{
-			name: "failure - not found, not bound",
+			name: "FailureNotFoundNotBound",
 			args: args{
 				name: name,
 				c: &test.MockClient{
@@ -219,7 +219,7 @@ func TestEKSClusterHandler_SetBindStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "failed to update",
+			name: "FailedToUpdate",
 			args: args{
 				name: name,
 				c: &test.MockClient{
@@ -234,7 +234,7 @@ func TestEKSClusterHandler_SetBindStatus(t *testing.T) {
 			want: errors.Wrapf(updateError, "failed to update cluster %s", name),
 		},
 		{
-			name: "successful set bound",
+			name: "SuccessfulSetBound",
 			args: args{
 				name: name,
 				c: &test.MockClient{

--- a/pkg/controller/compute/kubernetes/azure_handler_test.go
+++ b/pkg/controller/compute/kubernetes/azure_handler_test.go
@@ -51,7 +51,7 @@ func TestAKSClusterHandler_Find(t *testing.T) {
 		want want
 	}{
 		{
-			name: "failed",
+			name: "Failed",
 			args: args{
 				name: types.NamespacedName{Namespace: "foo", Name: "bar"},
 				c: &test.MockClient{
@@ -66,7 +66,7 @@ func TestAKSClusterHandler_Find(t *testing.T) {
 			},
 		},
 		{
-			name: "success",
+			name: "Success",
 			args: args{
 				name: types.NamespacedName{Namespace: "foo", Name: "bar"},
 				c:    test.NewMockClient(),
@@ -113,7 +113,7 @@ func TestAKSClusterHandler_Provision(t *testing.T) {
 		want want
 	}{
 		{
-			name: "success",
+			name: "Success",
 			args: args{
 				class: class,
 				claim: claim,
@@ -136,7 +136,7 @@ func TestAKSClusterHandler_Provision(t *testing.T) {
 			},
 		},
 		{
-			name: "failure",
+			name: "Failure",
 			args: args{
 				class: class,
 				claim: claim,
@@ -185,7 +185,7 @@ func TestAKSClusterHandler_SetBindStatus(t *testing.T) {
 		want error
 	}{
 		{
-			name: "failure",
+			name: "Failure",
 			args: args{
 				name: name,
 				c: &test.MockClient{
@@ -197,7 +197,7 @@ func TestAKSClusterHandler_SetBindStatus(t *testing.T) {
 			want: errors.Wrapf(getError, "failed to retrieve cluster %s", name),
 		},
 		{
-			name: "failure - not found, bound",
+			name: "FailureNotFoundBound",
 			args: args{
 				name: name,
 				c: &test.MockClient{
@@ -210,7 +210,7 @@ func TestAKSClusterHandler_SetBindStatus(t *testing.T) {
 			want: errors.Wrapf(getErrorNotFound, "failed to retrieve cluster %s", name),
 		},
 		{
-			name: "failure - not found, not bound",
+			name: "FailureNotFoundNotBound",
 			args: args{
 				name: name,
 				c: &test.MockClient{
@@ -221,7 +221,7 @@ func TestAKSClusterHandler_SetBindStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "failed to update",
+			name: "FailedToUpdate",
 			args: args{
 				name: name,
 				c: &test.MockClient{
@@ -236,7 +236,7 @@ func TestAKSClusterHandler_SetBindStatus(t *testing.T) {
 			want: errors.Wrapf(updateError, "failed to update cluster %s", name),
 		},
 		{
-			name: "successful set bound",
+			name: "SuccessfulSetBound",
 			args: args{
 				name: name,
 				c: &test.MockClient{

--- a/pkg/controller/compute/kubernetes/gcp_handler_test.go
+++ b/pkg/controller/compute/kubernetes/gcp_handler_test.go
@@ -50,7 +50,7 @@ func TestGKEClusterHandler_Find(t *testing.T) {
 		want want
 	}{
 		{
-			name: "failed",
+			name: "Failed",
 			args: args{
 				name: types.NamespacedName{Namespace: "foo", Name: "bar"},
 				c: &test.MockClient{
@@ -65,7 +65,7 @@ func TestGKEClusterHandler_Find(t *testing.T) {
 			},
 		},
 		{
-			name: "success",
+			name: "Success",
 			args: args{
 				name: types.NamespacedName{Namespace: "foo", Name: "bar"},
 				c:    test.NewMockClient(),
@@ -112,7 +112,7 @@ func TestGKEClusterHandler_Provision(t *testing.T) {
 		want want
 	}{
 		{
-			name: "success",
+			name: "Success",
 			args: args{
 				class: class,
 				claim: claim,
@@ -134,7 +134,7 @@ func TestGKEClusterHandler_Provision(t *testing.T) {
 			},
 		},
 		{
-			name: "failure",
+			name: "Failure",
 			args: args{
 				class: class,
 				claim: claim,
@@ -183,7 +183,7 @@ func TestGKEClusterHandler_SetBindStatus(t *testing.T) {
 		want error
 	}{
 		{
-			name: "failure",
+			name: "Failure",
 			args: args{
 				name: name,
 				c: &test.MockClient{
@@ -195,7 +195,7 @@ func TestGKEClusterHandler_SetBindStatus(t *testing.T) {
 			want: errors.Wrapf(getError, "failed to retrieve cluster %s", name),
 		},
 		{
-			name: "failure - not found, bound",
+			name: "FailureNotFoundBound",
 			args: args{
 				name: name,
 				c: &test.MockClient{
@@ -208,7 +208,7 @@ func TestGKEClusterHandler_SetBindStatus(t *testing.T) {
 			want: errors.Wrapf(getErrorNotFound, "failed to retrieve cluster %s", name),
 		},
 		{
-			name: "failure - not found, not bound",
+			name: "FailureNotFoundNotBound",
 			args: args{
 				name: name,
 				c: &test.MockClient{
@@ -219,7 +219,7 @@ func TestGKEClusterHandler_SetBindStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "failed to update",
+			name: "FailedToUpdate",
 			args: args{
 				name: name,
 				c: &test.MockClient{
@@ -234,7 +234,7 @@ func TestGKEClusterHandler_SetBindStatus(t *testing.T) {
 			want: errors.Wrapf(updateError, "failed to update cluster %s", name),
 		},
 		{
-			name: "successful set bound",
+			name: "SuccessfulSetBound",
 			args: args{
 				name: name,
 				c: &test.MockClient{

--- a/pkg/controller/compute/workload/workload_test.go
+++ b/pkg/controller/compute/workload/workload_test.go
@@ -333,10 +333,10 @@ func Test_addWorkloadReferenceLabel(t *testing.T) {
 		name string
 		args args
 	}{
-		{"Nil labels", args{&metav1.ObjectMeta{}, testUID}},
-		{"Empty labels", args{&metav1.ObjectMeta{Labels: make(map[string]string)}, testUID}},
-		{"Label added", args{&metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}}, testUID}},
-		{"Label updated", args{&metav1.ObjectMeta{Labels: map[string]string{workloadReferenceLabelKey: "foo-bar"}}, testUID}},
+		{"NilLabels", args{&metav1.ObjectMeta{}, testUID}},
+		{"EmptyLabels", args{&metav1.ObjectMeta{Labels: make(map[string]string)}, testUID}},
+		{"LabelAdded", args{&metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}}, testUID}},
+		{"LabelUpdated", args{&metav1.ObjectMeta{Labels: map[string]string{workloadReferenceLabelKey: "foo-bar"}}, testUID}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -358,10 +358,10 @@ func Test_getWorkloadReferenceLabel(t *testing.T) {
 		args args
 		want string
 	}{
-		{"Nil labels", args{metav1.ObjectMeta{}}, ""},
-		{"Empty labels", args{metav1.ObjectMeta{Labels: make(map[string]string)}}, ""},
-		{"Label not found", args{metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}}}, ""},
-		{"Label found", args{metav1.ObjectMeta{Labels: map[string]string{workloadReferenceLabelKey: "test-uid"}}}, "test-uid"},
+		{"NilLabels", args{metav1.ObjectMeta{}}, ""},
+		{"EmptyLabels", args{metav1.ObjectMeta{Labels: make(map[string]string)}}, ""},
+		{"LabelNotFound", args{metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}}}, ""},
+		{"LabelFound", args{metav1.ObjectMeta{Labels: map[string]string{workloadReferenceLabelKey: "test-uid"}}}, "test-uid"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controller/gcp/storage/bucket_operations_test.go
+++ b/pkg/controller/gcp/storage/bucket_operations_test.go
@@ -134,7 +134,7 @@ func Test_bucketHandler_addFinalizer(t *testing.T) {
 		want   []string
 	}{
 		{
-			name:   "test",
+			name:   "Test",
 			fields: fields{bucket: &v1alpha1.Bucket{}},
 			want:   []string{finalizer},
 		},
@@ -163,7 +163,7 @@ func Test_bucketHandler_removeFinalizer(t *testing.T) {
 		want   []string
 	}{
 		{
-			name: "test",
+			name: "Test",
 			fields: fields{bucket: &v1alpha1.Bucket{
 				ObjectMeta: metav1.ObjectMeta{Finalizers: []string{finalizer}},
 			}},
@@ -196,12 +196,12 @@ func Test_bucketHandler_isReclaimDelete(t *testing.T) {
 		want   bool
 	}{
 		{
-			name:   "default",
+			name:   "Default",
 			fields: fields{bucket: &v1alpha1.Bucket{}},
 			want:   false,
 		},
 		{
-			name:   "delete",
+			name:   "Delete",
 			fields: fields{bucket: &v1alpha1.Bucket{Spec: v1alpha1.BucketSpec{ReclaimPolicy: corev1alpha1.ReclaimDelete}}},
 			want:   true,
 		},
@@ -231,7 +231,7 @@ func Test_bucketHandler_getSpecAttrs(t *testing.T) {
 		want   v1alpha1.BucketUpdatableAttrs
 	}{
 		{
-			name: "test",
+			name: "Test",
 			fields: fields{bucket: &v1alpha1.Bucket{
 				Spec: v1alpha1.BucketSpec{
 					BucketSpecAttrs: v1alpha1.BucketSpecAttrs{BucketUpdatableAttrs: testBucketSpecAttrs},
@@ -265,7 +265,7 @@ func Test_bucketHandler_setSpecAttrs(t *testing.T) {
 		want   v1alpha1.BucketSpecAttrs
 	}{
 		{
-			name:   "test",
+			name:   "Test",
 			fields: fields{bucket: &v1alpha1.Bucket{}},
 			args:   &storage.BucketAttrs{Location: "foo"},
 			want:   testSpecAttrs,
@@ -296,7 +296,7 @@ func Test_bucketHandler_setStatusAttrs(t *testing.T) {
 		want   v1alpha1.BucketOutputAttrs
 	}{
 		{
-			name:   "test",
+			name:   "Test",
 			fields: fields{bucket: &v1alpha1.Bucket{}},
 			args:   &storage.BucketAttrs{Name: "foo"},
 			want:   v1alpha1.BucketOutputAttrs{Name: "foo"},
@@ -326,7 +326,7 @@ func Test_bucketHandler_setReady(t *testing.T) {
 		want   bool
 	}{
 		{
-			name:   "test",
+			name:   "Test",
 			fields: fields{bucket: &v1alpha1.Bucket{}},
 			want:   true,
 		},
@@ -448,14 +448,14 @@ func Test_bucketHandler_updateSecret(t *testing.T) {
 		want   error
 	}{
 		{
-			name: "without service account secret reference",
+			name: "WithoutServiceAccountSecretReference",
 			fields: fields{
 				Bucket: newBucket(testNamespace, testBucketName).Bucket,
 				kube:   test.NewMockClient(),
 			},
 		},
 		{
-			name: "failure to retrieve secret",
+			name: "FailureToRetrieveSecret",
 			fields: fields{
 				Bucket: newBucket(testNamespace, testBucketName).withServiceAccountSecretRef(saSecretName).Bucket,
 				kube: &test.MockClient{
@@ -468,7 +468,7 @@ func Test_bucketHandler_updateSecret(t *testing.T) {
 				"failed to retrieve storage service account secret: %s/%s", testNamespace, saSecretName),
 		},
 		{
-			name: "failure to update secret",
+			name: "FailureToUpdateSecret",
 			fields: fields{
 				Bucket: newBucket(testNamespace, testBucketName).
 					withServiceAccountSecretRef(saSecretName).
@@ -593,7 +593,7 @@ func Test_bucketHandler_getAttributes(t *testing.T) {
 		want   want
 	}{
 		{
-			name: "test",
+			name: "Test",
 			fields: fields{
 				gcp: &storagefake.MockBucketClient{
 					MockAttrs: func(ctx context.Context) (*storage.BucketAttrs, error) { return nil, nil },

--- a/pkg/controller/gcp/storage/bucket_test.go
+++ b/pkg/controller/gcp/storage/bucket_test.go
@@ -232,13 +232,13 @@ func TestReconciler_Reconcile(t *testing.T) {
 		wantObj *v1alpha1.Bucket
 	}{
 		{
-			name:    "get err-not-found",
+			name:    "GetErrNotFound",
 			fields:  fields{fake.NewFakeClient(), nil},
 			wantRs:  rsDone,
 			wantErr: nil,
 		},
 		{
-			name: "get error other",
+			name: "GetErrorOther",
 			fields: fields{
 				client: &test.MockClient{
 					MockGet: func(context.Context, client.ObjectKey, runtime.Object) error {
@@ -250,7 +250,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			wantErr: errors.New("test-get-error"),
 		},
 		{
-			name: "bucket handler error",
+			name: "BucketHandlerError",
 			fields: fields{
 				client:  fake.NewFakeClient(newBucket(ns, name).withFinalizer("foo.bar").Bucket),
 				factory: newMockBucketFactory(nil, errors.New("handler-factory-error")),
@@ -262,7 +262,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 				withFinalizer("foo.bar").Bucket,
 		},
 		{
-			name: "reconcile delete",
+			name: "ReconcileDelete",
 			fields: fields{
 				client: fake.NewFakeClient(newBucket(ns, name).
 					withDeleteTimestamp(metav1.NewTime(time.Now())).Bucket),
@@ -272,7 +272,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name: "reconcile sync",
+			name: "ReconcileSync",
 			fields: fields{
 				client:  fake.NewFakeClient(newBucket(ns, name).Bucket),
 				factory: newMockBucketFactory(newMockBucketSyncDeleter(), nil),
@@ -338,7 +338,7 @@ func Test_bucketFactory_newHandler(t *testing.T) {
 		want   want
 	}{
 		{
-			name:   "err provider is not found",
+			name:   "ErrProviderIsNotFound",
 			Client: fake.NewFakeClient(),
 			bucket: newBucket(ns, bucketName).withProvider(providerName).Bucket,
 			want: want{
@@ -348,7 +348,7 @@ func Test_bucketFactory_newHandler(t *testing.T) {
 			},
 		},
 		{
-			name: "provider is not ready",
+			name: "ProviderIsNotReady",
 			Client: fake.NewFakeClient(newProvider(ns, providerName).
 				withCondition(corev1alpha1.NewCondition(corev1alpha1.Failed, "", "")).Provider),
 			bucket: newBucket(ns, bucketName).withProvider("test-provider").Bucket,
@@ -357,7 +357,7 @@ func Test_bucketFactory_newHandler(t *testing.T) {
 			},
 		},
 		{
-			name: "provider secret is not found",
+			name: "ProviderSecretIsNotFound",
 			Client: fake.NewFakeClient(newProvider(ns, providerName).
 				withCondition(corev1alpha1.NewCondition(corev1alpha1.Ready, "", "")).
 				withSecret(secretName, secretKey).Provider),
@@ -368,7 +368,7 @@ func Test_bucketFactory_newHandler(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid credentials",
+			name: "InvalidCredentials",
 			Client: fake.NewFakeClient(newProvider(ns, providerName).
 				withCondition(corev1alpha1.NewCondition(corev1alpha1.Ready, "", "")).
 				withSecret(secretName, secretKey).Provider,
@@ -380,7 +380,7 @@ func Test_bucketFactory_newHandler(t *testing.T) {
 			},
 		},
 		{
-			name: "successful",
+			name: "Successful",
 			Client: fake.NewFakeClient(newProvider(ns, providerName).
 				withCondition(corev1alpha1.NewCondition(corev1alpha1.Ready, "", "")).
 				withSecret(secretName, secretKey).Provider,
@@ -426,7 +426,7 @@ func Test_bucketSyncDeleter_delete(t *testing.T) {
 		want   want
 	}{
 		{
-			name: "retain policy",
+			name: "RetainPolicy",
 			fields: fields{
 				ops: &mockOperations{
 					mockIsReclaimDelete: func() bool { return false },
@@ -439,7 +439,7 @@ func Test_bucketSyncDeleter_delete(t *testing.T) {
 			},
 		},
 		{
-			name: "delete successful",
+			name: "DeleteSuccessful",
 			fields: fields{
 				ops: &mockOperations{
 					mockIsReclaimDelete: func() bool { return true },
@@ -454,7 +454,7 @@ func Test_bucketSyncDeleter_delete(t *testing.T) {
 			},
 		},
 		{
-			name: "delete failed: not found",
+			name: "DeleteFailedNotFound",
 			fields: fields{
 				ops: &mockOperations{
 					mockIsReclaimDelete: func() bool { return true },
@@ -471,7 +471,7 @@ func Test_bucketSyncDeleter_delete(t *testing.T) {
 			},
 		},
 		{
-			name: "delete failed: other",
+			name: "DeleteFailedOther",
 			fields: fields{
 				ops: &mockOperations{
 					mockIsReclaimDelete: func() bool { return true },
@@ -525,7 +525,7 @@ func Test_bucketSyncDeleter_sync(t *testing.T) {
 		want   want
 	}{
 		{
-			name: "failed to update connection secret",
+			name: "FailedToUpdateConnectionSecret",
 			fields: fields{
 				ops: &mockOperations{
 					mockUpdateSecret: func(ctx context.Context) error { return secretError },
@@ -538,7 +538,7 @@ func Test_bucketSyncDeleter_sync(t *testing.T) {
 			want: want{res: resultRequeue},
 		},
 		{
-			name: "attrs error: other",
+			name: "AttrsErrorOther",
 			fields: fields{
 				ops: &mockOperations{
 					mockUpdateSecret: func(ctx context.Context) error { return nil },
@@ -554,7 +554,7 @@ func Test_bucketSyncDeleter_sync(t *testing.T) {
 			want: want{res: resultRequeue},
 		},
 		{
-			name: "create bucket",
+			name: "CreateBucket",
 			fields: fields{
 				ops: &mockOperations{
 					mockUpdateSecret: func(ctx context.Context) error { return nil },
@@ -571,7 +571,7 @@ func Test_bucketSyncDeleter_sync(t *testing.T) {
 			want: want{res: reconcile.Result{}},
 		},
 		{
-			name: "update bucket",
+			name: "UpdateBucket",
 			fields: fields{
 				ops: &mockOperations{
 					mockUpdateSecret: func(ctx context.Context) error { return nil },
@@ -626,7 +626,7 @@ func Test_bucketCreateUpdater_create(t *testing.T) {
 		want   want
 	}{
 		{
-			name: "failure to create",
+			name: "FailureToCreate",
 			fields: fields{
 				ops: &mockOperations{
 					mockAddFinalizer: func() {},
@@ -642,7 +642,7 @@ func Test_bucketCreateUpdater_create(t *testing.T) {
 			},
 		},
 		{
-			name: "failure to get attributes",
+			name: "FailureToGetAttributes",
 			fields: fields{
 				ops: &mockOperations{
 					mockAddFinalizer:  func() {},
@@ -660,7 +660,7 @@ func Test_bucketCreateUpdater_create(t *testing.T) {
 			},
 		},
 		{
-			name: "failure to update object",
+			name: "FailureToUpdateObject",
 			fields: fields{
 				ops: &mockOperations{
 					mockAddFinalizer:  func() {},
@@ -677,7 +677,7 @@ func Test_bucketCreateUpdater_create(t *testing.T) {
 			},
 		},
 		{
-			name: "success",
+			name: "Success",
 			fields: fields{
 				ops: &mockOperations{
 					mockAddFinalizer:   func() {},
@@ -733,7 +733,7 @@ func Test_bucketCreateUpdater_update(t *testing.T) {
 		want   want
 	}{
 		{
-			name: "no changes",
+			name: "NoChanges",
 			fields: fields{
 				ops: &mockOperations{
 					mockGetSpecAttrs: func() v1alpha1.BucketUpdatableAttrs {
@@ -746,7 +746,7 @@ func Test_bucketCreateUpdater_update(t *testing.T) {
 			want: want{res: requeueOnSuccess},
 		},
 		{
-			name: "failure to update bucket",
+			name: "FailureToUpdateBucket",
 			fields: fields{
 				ops: &mockOperations{
 					mockGetSpecAttrs: func() v1alpha1.BucketUpdatableAttrs {
@@ -766,7 +766,7 @@ func Test_bucketCreateUpdater_update(t *testing.T) {
 			want: want{res: resultRequeue},
 		},
 		{
-			name: "failure to update object",
+			name: "FailureToUpdateObject",
 			fields: fields{
 				ops: &mockOperations{
 					mockGetSpecAttrs: func() v1alpha1.BucketUpdatableAttrs {
@@ -787,7 +787,7 @@ func Test_bucketCreateUpdater_update(t *testing.T) {
 			},
 		},
 		{
-			name: "successful",
+			name: "Successful",
 			fields: fields{
 				ops: &mockOperations{
 					mockGetSpecAttrs: func() v1alpha1.BucketUpdatableAttrs {

--- a/pkg/controller/storage/bucket/azure_handler_test.go
+++ b/pkg/controller/storage/bucket/azure_handler_test.go
@@ -74,7 +74,7 @@ func TestAzureAccountHandler_Find(t *testing.T) {
 		want want
 	}{
 		{
-			name: "failed",
+			name: "Failed",
 			args: args{
 				n: types.NamespacedName{Namespace: testNS, Name: testName},
 				c: fake.NewFakeClient(),
@@ -85,7 +85,7 @@ func TestAzureAccountHandler_Find(t *testing.T) {
 			},
 		},
 		{
-			name: "successful",
+			name: "Successful",
 			args: args{
 				n: types.NamespacedName{Namespace: testNS, Name: testName},
 				c: test.NewMockClient(),
@@ -126,7 +126,7 @@ func TestAzureAccountHandler_Provision(t *testing.T) {
 		want     want
 	}{
 		{
-			name: "failed values resolver",
+			name: "FailedValuesResolver",
 			args: args{
 				class: &corev1alpha1.ResourceClass{},
 				claim: &storagev1alpha1.Bucket{},
@@ -142,7 +142,7 @@ func TestAzureAccountHandler_Provision(t *testing.T) {
 			},
 		},
 		{
-			name: "failed to create",
+			name: "FailedToCreate",
 			args: args{
 				class: &corev1alpha1.ResourceClass{
 					ObjectMeta: metav1.ObjectMeta{Namespace: testNS},
@@ -166,7 +166,7 @@ func TestAzureAccountHandler_Provision(t *testing.T) {
 			},
 		},
 		{
-			name: "successful",
+			name: "Successful",
 			args: args{
 				class: &corev1alpha1.ResourceClass{
 					ObjectMeta: metav1.ObjectMeta{Namespace: testNS},
@@ -234,7 +234,7 @@ func TestAzureContainerHandler_Find(t *testing.T) {
 		want want
 	}{
 		{
-			name: "failed",
+			name: "Failed",
 			args: args{
 				n: types.NamespacedName{Namespace: testNS, Name: testName},
 				c: fake.NewFakeClient(),
@@ -245,7 +245,7 @@ func TestAzureContainerHandler_Find(t *testing.T) {
 			},
 		},
 		{
-			name: "successful",
+			name: "Successful",
 			args: args{
 				n: types.NamespacedName{Namespace: testNS, Name: testName},
 				c: test.NewMockClient(),
@@ -285,7 +285,7 @@ func TestAzureContainerHandler_Provision(t *testing.T) {
 		want want
 	}{
 		{
-			name: "failed to retrieve account",
+			name: "FailedToRetrieveAccount",
 			args: args{
 				class: &corev1alpha1.ResourceClass{
 					ObjectMeta:  metav1.ObjectMeta{Namespace: testNS},
@@ -304,7 +304,7 @@ func TestAzureContainerHandler_Provision(t *testing.T) {
 			},
 		},
 		{
-			name: "failed: not a bucket claim",
+			name: "FailedNotABucketClaim",
 			args: args{
 				class: &corev1alpha1.ResourceClass{
 					ObjectMeta:  metav1.ObjectMeta{Namespace: testNS},
@@ -318,7 +318,7 @@ func TestAzureContainerHandler_Provision(t *testing.T) {
 			},
 		},
 		{
-			name: "failed to update bucket",
+			name: "FailedToUpdateBucket",
 			args: args{
 				class: &corev1alpha1.ResourceClass{
 					ObjectMeta:  metav1.ObjectMeta{Namespace: testNS},
@@ -340,7 +340,7 @@ func TestAzureContainerHandler_Provision(t *testing.T) {
 			},
 		},
 		{
-			name: "failed to create container",
+			name: "FailedToCreateContainer",
 			args: args{
 				class: &corev1alpha1.ResourceClass{
 					ObjectMeta:  metav1.ObjectMeta{Namespace: testNS},
@@ -365,7 +365,7 @@ func TestAzureContainerHandler_Provision(t *testing.T) {
 			},
 		},
 		{
-			name: "successful",
+			name: "Successful",
 			args: args{
 				class: &corev1alpha1.ResourceClass{
 					ObjectMeta:  metav1.ObjectMeta{Namespace: testNS, Name: testName},
@@ -427,7 +427,7 @@ func TestAzureAccountHandler_SetBindStatus(t *testing.T) {
 		want want
 	}{
 		{
-			name: "failed to get account",
+			name: "FailedToGetAccount",
 			args: args{
 				n: nn,
 				c: &test.MockClient{
@@ -443,7 +443,7 @@ func TestAzureAccountHandler_SetBindStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "failed to get account: not found and not bound",
+			name: "FailedToGetAccountNotFoundAndNotBound",
 			args: args{
 				n:     nn,
 				c:     fake.NewFakeClient(),
@@ -452,7 +452,7 @@ func TestAzureAccountHandler_SetBindStatus(t *testing.T) {
 			want: want{},
 		},
 		{
-			name: "failed to get account: not found and bound",
+			name: "FailedToGetAccountNotFoundAndBound",
 			args: args{
 				n:     nn,
 				c:     fake.NewFakeClient(),
@@ -464,7 +464,7 @@ func TestAzureAccountHandler_SetBindStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "failed to update account",
+			name: "FailedToUpdateAccount",
 			args: args{
 				n: nn,
 				c: &test.MockClient{
@@ -483,7 +483,7 @@ func TestAzureAccountHandler_SetBindStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "success",
+			name: "Success",
 			args: args{
 				n:     nn,
 				c:     fake.NewFakeClient(v1alpha1test.NewMockAccount(testNS, testName).Account),
@@ -531,7 +531,7 @@ func TestAzureContainerHandler_SetBindStatus(t *testing.T) {
 		want want
 	}{
 		{
-			name: "failed to get container",
+			name: "FailedToGetContainer",
 			args: args{
 				n: nn,
 				c: &test.MockClient{
@@ -547,7 +547,7 @@ func TestAzureContainerHandler_SetBindStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "failed to get container: not found and not bound",
+			name: "FailedToGetContainerNotFoundAndNotBound",
 			args: args{
 				n:     nn,
 				c:     fake.NewFakeClient(),
@@ -556,7 +556,7 @@ func TestAzureContainerHandler_SetBindStatus(t *testing.T) {
 			want: want{},
 		},
 		{
-			name: "failed to get container: not found and bound",
+			name: "FailedToGetContainerNotFoundAndBound",
 			args: args{
 				n:     nn,
 				c:     fake.NewFakeClient(),
@@ -568,7 +568,7 @@ func TestAzureContainerHandler_SetBindStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "failed to update container",
+			name: "FailedToUpdateContainer",
 			args: args{
 				n: nn,
 				c: &test.MockClient{
@@ -587,7 +587,7 @@ func TestAzureContainerHandler_SetBindStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "success",
+			name: "Success",
 			args: args{
 				n:     nn,
 				c:     fake.NewFakeClient(v1alpha1test.NewMockContainer(testNS, testName).Container),
@@ -634,21 +634,21 @@ func Test_azureAccountResolver_resolve(t *testing.T) {
 		want want
 	}{
 		{
-			name: "failed - not a bucket",
+			name: "FailedNotABucket",
 			args: args{
 				claim: &storagev1alpha1.MySQLInstance{},
 			},
 			want: want{err: errors.New("unexpected claim type: *v1alpha1.MySQLInstance")},
 		},
 		{
-			name: "invalid spec: missing name",
+			name: "InvalidSpecMissingName",
 			args: args{
 				claim: &storagev1alpha1.Bucket{},
 			},
 			want: want{err: errors.New("invalid account claim:  spec, name property is required")},
 		},
 		{
-			name: "successful",
+			name: "Successful",
 			args: args{
 				account: v1alpha1test.NewMockAccount(testNS, testName).Account,
 				claim:   buckettest.NewBucket(testNS, testName).WithSpecName("account-name").Bucket,

--- a/pkg/controller/storage/bucket/gcp_handler_test.go
+++ b/pkg/controller/storage/bucket/gcp_handler_test.go
@@ -70,7 +70,7 @@ func TestGCSBucketHandler_Find(t *testing.T) {
 		want want
 	}{
 		{
-			name: "error retrieving",
+			name: "ErrorRetrieving",
 			args: args{
 				n: nn,
 				c: &test.MockClient{
@@ -85,7 +85,7 @@ func TestGCSBucketHandler_Find(t *testing.T) {
 			},
 		},
 		{
-			name: "success",
+			name: "Success",
 			args: args{
 				n: nn,
 				c: fake.NewFakeClient(&v1alpha1.Bucket{ObjectMeta: meta}),
@@ -136,7 +136,7 @@ func TestGCSBucketHandler_Provision(t *testing.T) {
 		want want
 	}{
 		{
-			name: "create successful",
+			name: "CreateSuccessful",
 			args: args{
 				class: class,
 				claim: claim,
@@ -189,7 +189,7 @@ func TestGCSBucketHandler_SetBindStatus(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "get error: not found and not bound",
+			name: "GetErrorNotFoundAndNotBound",
 			args: args{
 				n:     nn,
 				c:     fake.NewFakeClient(),
@@ -197,7 +197,7 @@ func TestGCSBucketHandler_SetBindStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "get error: not found and bound",
+			name: "GetErrorNotFoundAndBound",
 			args: args{
 				n:     nn,
 				c:     fake.NewFakeClient(),
@@ -207,7 +207,7 @@ func TestGCSBucketHandler_SetBindStatus(t *testing.T) {
 				"cannot get bucket default/testBucket"),
 		},
 		{
-			name: "update error",
+			name: "UpdateError",
 			args: args{
 				n: nn,
 				c: &test.MockClient{

--- a/pkg/util/googleapi/googleapi_test.go
+++ b/pkg/util/googleapi/googleapi_test.go
@@ -31,8 +31,8 @@ func TestIsErrorNotFound(t *testing.T) {
 		args error
 		want bool
 	}{
-		{name: "nil", args: nil, want: false},
-		{name: "other", args: errors.New("foo"), want: false},
+		{name: "Nil", args: nil, want: false},
+		{name: "Other", args: errors.New("foo"), want: false},
 		{name: "404", args: &googleapi.Error{Code: http.StatusNotFound}, want: true},
 	}
 	for _, tt := range tests {

--- a/pkg/util/references_test.go
+++ b/pkg/util/references_test.go
@@ -35,17 +35,17 @@ func TestAddOwnerReference(t *testing.T) {
 		want *metav1.ObjectMeta
 	}{
 		{
-			name: "meta is nil",
+			name: "MetaIsNil",
 			args: args{om: nil, or: metav1.OwnerReference{Name: "foo"}},
 			want: nil,
 		},
 		{
-			name: "meta.or is nil",
+			name: "MetaOrIsNil",
 			args: args{om: &metav1.ObjectMeta{}, or: metav1.OwnerReference{Name: "foo"}},
 			want: &metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{Name: "foo"}}},
 		},
 		{
-			name: "no dupes",
+			name: "NoDupes",
 			args: args{
 				om: &metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{Name: "bar"}}},
 				or: metav1.OwnerReference{Name: "foo"},
@@ -56,7 +56,7 @@ func TestAddOwnerReference(t *testing.T) {
 			}},
 		},
 		{
-			name: "dupes",
+			name: "Dupes",
 			args: args{
 				om: &metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{
 					{Name: "foo"},

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -48,10 +48,10 @@ func TestParseMap(t *testing.T) {
 		args string
 		want map[string]string
 	}{
-		{name: "empty", args: "", want: map[string]string{}},
-		{name: "single", args: "foo:bar", want: map[string]string{"foo": "bar"}},
-		{name: "multi", args: "foo:bar, one:two", want: map[string]string{"foo": "bar", "one": "two"}},
-		{name: "dupe key", args: "foo:bar,foo:buz", want: map[string]string{"foo": "buz"}},
+		{name: "Empty", args: "", want: map[string]string{}},
+		{name: "Single", args: "foo:bar", want: map[string]string{"foo": "bar"}},
+		{name: "Multi", args: "foo:bar, one:two", want: map[string]string{"foo": "bar", "one": "two"}},
+		{name: "DupeKey", args: "foo:bar,foo:buz", want: map[string]string{"foo": "buz"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -69,11 +69,11 @@ func TestParseBool(t *testing.T) {
 		args string
 		want bool
 	}{
-		{name: "empty", args: "", want: false},
-		{name: "true", args: "true", want: true},
-		{name: "True", args: "True", want: true},
-		{name: "tRue", args: "tRue", want: false},
-		{name: "_true", args: " true", want: false},
+		{name: "Empty", args: "", want: false},
+		{name: "LowerTrue", args: "true", want: true},
+		{name: "UpperTrue", args: "True", want: true},
+		{name: "UpperRTrue", args: "tRue", want: false},
+		{name: "SpaceTrue", args: " true", want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -96,7 +96,7 @@ func TestConditionalStringFormat(t *testing.T) {
 		want string
 	}{
 		{
-			name: "no name format",
+			name: "NoNameFormat",
 			args: args{
 				format: "",
 				value:  "test-value",
@@ -104,7 +104,7 @@ func TestConditionalStringFormat(t *testing.T) {
 			want: "test-value",
 		},
 		{
-			name: "format string only",
+			name: "FormatStringOnly",
 			args: args{
 				format: "%s",
 				value:  "test-value",
@@ -112,7 +112,7 @@ func TestConditionalStringFormat(t *testing.T) {
 			want: "test-value",
 		},
 		{
-			name: "format string at the beginning",
+			name: "FormatStringAtTheBeginning",
 			args: args{
 				format: "%s-foo",
 				value:  "test-value",
@@ -120,7 +120,7 @@ func TestConditionalStringFormat(t *testing.T) {
 			want: "test-value-foo",
 		},
 		{
-			name: "format string at the end",
+			name: "FormatStringAtTheEnd",
 			args: args{
 				format: "foo-%s",
 				value:  "test-value",
@@ -128,7 +128,7 @@ func TestConditionalStringFormat(t *testing.T) {
 			want: "foo-test-value",
 		},
 		{
-			name: "format string in the middle",
+			name: "FormatStringInTheMiddle",
 			args: args{
 				format: "foo-%s-bar",
 				value:  "test-value",
@@ -136,7 +136,7 @@ func TestConditionalStringFormat(t *testing.T) {
 			want: "foo-test-value-bar",
 		},
 		{
-			name: "constant string",
+			name: "ConstantString",
 			args: args{
 				format: "foo-bar",
 				value:  "test-value",
@@ -144,7 +144,7 @@ func TestConditionalStringFormat(t *testing.T) {
 			want: "foo-bar",
 		},
 		{
-			name: "invalid: multiple substitutions",
+			name: "InvalidMultipleSubstitutions",
 			args: args{
 				format: "foo-%s-bar-%s",
 				value:  "test-value",
@@ -172,9 +172,9 @@ func TestSplit(t *testing.T) {
 		args args
 		want []string
 	}{
-		{name: "empty", args: args{s: "", sep: ","}, want: []string{}},
-		{name: "comma", args: args{s: ",", sep: ","}, want: []string{}},
-		{name: "values", args: args{s: " a,,b ", sep: ","}, want: []string{"a", "b"}},
+		{name: "Empty", args: args{s: "", sep: ","}, want: []string{}},
+		{name: "Comma", args: args{s: ",", sep: ","}, want: []string{}},
+		{name: "Values", args: args{s: " a,,b ", sep: ","}, want: []string{"a", "b"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -203,7 +203,7 @@ func TestApply(t *testing.T) {
 		want error
 	}{
 		{
-			name: "create failed: other",
+			name: "CreateFailedOther",
 			args: args{
 				kube: &test.MockClient{
 					MockCreate: func(ctx context.Context, obj runtime.Object) error {
@@ -214,7 +214,7 @@ func TestApply(t *testing.T) {
 			want: testError,
 		},
 		{
-			name: "create failed: already exists",
+			name: "CreateFailedAlreadyExists",
 			args: args{
 				kube: &test.MockClient{
 					MockCreate: func(ctx context.Context, obj runtime.Object) error {


### PR DESCRIPTION
In order to have a consistent naming convention for table based tests throughout the codebase, all test names have converged to CamelCase

Signed-off-by: HashedDan <georgedanielmangum@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #412 

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [x] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [x] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [x] RBAC permissions in `clusterrole.yaml` have been updated to include new types, if necessary
- [x] All related commits have been squashed to improve readability.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
