### PR TITLE
GKE Update

### DIFF
--- a/cluster/charts/crossplane/crds/gcp/compute/v1alpha1/gkecluster.yaml
+++ b/cluster/charts/crossplane/crds/gcp/compute/v1alpha1/gkecluster.yaml
@@ -22,7 +22,7 @@ spec:
   - JSONPath: .spec.classRef.name
     name: CLUSTER-CLASS
     type: string
-  - JSONPath: .spec.location
+  - JSONPath: .spec.zone
     name: LOCATION
     type: string
   - JSONPath: .spec.reclaimPolicy

--- a/pkg/apis/gcp/compute/v1alpha1/types.go
+++ b/pkg/apis/gcp/compute/v1alpha1/types.go
@@ -117,7 +117,7 @@ type GKEClusterStatus struct {
 // +kubebuilder:printcolumn:name="CLUSTER-NAME",type="string",JSONPath=".status.clusterName"
 // +kubebuilder:printcolumn:name="ENDPOINT",type="string",JSONPath=".status.endpoint"
 // +kubebuilder:printcolumn:name="CLUSTER-CLASS",type="string",JSONPath=".spec.classRef.name"
-// +kubebuilder:printcolumn:name="LOCATION",type="string",JSONPath=".spec.location"
+// +kubebuilder:printcolumn:name="LOCATION",type="string",JSONPath=".spec.zone"
 // +kubebuilder:printcolumn:name="RECLAIM-POLICY",type="string",JSONPath=".spec.reclaimPolicy"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 type GKECluster struct {
@@ -148,6 +148,7 @@ func ParseClusterSpec(properties map[string]string) *GKEClusterSpec {
 	}
 
 	spec.EnableIPAlias = util.ParseBool(properties["enableIPAlias"])
+	spec.Labels = util.ParseMap(properties["labels"])
 	spec.MachineType = properties["machineType"]
 	spec.NumNodes = parseNodesNumber(properties["numNodes"])
 	spec.Scopes = util.Split(properties["scopes"], ",")

--- a/pkg/apis/gcp/compute/v1alpha1/types_test.go
+++ b/pkg/apis/gcp/compute/v1alpha1/types_test.go
@@ -106,6 +106,7 @@ func TestParseClusterSpec(t *testing.T) {
 			want: &GKEClusterSpec{
 				ReclaimPolicy: DefaultReclaimPolicy,
 				EnableIPAlias: true,
+				Labels:        map[string]string{},
 				MachineType:   "test-machine",
 				NumNodes:      3,
 				Scopes:        []string{"foo", "bar"},
@@ -123,6 +124,7 @@ func TestParseClusterSpec(t *testing.T) {
 			},
 			want: &GKEClusterSpec{
 				ReclaimPolicy: DefaultReclaimPolicy,
+				Labels:        map[string]string{},
 				EnableIPAlias: false,
 				MachineType:   "test-machine",
 				NumNodes:      1,
@@ -139,6 +141,7 @@ func TestParseClusterSpec(t *testing.T) {
 			want: &GKEClusterSpec{
 				ReclaimPolicy: DefaultReclaimPolicy,
 				EnableIPAlias: false,
+				Labels:        map[string]string{},
 				MachineType:   "test-machine",
 				NumNodes:      1,
 				Scopes:        []string{},

--- a/pkg/clients/gcp/gke/gke.go
+++ b/pkg/clients/gcp/gke/gke.go
@@ -76,8 +76,8 @@ func (c *ClusterClient) CreateCluster(name string, spec computev1alpha1.GKEClust
 			MachineType: spec.MachineType,
 			OauthScopes: spec.Scopes,
 		},
-
-		Zone: zone,
+		ResourceLabels: spec.Labels,
+		Zone:           zone,
 	}
 
 	cr := &container.CreateClusterRequest{

--- a/pkg/controller/gcp/compute/gke_test.go
+++ b/pkg/controller/gcp/compute/gke_test.go
@@ -65,7 +65,7 @@ var (
 )
 
 func init() {
-	gcp.AddToScheme(scheme.Scheme)
+	_ = gcp.AddToScheme(scheme.Scheme)
 }
 
 func testCluster() *GKECluster {
@@ -143,7 +143,7 @@ func TestSyncClusterNotReady(t *testing.T) {
 	expectedStatus := corev1alpha1.ConditionedStatus{}
 
 	rs, err := r._sync(tc, cl)
-	g.Expect(rs).To(Equal(resultRequeue))
+	g.Expect(rs).To(Equal(reconcile.Result{RequeueAfter: requeueOnWait}))
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(called).To(BeTrue())
 	assertResource(g, r, expectedStatus)
@@ -218,7 +218,7 @@ func TestSync(t *testing.T) {
 	expectedStatus.SetReady()
 
 	rs, err := r._sync(tc, cl)
-	g.Expect(rs).To(Equal(result))
+	g.Expect(rs).To(Equal(reconcile.Result{RequeueAfter: requeueOnSucces}))
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(called).To(BeTrue())
 	assertResource(g, r, expectedStatus)
@@ -431,10 +431,6 @@ func TestReconcileCreate(t *testing.T) {
 	g.Expect(rs).To(Equal(resultRequeue))
 	g.Expect(err).To(BeNil())
 	g.Expect(called).To(BeTrue())
-
-	rc := assertResource(g, r, corev1alpha1.ConditionedStatus{})
-	g.Expect(rc.Finalizers).To(HaveLen(1))
-	g.Expect(rc.Finalizers).To(ContainElement(finalizer))
 }
 
 func TestReconcileSync(t *testing.T) {


### PR DESCRIPTION
While GKE is in need of a more comprehensive update, this PR attempts to alleviate specific pain-points:

- Apply "new design paradigm" `reconcileAfter`                                                       
- Fix Location column name                                                                           
- Add Resource Labels support (client/controller)           


Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [ ] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [ ] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [ ] RBAC permissions in `clusterrole.yaml` have been updated to include new types, if necessary
- [ ] All related commits have been squashed to improve readability.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)