### PR TITLE
Add test coverage for apis scaffolding components

### DIFF
--- a/pkg/apis/aws/aws_test.go
+++ b/pkg/apis/aws/aws_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package aws contains Kubernetes API groups for AWS cloud provider.
+package aws
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	cache "github.com/crossplaneio/crossplane/pkg/apis/aws/cache/v1alpha1"
+	compute "github.com/crossplaneio/crossplane/pkg/apis/aws/compute/v1alpha1"
+	database "github.com/crossplaneio/crossplane/pkg/apis/aws/database/v1alpha1"
+	storage "github.com/crossplaneio/crossplane/pkg/apis/aws/storage/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/apis/aws/v1alpha1"
+)
+
+func TestAddToScheme(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := AddToScheme(s); err != nil {
+		t.Errorf("AddToScheme() error = %v", err)
+	}
+	gvs := []schema.GroupVersion{
+		v1alpha1.SchemeGroupVersion,
+		cache.SchemeGroupVersion,
+		compute.SchemeGroupVersion,
+		database.SchemeGroupVersion,
+		storage.SchemeGroupVersion,
+	}
+	for _, gv := range gvs {
+		if !s.IsVersionRegistered(gv) {
+			t.Errorf("AddToScheme() %v should be registered", gv)
+		}
+	}
+}

--- a/pkg/apis/azure/azure_test.go
+++ b/pkg/apis/azure/azure_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package azure contains Kubernetes API groups for Azure cloud provider.
+package azure
+
+import (
+	"testing"
+
+	cache "github.com/crossplaneio/crossplane/pkg/apis/azure/cache/v1alpha1"
+	compute "github.com/crossplaneio/crossplane/pkg/apis/azure/compute/v1alpha1"
+	database "github.com/crossplaneio/crossplane/pkg/apis/azure/database/v1alpha1"
+	storage "github.com/crossplaneio/crossplane/pkg/apis/azure/storage/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/apis/azure/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestAddToScheme(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := AddToScheme(s); err != nil {
+		t.Errorf("AddToScheme() error = %v", err)
+	}
+	gvs := []schema.GroupVersion{
+		v1alpha1.SchemeGroupVersion,
+		cache.SchemeGroupVersion,
+		compute.SchemeGroupVersion,
+		database.SchemeGroupVersion,
+		storage.SchemeGroupVersion,
+	}
+	for _, gv := range gvs {
+		if !s.IsVersionRegistered(gv) {
+			t.Errorf("AddToScheme() %v should be registered", gv)
+		}
+	}
+}

--- a/pkg/apis/cache/cache_test.go
+++ b/pkg/apis/cache/cache_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cache contains cache API versions
+package cache
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/crossplaneio/crossplane/pkg/apis/cache/v1alpha1"
+)
+
+func TestAddToScheme(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := AddToScheme(s); err != nil {
+		t.Errorf("AddToScheme() error = %v", err)
+	}
+	gvs := []schema.GroupVersion{
+		v1alpha1.SchemeGroupVersion,
+	}
+	for _, gv := range gvs {
+		if !s.IsVersionRegistered(gv) {
+			t.Errorf("AddToScheme() %v should be registered", gv)
+		}
+	}
+}

--- a/pkg/apis/compute/compute_test.go
+++ b/pkg/apis/compute/compute_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package compute contains Kubernetes API groups for cloud compute resources.
+package compute
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/crossplaneio/crossplane/pkg/apis/compute/v1alpha1"
+)
+
+func TestAddToScheme(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := AddToScheme(s); err != nil {
+		t.Errorf("AddToScheme() error = %v", err)
+	}
+	gvs := []schema.GroupVersion{
+		v1alpha1.SchemeGroupVersion,
+	}
+	for _, gv := range gvs {
+		if !s.IsVersionRegistered(gv) {
+			t.Errorf("AddToScheme() %v should be registered", gv)
+		}
+	}
+}

--- a/pkg/apis/core/core_test.go
+++ b/pkg/apis/core/core_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package core contains Kubernetes API groups for AWS cloud provider.
+package core
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
+)
+
+func TestAddToScheme(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := AddToScheme(s); err != nil {
+		t.Errorf("AddToScheme() error = %v", err)
+	}
+	gvs := []schema.GroupVersion{
+		v1alpha1.SchemeGroupVersion,
+	}
+	for _, gv := range gvs {
+		if !s.IsVersionRegistered(gv) {
+			t.Errorf("AddToScheme() %v should be registered", gv)
+		}
+	}
+}

--- a/pkg/apis/gcp/gcp_test.go
+++ b/pkg/apis/gcp/gcp_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package gcp contains Kubernetes API for GCP cloud provider.
+package gcp
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	cache "github.com/crossplaneio/crossplane/pkg/apis/gcp/cache/v1alpha1"
+	compute "github.com/crossplaneio/crossplane/pkg/apis/gcp/compute/v1alpha1"
+	database "github.com/crossplaneio/crossplane/pkg/apis/gcp/database/v1alpha1"
+	storage "github.com/crossplaneio/crossplane/pkg/apis/gcp/storage/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/apis/gcp/v1alpha1"
+)
+
+func TestAddToScheme(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := AddToScheme(s); err != nil {
+		t.Errorf("AddToScheme() error = %v", err)
+	}
+	gvs := []schema.GroupVersion{
+		v1alpha1.SchemeGroupVersion,
+		cache.SchemeGroupVersion,
+		compute.SchemeGroupVersion,
+		database.SchemeGroupVersion,
+		storage.SchemeGroupVersion,
+	}
+	for _, gv := range gvs {
+		if !s.IsVersionRegistered(gv) {
+			t.Errorf("AddToScheme() %v should be registered", gv)
+		}
+	}
+}

--- a/pkg/apis/storage/storage_test.go
+++ b/pkg/apis/storage/storage_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package storage contains Kubernetes API groups for cloud provider storage.
+package storage
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/crossplaneio/crossplane/pkg/apis/storage/v1alpha1"
+)
+
+func TestAddToScheme(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := AddToScheme(s); err != nil {
+		t.Errorf("AddToScheme() error = %v", err)
+	}
+	gvs := []schema.GroupVersion{
+		v1alpha1.SchemeGroupVersion,
+	}
+	for _, gv := range gvs {
+		if !s.IsVersionRegistered(gv) {
+			t.Errorf("AddToScheme() %v should be registered", gv)
+		}
+	}
+}

--- a/pkg/apis/workload/workload_test.go
+++ b/pkg/apis/workload/workload_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package workload contains Kubernetes API groups for cloud workload resources.
+package workload
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/crossplaneio/crossplane/pkg/apis/workload/v1alpha1"
+)
+
+func TestAddToScheme(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := AddToScheme(s); err != nil {
+		t.Errorf("AddToScheme() error = %v", err)
+	}
+	gvs := []schema.GroupVersion{
+		v1alpha1.SchemeGroupVersion,
+	}
+	for _, gv := range gvs {
+		if !s.IsVersionRegistered(gv) {
+			t.Errorf("AddToScheme() %v should be registered", gv)
+		}
+	}
+}


### PR DESCRIPTION
After spending several hours trying to figure out how to exclude specific `go` files in a way that it not too granular nor excludes (erroneously) files that should not be excluded, I decided to take another look at the specific issue brought up by @negz in #399. Specifically, this issue deals with the code coverage of files that we deem should not have any coverage. However, to avoid the failing `sonar` PR checks, we decided to drop the overall coverage requirements %-age on all new code to 55%. 

I took another look a that PR #399, more specifically at the offending file: [`workload.go`](https://sonarcloud.io/component_measures?id=crossplaneio_crossplane&metric=new_coverage&pullRequest=399&view=list)
![image](https://user-images.githubusercontent.com/324803/56855105-095f6100-68f6-11e9-8eda-c12ebbc68131.png)

After the slack conversation w/ @negz we "reached" the tentative agreement that files under `pkg/apis` that don't have "ant real functional code", should not be included in the coverage, thus should not drive the overall PR coverage `%-age` down. However, after taking another look, I don't think I agree with that approach. I remember tripping specifically over this issue in my other PR's, but first the details:

Workload.go is a tiny file at the operator group level with the main purpose to register schema types for a given operator group:
```go
package workload

import (
	"k8s.io/apimachinery/pkg/runtime"

	"github.com/crossplaneio/crossplane/pkg/apis/workload/v1alpha1"
)

func init() {
	// Register the types with the Scheme so the resources can map objects to GroupVersionKinds and back
	AddToSchemes = append(AddToSchemes, v1alpha1.SchemeBuilder.AddToScheme)
}

// AddToSchemes may be used to add all resources defined in the project to a Scheme
var AddToSchemes runtime.SchemeBuilder

// AddToScheme adds all Resources to the Scheme
func AddToScheme(s *runtime.Scheme) error {
	return AddToSchemes.AddToScheme(s)
}
```

Since the `workload` group does not contain any subgroups, all types are located in `workload/v1alpha1`, hence the very one-liner `init()` and one-liner `AddToScheme(...)` function.
One can claim that neither of those functions has "real functionality" that should be covered by a unit-test.  And while at first glance it makes sense, let's take a look at what would happen if we didn't have `init()` function, or if `init()` function did not register `v1alpha1` types. The project would build successfully. The project tests even would pass successfully. However, at runtime when we would try to reconcile the `Workload` type we most likely get an error: "no kind is registered for the type ..."! 

While `workload.go` is a simple case, we do have "more involved" type groups/sub-groups:
```go
//...
func init() {
	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
	AddToSchemes = append(AddToSchemes,
		cache.SchemeBuilder.AddToScheme,
		compute.SchemeBuilder.AddToScheme,
		database.SchemeBuilder.AddToScheme,
		awsv1alpha1.SchemeBuilder.AddToScheme,
		storage.SchemeBuilder.AddToScheme,
	)
}

// AddToSchemes may be used to add all resources defined in the project to a Scheme
var AddToSchemes runtime.SchemeBuilder

// AddToScheme adds all Resources to the Scheme
func AddToScheme(s *runtime.Scheme) error {
	return AddToSchemes.AddToScheme(s)
}
```

While I agree that `wokload.go` and similar are mostly "scaffolding" code, nevertheless, it has simple, yet important functionality, which should be tested. The test for this type of functions is equally simple and uninvolved: 
- call `AddToScheme`
- assert that all schema GroupVersions are registered

`aws_test.go`
```
//...
func TestAddToScheme(t *testing.T) {
	s := runtime.NewScheme()
	if err := AddToScheme(s); err != nil {
		t.Errorf("AddToScheme() error = %v", err)
	}
	gvs := []schema.GroupVersion{
		v1alpha1.SchemeGroupVersion,
		cache.SchemeGroupVersion,
		compute.SchemeGroupVersion,
		database.SchemeGroupVersion,
		storage.SchemeGroupVersion,
	}
	for _, gv := range gvs {
		if !s.IsVersionRegistered(gv) {
			t.Errorf("AddToScheme() %v should be registered", gv)
		}
	}
}
```
### Change
Add tests for all `apis/*` scaffolding files.
![image](https://user-images.githubusercontent.com/324803/56855294-9b1c9d80-68f9-11e9-8e16-b70e3294ecd7.png)







Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [ ] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [ ] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [ ] RBAC permissions in `clusterrole.yaml` have been updated to include new types, if necessary
- [ ] All related commits have been squashed to improve readability.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)