### PR TITLE
Add initial support for Complex Workloads

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -48,8 +48,8 @@
     "services/redis/mgmt/2018-03-01/redis",
     "services/redis/mgmt/2018-03-01/redis/redisapi",
     "services/resources/mgmt/2018-05-01/resources",
-    "services/storage/mgmt/2017-06-01/storage",
     "services/resources/mgmt/2018-05-01/resources/resourcesapi",
+    "services/storage/mgmt/2017-06-01/storage",
     "version",
   ]
   pruneopts = "UT"
@@ -1349,6 +1349,7 @@
     "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",

--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 512Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 256Mi

--- a/pkg/apis/compute/v1alpha1/register.go
+++ b/pkg/apis/compute/v1alpha1/register.go
@@ -31,13 +31,13 @@ import (
 
 // Kubernetes Group, Version, and Kind metadata.
 const (
-	Group                            = "compute.crossplane.io"
-	Version                          = "v1alpha1"
-	APIVersion                       = Group + "/" + Version
-	KubernetesInstanceKind           = "kubernetescluster"
-	KubernetesInstanceKindAPIVersion = KubernetesInstanceKind + "." + APIVersion
-	WorkloadKind                     = "workload"
-	WorkloadKindAPIVersion           = WorkloadKind + "." + APIVersion
+	Group                           = "compute.crossplane.io"
+	Version                         = "v1alpha1"
+	APIVersion                      = Group + "/" + Version
+	KubernetesClusterKind           = "kubernetescluster"
+	KubernetesClusterKindAPIVersion = KubernetesClusterKind + "." + APIVersion
+	WorkloadKind                    = "workload"
+	WorkloadKindAPIVersion          = WorkloadKind + "." + APIVersion
 )
 
 var (

--- a/pkg/apis/compute/v1alpha1/types.go
+++ b/pkg/apis/compute/v1alpha1/types.go
@@ -64,7 +64,7 @@ type KubernetesClusterList struct {
 // ObjectReference to using this object as a reference
 func (kc *KubernetesCluster) ObjectReference() *corev1.ObjectReference {
 	if kc.Kind == "" {
-		kc.Kind = KubernetesInstanceKind
+		kc.Kind = KubernetesClusterKind
 	}
 	if kc.APIVersion == "" {
 		kc.APIVersion = APIVersion
@@ -177,7 +177,7 @@ type WorkloadList struct {
 // ObjectReference to using this object as a reference
 func (kc *Workload) ObjectReference() *corev1.ObjectReference {
 	if kc.Kind == "" {
-		kc.Kind = KubernetesInstanceKind
+		kc.Kind = KubernetesClusterKind
 	}
 	if kc.APIVersion == "" {
 		kc.APIVersion = APIVersion

--- a/pkg/controller/compute/kubernetes/cluster.go
+++ b/pkg/controller/compute/kubernetes/cluster.go
@@ -85,7 +85,7 @@ func Add(mgr manager.Manager) error {
 // Reconcile reads that state of the cluster for a Instance object and makes changes based on the state read
 // and what is in the Instance.Spec
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	log.V(logging.Debug).Info("reconciling", "kind", computev1alpha1.KubernetesInstanceKindAPIVersion, "request", request)
+	log.V(logging.Debug).Info("reconciling", "kind", computev1alpha1.KubernetesClusterKindAPIVersion, "request", request)
 
 	// fetch the CRD instance
 	instance := &computev1alpha1.KubernetesCluster{}

--- a/pkg/controller/workload/kubernetes/application/application.go
+++ b/pkg/controller/workload/kubernetes/application/application.go
@@ -1,0 +1,339 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/crossplaneio/crossplane/pkg/apis/workload/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/controller/core"
+	"github.com/crossplaneio/crossplane/pkg/logging"
+	"github.com/crossplaneio/crossplane/pkg/util"
+)
+
+const (
+	controllerName   = "kubernetesapplication.workload.crossplane.io"
+	finalizerName    = "finalizer." + controllerName
+	reconcileTimeout = 1 * time.Minute
+
+	reasonGCResources     = "failed to garbage collect " + v1alpha1.KubernetesApplicationResourceKind
+	reasonSyncingResource = "failed to sync " + v1alpha1.KubernetesApplicationResourceKind
+)
+
+var log = logging.Logger.WithName("controller." + controllerName)
+
+type syncer interface {
+	sync(ctx context.Context, app *v1alpha1.KubernetesApplication) reconcile.Result
+}
+
+type deleter interface {
+	delete(ctx context.Context, app *v1alpha1.KubernetesApplication) reconcile.Result
+}
+
+// A syncdeleter can sync and delete resources in a KubernetesCluster.
+type syncdeleter interface {
+	syncer
+	deleter
+}
+
+// CreatePredicate accepts KubernetesApplications that have been scheduled to a
+// KubernetesCluster.
+func CreatePredicate(event event.CreateEvent) bool {
+	wl, ok := event.Object.(*v1alpha1.KubernetesApplication)
+	if !ok {
+		return false
+	}
+	return wl.Status.Cluster != nil
+}
+
+// UpdatePredicate accepts KubernetesApplications that have been scheduled to a
+// KubernetesCluster.
+func UpdatePredicate(event event.UpdateEvent) bool {
+	wl, ok := event.ObjectNew.(*v1alpha1.KubernetesApplication)
+	if !ok {
+		return false
+	}
+	return wl.Status.Cluster != nil
+}
+
+// Add the KubernetesApplication scheduler reconciler to the supplied manager.
+// Reconcilers are triggered when either the application or any of its resources
+// change.
+func Add(mgr manager.Manager) error {
+	kube := mgr.GetClient()
+	r := &Reconciler{
+		kube: kube,
+		local: &localCluster{
+			ar: &applicationResourceClient{kube: kube},
+			gc: &applicationResourceGarbageCollector{kube: kube},
+		},
+	}
+	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return errors.Wrap(err, "cannot create Kubernetes controller")
+	}
+
+	if err := c.Watch(
+		&source.Kind{Type: &v1alpha1.KubernetesApplicationResource{}},
+		&handler.EnqueueRequestForOwner{OwnerType: &v1alpha1.KubernetesApplication{}, IsController: true},
+	); err != nil {
+		return errors.Wrapf(err, "cannot watch for %s", v1alpha1.KubernetesApplicationResourceKind)
+	}
+
+	err = c.Watch(
+		&source.Kind{Type: &v1alpha1.KubernetesApplication{}},
+		&handler.EnqueueRequestForObject{},
+		&predicate.Funcs{CreateFunc: CreatePredicate, UpdateFunc: UpdatePredicate},
+	)
+	return errors.Wrapf(err, "cannot watch for %s", v1alpha1.KubernetesApplicationKind)
+}
+
+// localCluster is a syncDeleter that syncs and deletes resources from the same
+// cluster as their controlling application.
+type localCluster struct {
+	ar applicationResourceSyncer
+	gc garbageCollector
+}
+
+func (c *localCluster) sync(ctx context.Context, app *v1alpha1.KubernetesApplication) reconcile.Result {
+	util.AddFinalizer(app, finalizerName)
+
+	app.Status.UnsetAllConditions()
+	app.Status.DesiredResources = len(app.Spec.ResourceTemplates)
+	app.Status.SubmittedResources = 0
+
+	// Garbage collect any resource we control but no longer have templates for.
+	if err := c.gc.process(ctx, app); err != nil {
+		app.Status.State = v1alpha1.KubernetesApplicationStateFailed
+		app.Status.SetFailed(reasonGCResources, err.Error())
+		return reconcile.Result{Requeue: true}
+	}
+
+	// Create or update all resources with extant templates.
+	for i := range app.Spec.ResourceTemplates {
+		submitted, err := c.ar.sync(ctx, renderTemplate(app, &app.Spec.ResourceTemplates[i]))
+
+		if submitted {
+			app.Status.SubmittedResources++
+		}
+
+		if err != nil {
+			app.Status.State = v1alpha1.KubernetesApplicationStateFailed
+			app.Status.SetFailed(reasonSyncingResource, err.Error())
+			return reconcile.Result{Requeue: true}
+		}
+	}
+
+	if app.Status.SubmittedResources == 0 {
+		// Note we set _state_ scheduled, and _status_ pending here. The pending
+		// state and status have different meanings; the former means "pending
+		// scheduling to a Kubernetets cluster" while the latter means "pending
+		// successful reconciliation".
+		app.Status.State = v1alpha1.KubernetesApplicationStateScheduled
+		app.Status.SetPending()
+		return reconcile.Result{RequeueAfter: core.RequeueOnWait}
+	}
+
+	if app.Status.SubmittedResources < app.Status.DesiredResources {
+		app.Status.State = v1alpha1.KubernetesApplicationStatePartial
+		app.Status.SetPending()
+		return reconcile.Result{RequeueAfter: core.RequeueOnWait}
+	}
+
+	app.Status.State = v1alpha1.KubernetesApplicationStateSubmitted
+	app.Status.SetReady()
+	return reconcile.Result{Requeue: false}
+}
+
+// renderTemplate produces a KubernetesApplicationResource from the supplied
+// KubernetesApplicationResourceTemplate. Note that we somewhat confusingly
+// also refer to the output KubernetesApplicationResource as a 'template' when
+// it is passed to an applicationResourceSyncer.
+func renderTemplate(app *v1alpha1.KubernetesApplication, template *v1alpha1.KubernetesApplicationResourceTemplate) *v1alpha1.KubernetesApplicationResource {
+	ref := metav1.NewControllerRef(app, v1alpha1.KubernetesApplicationGroupVersionKind)
+
+	ar := &v1alpha1.KubernetesApplicationResource{}
+	ar.SetName(template.GetName())
+	ar.SetNamespace(app.GetNamespace())
+	ar.SetOwnerReferences([]metav1.OwnerReference{*ref})
+	ar.SetLabels(template.GetLabels())
+	ar.SetAnnotations(template.GetAnnotations())
+
+	ar.Spec = template.Spec
+	ar.Status.Cluster = app.Status.Cluster
+	ar.Status.State = v1alpha1.KubernetesApplicationResourceStateScheduled
+
+	return ar
+}
+
+type applicationResourceSyncer interface {
+	// sync the supplied template with the Crossplane API server. Returns true
+	// if the templated resource exists and has been submitted to its scheduled
+	// API server, as well as any error encountered.
+	sync(ctx context.Context, template *v1alpha1.KubernetesApplicationResource) (submitted bool, err error)
+}
+
+type applicationResourceClient struct {
+	kube client.Client
+}
+
+func (c *applicationResourceClient) sync(ctx context.Context, template *v1alpha1.KubernetesApplicationResource) (bool, error) {
+	// We make a copy of our template here so we can compare the template as
+	// passed to this method with the remote resource.
+	remote := template.DeepCopy()
+
+	submitted := false
+	err := util.CreateOrUpdate(ctx, c.kube, remote, func() error {
+		// Inside this anonymous function ar could either be unchanged (if
+		// it does not exist in the API server) or updated to reflect its
+		// current state according to the API server.
+
+		if !hasSameController(remote, template) {
+			return errors.Errorf("%s %s exists and is not controlled by %s %s",
+				v1alpha1.KubernetesApplicationResourceKind, remote.GetName(),
+				v1alpha1.KubernetesApplicationKind, getControllerName(template))
+		}
+
+		if remote.Status.State == v1alpha1.KubernetesApplicationResourceStateSubmitted {
+			submitted = true
+		}
+
+		remote.SetLabels(template.GetLabels())
+		remote.SetAnnotations(template.GetAnnotations())
+		remote.Spec = *template.Spec.DeepCopy()
+
+		return nil
+	})
+
+	return submitted, errors.Wrapf(err, "cannot sync %s", v1alpha1.KubernetesApplicationResourceKind)
+}
+
+type garbageCollector interface {
+	// process garbage collection of the supplied app.
+	process(ctx context.Context, app *v1alpha1.KubernetesApplication) error
+}
+
+type applicationResourceGarbageCollector struct {
+	kube client.Client
+}
+
+func (gc *applicationResourceGarbageCollector) process(ctx context.Context, app *v1alpha1.KubernetesApplication) error {
+	desired := map[string]bool{}
+	for _, t := range app.Spec.ResourceTemplates {
+		desired[t.GetName()] = true
+	}
+
+	// Grab a list of all resources in our namespace.
+	resources := &v1alpha1.KubernetesApplicationResourceList{}
+	if err := gc.kube.List(ctx, &client.ListOptions{Namespace: app.GetNamespace()}, resources); err != nil {
+		return errors.Wrapf(err, "cannot garbage collect %s", v1alpha1.KubernetesApplicationResourceKind)
+	}
+
+	// Delete any resources we control that do not match an extant template.
+	// We presume, because we are the controller of these resources, that we
+	// created them but their templates have been removed.
+	for i := range resources.Items {
+		ar := &resources.Items[i]
+
+		// We don't control this resource.
+		if c := metav1.GetControllerOf(ar); c == nil || c.UID != app.GetUID() {
+			continue
+		}
+
+		// This resource exists in one of our templates.
+		if desired[ar.GetName()] {
+			continue
+		}
+
+		// We control this resource but we don't have a template for it.
+		if err := gc.kube.Delete(ctx, ar); err != nil && !kerrors.IsNotFound(err) {
+			app.Status.SetFailed(reasonGCResources, err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (c *localCluster) delete(_ context.Context, app *v1alpha1.KubernetesApplication) reconcile.Result {
+	app.Status.SetDeleting()
+	util.RemoveFinalizer(app, finalizerName)
+	return reconcile.Result{Requeue: false}
+}
+
+// A Reconciler reconciles KubernetesApplications.
+type Reconciler struct {
+	kube  client.Client
+	local syncdeleter
+}
+
+// Reconcile scheduled KubernetesApplications by managing their templated
+// KubernetesApplicationResources.
+func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) {
+	log.V(logging.Debug).Info("reconciling", "kind", v1alpha1.KubernetesApplicationKindAPIVersion, "request", req)
+
+	ctx, cancel := context.WithTimeout(context.Background(), reconcileTimeout)
+	defer cancel()
+
+	app := &v1alpha1.KubernetesApplication{}
+	if err := r.kube.Get(ctx, req.NamespacedName, app); err != nil {
+		if kerrors.IsNotFound(err) {
+			return reconcile.Result{Requeue: false}, nil
+		}
+		return reconcile.Result{Requeue: false}, errors.Wrapf(err, "cannot get %s %s", v1alpha1.KubernetesApplicationKind, req.NamespacedName)
+	}
+
+	if app.DeletionTimestamp != nil {
+		return r.local.delete(ctx, app), errors.Wrapf(r.kube.Update(ctx, app), "cannot update %s %s", v1alpha1.KubernetesApplicationKind, req.NamespacedName)
+	}
+
+	return r.local.sync(ctx, app), errors.Wrapf(r.kube.Update(ctx, app), "cannot update %s %s", v1alpha1.KubernetesApplicationKind, req.NamespacedName)
+}
+
+func hasSameController(a, b metav1.Object) bool {
+	ac := metav1.GetControllerOf(a)
+	bc := metav1.GetControllerOf(b)
+
+	// We do not consider two objects without any controller to have
+	// the same controller.
+	if ac == nil || bc == nil {
+		return false
+	}
+
+	return ac.UID == bc.UID
+}
+
+func getControllerName(obj metav1.Object) string {
+	c := metav1.GetControllerOf(obj)
+	if c == nil {
+		return ""
+	}
+
+	return c.Name
+}

--- a/pkg/controller/workload/kubernetes/application/application_test.go
+++ b/pkg/controller/workload/kubernetes/application/application_test.go
@@ -1,0 +1,895 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-test/deep"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	computev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/compute/v1alpha1"
+	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/apis/workload/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/controller/core"
+	"github.com/crossplaneio/crossplane/pkg/test"
+)
+
+const (
+	namespace = "coolNamespace"
+	name      = "coolApp"
+	uid       = types.UID("definitely-a-uuid")
+)
+
+var (
+	errorBoom = errors.New("boom")
+	meta      = metav1.ObjectMeta{Namespace: namespace, Name: name, UID: uid}
+	ctx       = context.Background()
+
+	templateA = v1alpha1.KubernetesApplicationResourceTemplate{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "coolTemplateA"},
+		Spec: v1alpha1.KubernetesApplicationResourceSpec{
+			Secrets: []corev1.LocalObjectReference{{Name: "coolSecretA"}},
+		},
+	}
+	templateB = v1alpha1.KubernetesApplicationResourceTemplate{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "coolTemplateB"},
+		Spec: v1alpha1.KubernetesApplicationResourceSpec{
+			Secrets: []corev1.LocalObjectReference{{Name: "coolSecretB"}},
+		},
+	}
+
+	resourceA = &v1alpha1.KubernetesApplicationResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   meta.GetNamespace(),
+			Name:        templateA.GetName(),
+			Labels:      templateA.GetLabels(),
+			Annotations: templateA.GetAnnotations(),
+			OwnerReferences: []metav1.OwnerReference{
+				*(metav1.NewControllerRef(kubeApp(), v1alpha1.KubernetesApplicationGroupVersionKind)),
+			},
+		},
+		Spec: templateA.Spec,
+		Status: v1alpha1.KubernetesApplicationResourceStatus{
+			State:   v1alpha1.KubernetesApplicationResourceStateScheduled,
+			Cluster: cluster.ObjectReference(),
+		},
+	}
+
+	cluster = &computev1alpha1.KubernetesCluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "coolCluster"},
+	}
+)
+
+// Frequently used conditions.
+var (
+	deleting = corev1alpha1.Condition{Type: corev1alpha1.Deleting, Status: corev1.ConditionTrue}
+	ready    = corev1alpha1.Condition{Type: corev1alpha1.Ready, Status: corev1.ConditionTrue}
+	pending  = corev1alpha1.Condition{Type: corev1alpha1.Pending, Status: corev1.ConditionTrue}
+)
+
+type kubeAppModifier func(*v1alpha1.KubernetesApplication)
+
+func withFinalizers(f ...string) kubeAppModifier {
+	if f == nil {
+		f = []string{}
+	}
+	return func(r *v1alpha1.KubernetesApplication) { r.ObjectMeta.Finalizers = f }
+}
+
+func withDeletionTimestamp(t time.Time) kubeAppModifier {
+	return func(r *v1alpha1.KubernetesApplication) {
+		r.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: t}
+	}
+}
+
+func withConditions(c ...corev1alpha1.Condition) kubeAppModifier {
+	return func(r *v1alpha1.KubernetesApplication) { r.Status.ConditionedStatus.Conditions = c }
+}
+
+func withState(s v1alpha1.KubernetesApplicationState) kubeAppModifier {
+	return func(r *v1alpha1.KubernetesApplication) { r.Status.State = s }
+}
+
+func withDesiredResources(i int) kubeAppModifier {
+	return func(r *v1alpha1.KubernetesApplication) { r.Status.DesiredResources = i }
+}
+
+func withSubmittedResources(i int) kubeAppModifier {
+	return func(r *v1alpha1.KubernetesApplication) { r.Status.SubmittedResources = i }
+}
+
+func withCluster(c *corev1.ObjectReference) kubeAppModifier {
+	return func(r *v1alpha1.KubernetesApplication) {
+		r.Status.Cluster = c
+	}
+}
+
+func withTemplates(t ...v1alpha1.KubernetesApplicationResourceTemplate) kubeAppModifier {
+	return func(r *v1alpha1.KubernetesApplication) {
+		r.Spec.ResourceTemplates = t
+	}
+}
+
+func kubeApp(rm ...kubeAppModifier) *v1alpha1.KubernetesApplication {
+	r := &v1alpha1.KubernetesApplication{ObjectMeta: meta}
+
+	for _, m := range rm {
+		m(r)
+	}
+
+	return r
+}
+
+func TestCreatePredicate(t *testing.T) {
+	cases := []struct {
+		name  string
+		event event.CreateEvent
+		want  bool
+	}{
+		{
+			name: "ScheduledCluster",
+			event: event.CreateEvent{
+				Object: &v1alpha1.KubernetesApplication{
+					Status: v1alpha1.KubernetesApplicationStatus{
+						Cluster: cluster.ObjectReference(),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "UnscheduledCluster",
+			event: event.CreateEvent{
+				Object: &v1alpha1.KubernetesApplication{},
+			},
+			want: false,
+		},
+		{
+			name: "NotAKubernetesApplication",
+			event: event.CreateEvent{
+				Object: &v1alpha1.KubernetesApplicationResource{},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CreatePredicate(tc.event)
+			if got != tc.want {
+				t.Errorf("CreatePredicate(...): got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+func TestUpdatePredicate(t *testing.T) {
+	cases := []struct {
+		name  string
+		event event.UpdateEvent
+		want  bool
+	}{
+		{
+			name: "ScheduledCluster",
+			event: event.UpdateEvent{
+				ObjectNew: &v1alpha1.KubernetesApplication{
+					Status: v1alpha1.KubernetesApplicationStatus{
+						Cluster: cluster.ObjectReference(),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "UnscheduledCluster",
+			event: event.UpdateEvent{
+				ObjectNew: &v1alpha1.KubernetesApplication{},
+			},
+			want: false,
+		},
+		{
+			name: "NotAKubernetesApplication",
+			event: event.UpdateEvent{
+				ObjectNew: &v1alpha1.KubernetesApplicationResource{},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := UpdatePredicate(tc.event)
+			if got != tc.want {
+				t.Errorf("UpdatePredicate(...): got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+type mockARSyncFn func(ctx context.Context, template *v1alpha1.KubernetesApplicationResource) (bool, error)
+
+func newMockARSyncFn(submitted bool, err error) mockARSyncFn {
+	return func(_ context.Context, _ *v1alpha1.KubernetesApplicationResource) (bool, error) {
+		return submitted, err
+	}
+}
+
+type mockARSyncer struct {
+	mockSync mockARSyncFn
+}
+
+func (tp *mockARSyncer) sync(ctx context.Context, template *v1alpha1.KubernetesApplicationResource) (bool, error) {
+	return tp.mockSync(ctx, template)
+}
+
+type mockProcessFn func(ctx context.Context, app *v1alpha1.KubernetesApplication) error
+
+func newMockProcessFn(err error) mockProcessFn {
+	return func(ctx context.Context, app *v1alpha1.KubernetesApplication) error { return err }
+}
+
+type mockGarbageCollector struct {
+	mockProcess mockProcessFn
+}
+
+func (gc *mockGarbageCollector) process(ctx context.Context, app *v1alpha1.KubernetesApplication) error {
+	return gc.mockProcess(ctx, app)
+}
+
+func TestSync(t *testing.T) {
+	cases := []struct {
+		name       string
+		syncer     syncer
+		app        *v1alpha1.KubernetesApplication
+		wantApp    *v1alpha1.KubernetesApplication
+		wantResult reconcile.Result
+	}{
+		{
+			name: "NoResourcesSubmitted",
+			syncer: &localCluster{
+				ar: &mockARSyncer{mockSync: newMockARSyncFn(false, nil)},
+				gc: &mockGarbageCollector{mockProcess: newMockProcessFn(nil)},
+			},
+			app: kubeApp(withTemplates(templateA)),
+			wantApp: kubeApp(
+				withTemplates(templateA),
+				withFinalizers(finalizerName),
+				withState(v1alpha1.KubernetesApplicationStateScheduled),
+				withConditions(pending),
+				withDesiredResources(1),
+				withSubmittedResources(0),
+			),
+			wantResult: reconcile.Result{RequeueAfter: core.RequeueOnWait},
+		},
+		{
+			name: "PartialResourcesSubmitted",
+			syncer: &localCluster{
+				ar: &mockARSyncer{
+					mockSync: func(_ context.Context, template *v1alpha1.KubernetesApplicationResource) (bool, error) {
+						// Simulate one resource in the submitted state. We're
+						// called once for each template, so we set this to 1
+						// each time.
+						if template.GetName() == templateA.GetName() {
+							return true, nil
+						}
+						return false, nil
+					},
+				},
+				gc: &mockGarbageCollector{mockProcess: newMockProcessFn(nil)},
+			},
+			app: kubeApp(withTemplates(templateA, templateB)),
+			wantApp: kubeApp(
+				withTemplates(templateA, templateB),
+				withFinalizers(finalizerName),
+				withState(v1alpha1.KubernetesApplicationStatePartial),
+				withConditions(pending),
+				withDesiredResources(2),
+				withSubmittedResources(1),
+			),
+			wantResult: reconcile.Result{RequeueAfter: core.RequeueOnWait},
+		},
+		{
+			name: "AllResourcesSubmitted",
+			syncer: &localCluster{
+				ar: &mockARSyncer{
+					mockSync: func(_ context.Context, _ *v1alpha1.KubernetesApplicationResource) (bool, error) {
+						// Simulate all resources in the submitted state.
+						return true, nil
+					},
+				},
+				gc: &mockGarbageCollector{mockProcess: newMockProcessFn(nil)},
+			},
+			app: kubeApp(withTemplates(templateA, templateB)),
+			wantApp: kubeApp(
+				withTemplates(templateA, templateB),
+				withFinalizers(finalizerName),
+				withState(v1alpha1.KubernetesApplicationStateSubmitted),
+				withConditions(ready),
+				withDesiredResources(2),
+				withSubmittedResources(2),
+			),
+			wantResult: reconcile.Result{Requeue: false},
+		},
+		{
+			name: "GarbageCollectionFailed",
+			syncer: &localCluster{
+				ar: &mockARSyncer{mockSync: newMockARSyncFn(false, nil)},
+				gc: &mockGarbageCollector{mockProcess: newMockProcessFn(errorBoom)},
+			},
+			app: kubeApp(withTemplates(templateA)),
+			wantApp: kubeApp(
+				withTemplates(templateA),
+				withFinalizers(finalizerName),
+				withState(v1alpha1.KubernetesApplicationStateFailed),
+				withConditions(
+					corev1alpha1.Condition{
+						Type:    corev1alpha1.Failed,
+						Status:  corev1.ConditionTrue,
+						Reason:  reasonGCResources,
+						Message: errorBoom.Error(),
+					},
+				),
+				withDesiredResources(1),
+			),
+			wantResult: reconcile.Result{Requeue: true},
+		},
+		{
+			name: "SyncApplicationResourceFailed",
+			syncer: &localCluster{
+				ar: &mockARSyncer{mockSync: newMockARSyncFn(false, errorBoom)},
+				gc: &mockGarbageCollector{mockProcess: newMockProcessFn(nil)},
+			},
+			app: kubeApp(withTemplates(templateA)),
+			wantApp: kubeApp(
+				withTemplates(templateA),
+				withFinalizers(finalizerName),
+				withState(v1alpha1.KubernetesApplicationStateFailed),
+				withConditions(
+					corev1alpha1.Condition{
+						Type:    corev1alpha1.Failed,
+						Status:  corev1.ConditionTrue,
+						Reason:  reasonSyncingResource,
+						Message: errorBoom.Error(),
+					},
+				),
+				withDesiredResources(1),
+			),
+			wantResult: reconcile.Result{Requeue: true},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotResult := tc.syncer.sync(ctx, tc.app)
+
+			if diff := deep.Equal(tc.wantResult, gotResult); diff != nil {
+				t.Errorf("tc.sd.Sync(...): want != got:\n%s", diff)
+			}
+
+			if diff := deep.Equal(tc.wantApp, tc.app); diff != nil {
+				t.Errorf("app: want != got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	cases := []struct {
+		name       string
+		deleter    deleter
+		app        *v1alpha1.KubernetesApplication
+		wantApp    *v1alpha1.KubernetesApplication
+		wantResult reconcile.Result
+	}{
+		{
+			name:    "Successful",
+			deleter: &localCluster{},
+			app:     kubeApp(withFinalizers(finalizerName)),
+			wantApp: kubeApp(
+				withFinalizers(),
+				withConditions(deleting),
+			),
+			wantResult: reconcile.Result{Requeue: false},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotResult := tc.deleter.delete(ctx, tc.app)
+
+			if diff := deep.Equal(tc.wantResult, gotResult); diff != nil {
+				t.Errorf("tc.sd.Sync(...): want != got:\n%s", diff)
+			}
+
+			if diff := deep.Equal(tc.wantApp, tc.app); diff != nil {
+				t.Errorf("app: want != got:\n%s", diff)
+			}
+		})
+	}
+}
+
+type mockSyncFn func(ctx context.Context, app *v1alpha1.KubernetesApplication) reconcile.Result
+
+func newMockSyncFn(r reconcile.Result) mockSyncFn {
+	return func(_ context.Context, _ *v1alpha1.KubernetesApplication) reconcile.Result { return r }
+}
+
+type mockDeleteFn func(ctx context.Context, app *v1alpha1.KubernetesApplication) reconcile.Result
+
+func newMockDeleteFn(r reconcile.Result) mockDeleteFn {
+	return func(_ context.Context, _ *v1alpha1.KubernetesApplication) reconcile.Result { return r }
+}
+
+type mockSyncDeleter struct {
+	mockSync   mockSyncFn
+	mockDelete mockDeleteFn
+}
+
+func (sd *mockSyncDeleter) sync(ctx context.Context, app *v1alpha1.KubernetesApplication) reconcile.Result {
+	return sd.mockSync(ctx, app)
+}
+
+func (sd *mockSyncDeleter) delete(ctx context.Context, app *v1alpha1.KubernetesApplication) reconcile.Result {
+	return sd.mockDelete(ctx, app)
+}
+
+func TestReconcile(t *testing.T) {
+	cases := []struct {
+		name       string
+		rec        *Reconciler
+		req        reconcile.Request
+		wantResult reconcile.Result
+		wantErr    error
+	}{
+		{
+			name: "FailedToGetNonExistentKubernetesApplication",
+			rec: &Reconciler{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
+						return kerrors.NewNotFound(schema.GroupResource{}, name)
+					},
+				},
+			},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+			wantResult: reconcile.Result{Requeue: false},
+			wantErr:    nil,
+		},
+		{
+			name: "FailedToGetExtantKubernetesApplication",
+			rec: &Reconciler{
+				kube: &test.MockClient{MockGet: test.NewMockGetFn(errorBoom)},
+			},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+			wantResult: reconcile.Result{Requeue: false},
+			wantErr:    errors.Wrapf(errorBoom, "cannot get %s %s/%s", v1alpha1.KubernetesApplicationKind, namespace, name),
+		},
+		{
+			name: "ApplicationDeletedSuccessfully",
+			rec: &Reconciler{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
+						*obj.(*v1alpha1.KubernetesApplication) = *(kubeApp(withDeletionTimestamp(time.Now())))
+						return nil
+					},
+					MockUpdate: test.NewMockUpdateFn(nil),
+				},
+				local: &mockSyncDeleter{mockDelete: newMockDeleteFn(reconcile.Result{Requeue: false})},
+			},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+			wantResult: reconcile.Result{Requeue: false},
+		},
+
+		{
+			name: "ApplicationDeleteFailure",
+			rec: &Reconciler{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
+						*obj.(*v1alpha1.KubernetesApplication) = *(kubeApp(withDeletionTimestamp(time.Now())))
+						return nil
+					},
+					MockUpdate: test.NewMockUpdateFn(errorBoom),
+				},
+				local: &mockSyncDeleter{mockDelete: newMockDeleteFn(reconcile.Result{Requeue: false})},
+			},
+			req: reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+
+			// Dirty, not Error, because we return the result and call update
+			// at the same time and thus did not know to expect the error.
+			wantResult: reconcile.Result{Requeue: false},
+			wantErr:    errors.Wrapf(errorBoom, "cannot update %s %s/%s", v1alpha1.KubernetesApplicationKind, namespace, name),
+		},
+		{
+			name: "ApplicationSyncedSuccessfully",
+			rec: &Reconciler{
+				kube:  &test.MockClient{MockGet: test.NewMockGetFn(nil), MockUpdate: test.NewMockUpdateFn(nil)},
+				local: &mockSyncDeleter{mockSync: newMockSyncFn(reconcile.Result{Requeue: false})},
+			},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+			wantResult: reconcile.Result{Requeue: false},
+		},
+		{
+			name: "ApplicationSyncFailure",
+			rec: &Reconciler{
+				kube:  &test.MockClient{MockGet: test.NewMockGetFn(nil), MockUpdate: test.NewMockUpdateFn(errorBoom)},
+				local: &mockSyncDeleter{mockSync: newMockSyncFn(reconcile.Result{Requeue: false})},
+			},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+			wantResult: reconcile.Result{Requeue: false},
+			wantErr:    errors.Wrapf(errorBoom, "cannot update %s %s/%s", v1alpha1.KubernetesApplicationKind, namespace, name),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotResult, gotErr := tc.rec.Reconcile(tc.req)
+
+			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
+			}
+
+			if diff := deep.Equal(tc.wantResult, gotResult); diff != nil {
+				t.Errorf("tc.rec.Reconcile(...): want != got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGarbageCollect(t *testing.T) {
+	cases := []struct {
+		name    string
+		gc      garbageCollector
+		app     *v1alpha1.KubernetesApplication
+		wantApp *v1alpha1.KubernetesApplication
+		wantErr error
+	}{
+		{
+			name: "SuccessfulResourceDeletion",
+			gc: &applicationResourceGarbageCollector{
+				kube: &test.MockClient{
+					MockList: func(_ context.Context, _ *client.ListOptions, obj runtime.Object) error {
+						ref := metav1.NewControllerRef(kubeApp(), v1alpha1.KubernetesApplicationGroupVersionKind)
+						m := meta.DeepCopy()
+						m.SetOwnerReferences([]metav1.OwnerReference{*ref})
+						*obj.(*v1alpha1.KubernetesApplicationResourceList) = v1alpha1.KubernetesApplicationResourceList{
+							Items: []v1alpha1.KubernetesApplicationResource{{ObjectMeta: *m}},
+						}
+						return nil
+					},
+					MockDelete: test.NewMockDeleteFn(nil),
+				},
+			},
+			app:     kubeApp(withTemplates(templateA)),
+			wantApp: kubeApp(withTemplates(templateA)),
+		},
+		{
+			name: "FailedResourceDeletion",
+			gc: &applicationResourceGarbageCollector{
+				kube: &test.MockClient{
+					MockList: func(_ context.Context, _ *client.ListOptions, obj runtime.Object) error {
+						ref := metav1.NewControllerRef(kubeApp(), v1alpha1.KubernetesApplicationGroupVersionKind)
+						m := meta.DeepCopy()
+						m.SetOwnerReferences([]metav1.OwnerReference{*ref})
+						*obj.(*v1alpha1.KubernetesApplicationResourceList) = v1alpha1.KubernetesApplicationResourceList{
+							Items: []v1alpha1.KubernetesApplicationResource{{ObjectMeta: *m}},
+						}
+						return nil
+					},
+					MockDelete: test.NewMockDeleteFn(errorBoom),
+				},
+			},
+			app: kubeApp(withTemplates(templateA)),
+			wantApp: kubeApp(
+				withTemplates(templateA),
+				withConditions(
+					corev1alpha1.Condition{
+						Type:    corev1alpha1.Failed,
+						Status:  corev1.ConditionTrue,
+						Reason:  reasonGCResources,
+						Message: errorBoom.Error(),
+					},
+				),
+			),
+		},
+		{
+			name: "FailedListResources",
+			gc: &applicationResourceGarbageCollector{
+				kube: &test.MockClient{MockList: test.NewMockListFn(errorBoom)},
+			},
+			app:     kubeApp(withTemplates(templateA)),
+			wantApp: kubeApp(withTemplates(templateA)),
+			wantErr: errors.Wrapf(errorBoom, "cannot garbage collect %s", v1alpha1.KubernetesApplicationResourceKind),
+		},
+		{
+			name: "ResourceNotControlledByApplication",
+			gc: &applicationResourceGarbageCollector{
+				kube: &test.MockClient{
+					MockList: func(_ context.Context, _ *client.ListOptions, obj runtime.Object) error {
+						*obj.(*v1alpha1.KubernetesApplicationResourceList) = v1alpha1.KubernetesApplicationResourceList{
+							Items: []v1alpha1.KubernetesApplicationResource{{ObjectMeta: meta}},
+						}
+						return nil
+					},
+				},
+			},
+			app:     kubeApp(withTemplates(templateA)),
+			wantApp: kubeApp(withTemplates(templateA)),
+		},
+		{
+			name: "ResourceIsTemplated",
+			gc: &applicationResourceGarbageCollector{
+				kube: &test.MockClient{
+					MockList: func(_ context.Context, _ *client.ListOptions, obj runtime.Object) error {
+						ref := metav1.NewControllerRef(kubeApp(), v1alpha1.KubernetesApplicationGroupVersionKind)
+						m := templateA.ObjectMeta.DeepCopy()
+						m.SetOwnerReferences([]metav1.OwnerReference{*ref})
+						*obj.(*v1alpha1.KubernetesApplicationResourceList) = v1alpha1.KubernetesApplicationResourceList{
+							Items: []v1alpha1.KubernetesApplicationResource{{ObjectMeta: *m}},
+						}
+						return nil
+					},
+				},
+			},
+			app:     kubeApp(withTemplates(templateA)),
+			wantApp: kubeApp(withTemplates(templateA)),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotErr := tc.gc.process(ctx, tc.app)
+
+			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
+			}
+
+			if diff := deep.Equal(tc.wantApp, tc.app); diff != nil {
+				t.Errorf("app: want != got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSyncApplicationResource(t *testing.T) {
+	cases := []struct {
+		name          string
+		ar            applicationResourceSyncer
+		template      *v1alpha1.KubernetesApplicationResource
+		wantSubmitted bool
+		wantErr       error
+	}{
+		{
+			name: "Successful",
+			ar: &applicationResourceClient{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ types.NamespacedName, obj runtime.Object) error {
+						r := resourceA.DeepCopy()
+						r.Status.State = v1alpha1.KubernetesApplicationResourceStateSubmitted
+
+						*obj.(*v1alpha1.KubernetesApplicationResource) = *r
+						return nil
+					},
+				},
+			},
+			template:      resourceA,
+			wantSubmitted: true,
+		},
+		{
+			name: "ExistingResourceHasDifferentController",
+			ar: &applicationResourceClient{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ types.NamespacedName, obj runtime.Object) error {
+						r := resourceA.DeepCopy()
+						r.SetOwnerReferences([]metav1.OwnerReference{})
+
+						*obj.(*v1alpha1.KubernetesApplicationResource) = *r
+						return nil
+					},
+				},
+			},
+			template: resourceA,
+			wantErr: errors.WithStack(errors.Errorf("cannot sync %s: could not mutate object for update: %s %s exists and is not controlled by %s %s",
+				v1alpha1.KubernetesApplicationResourceKind,
+				v1alpha1.KubernetesApplicationResourceKind,
+				templateA.GetName(),
+				v1alpha1.KubernetesApplicationKind,
+				meta.GetName(),
+			)),
+		},
+		{
+
+			name: "CreateOrUpdateFailed",
+			ar: &applicationResourceClient{
+				kube: &test.MockClient{MockGet: test.NewMockGetFn(errorBoom)},
+			},
+			template: resourceA,
+			wantErr:  errors.Wrapf(errorBoom, "cannot sync %s: could not get object", v1alpha1.KubernetesApplicationResourceKind),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotSubmitted, gotErr := tc.ar.sync(ctx, tc.template)
+
+			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+				t.Errorf("tc.ar.sync(...): want error != got error:\n%s", diff)
+			}
+
+			if diff := deep.Equal(tc.wantSubmitted, gotSubmitted); diff != nil {
+				t.Errorf("tc.ar.Sync(...): want != got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRenderTemplate(t *testing.T) {
+	cases := []struct {
+		name     string
+		app      *v1alpha1.KubernetesApplication
+		template *v1alpha1.KubernetesApplicationResourceTemplate
+		want     *v1alpha1.KubernetesApplicationResource
+	}{
+		{
+			name:     "Successful",
+			app:      kubeApp(withCluster(cluster.ObjectReference())),
+			template: &templateA,
+			want:     resourceA,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := renderTemplate(tc.app, tc.template)
+
+			if diff := deep.Equal(tc.want, got); diff != nil {
+				t.Errorf("renderTemplate(...): want != got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestHasSameController(t *testing.T) {
+	cases := []struct {
+		name string
+		a    metav1.Object
+		b    metav1.Object
+		want bool
+	}{
+		{
+			name: "SameController",
+			a: &v1alpha1.KubernetesApplicationResource{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						*(metav1.NewControllerRef(kubeApp(), v1alpha1.KubernetesApplicationGroupVersionKind)),
+					},
+				},
+			},
+			b: &v1alpha1.KubernetesApplicationResource{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						*(metav1.NewControllerRef(kubeApp(), v1alpha1.KubernetesApplicationGroupVersionKind)),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "AHasNoController",
+			a:    &v1alpha1.KubernetesApplicationResource{},
+			b: &v1alpha1.KubernetesApplicationResource{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						*(metav1.NewControllerRef(kubeApp(), v1alpha1.KubernetesApplicationGroupVersionKind)),
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "BHasNoController",
+			a: &v1alpha1.KubernetesApplicationResource{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						*(metav1.NewControllerRef(kubeApp(), v1alpha1.KubernetesApplicationGroupVersionKind)),
+					},
+				},
+			},
+			b:    &v1alpha1.KubernetesApplicationResource{},
+			want: false,
+		},
+		{
+			name: "ControllersDiffer",
+			a: &v1alpha1.KubernetesApplicationResource{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Controller: func() *bool {
+								t := true
+								return &t
+							}(),
+							UID: "imdifferent",
+						},
+					},
+				},
+			},
+			b: &v1alpha1.KubernetesApplicationResource{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						*(metav1.NewControllerRef(kubeApp(), v1alpha1.KubernetesApplicationGroupVersionKind)),
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hasSameController(tc.a, tc.b)
+
+			if diff := deep.Equal(tc.want, got); diff != nil {
+				t.Errorf("hasSameController(...): want != got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetControllerName(t *testing.T) {
+	cases := []struct {
+		name string
+		obj  metav1.Object
+		want string
+	}{
+		{
+			name: "HasController",
+			obj: &v1alpha1.KubernetesApplicationResource{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						*(metav1.NewControllerRef(kubeApp(), v1alpha1.KubernetesApplicationGroupVersionKind)),
+					},
+				},
+			},
+			want: meta.GetName(),
+		},
+		{
+			name: "HasNoController",
+			obj:  &v1alpha1.KubernetesApplicationResource{},
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getControllerName(tc.obj)
+
+			if diff := deep.Equal(tc.want, got); diff != nil {
+				t.Errorf("getControllerName(...): want != got:\n%s", diff)
+			}
+		})
+	}
+
+}

--- a/pkg/controller/workload/kubernetes/resource/resource.go
+++ b/pkg/controller/workload/kubernetes/resource/resource.go
@@ -1,0 +1,576 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	computev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/compute/v1alpha1"
+	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/apis/workload/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/logging"
+	"github.com/crossplaneio/crossplane/pkg/util"
+)
+
+const (
+	controllerName   = "kubernetesapplicationresource." + v1alpha1.Group
+	finalizerName    = "finalizer." + controllerName
+	reconcileTimeout = 1 * time.Minute
+
+	reasonFetchingClient   = "failed to fetch Kubernetes client"
+	reasonSyncingResource  = "failed to sync templated resource in Kubernetes cluster"
+	reasonDeletingResource = "failed to delete templated resource from Kubernetes cluster"
+	reasonGettingSecret    = "failed to get connection secret for resource dependency"
+	reasonSyncingSecret    = "failed to update connection secret for resource dependency"
+	reasonDeletingSecret   = "failed to delete connection secret for resource dependency"
+
+	messageMissingTemplate = v1alpha1.KubernetesApplicationResourceKind + " must include a template"
+)
+
+// Ownership annotations
+const (
+	RemoteControllerNamespace = v1alpha1.KubernetesApplicationResourceKind + "." + v1alpha1.Group + "/namespace"
+	RemoteControllerName      = v1alpha1.KubernetesApplicationResourceKind + "." + v1alpha1.Group + "/name"
+	RemoteControllerUID       = v1alpha1.KubernetesApplicationResourceKind + "." + v1alpha1.Group + "/uid"
+)
+
+var (
+	log = logging.Logger.WithName("controller." + controllerName)
+)
+
+// CreatePredicate accepts KubernetesApplicationResources that have been
+// scheduled to a KubernetesCluster.
+func CreatePredicate(event event.CreateEvent) bool {
+	wl, ok := event.Object.(*v1alpha1.KubernetesApplicationResource)
+	if !ok {
+		return false
+	}
+	return wl.Status.Cluster != nil
+}
+
+// UpdatePredicate accepts KubernetesApplicationResources that have been
+// scheduled to a KubernetesCluster.
+func UpdatePredicate(event event.UpdateEvent) bool {
+	wl, ok := event.ObjectNew.(*v1alpha1.KubernetesApplicationResource)
+	if !ok {
+		return false
+	}
+	return wl.Status.Cluster != nil
+}
+
+// Add creates a new Instance Controller and adds it to the Manager with default RBAC.
+// The Manager will set fields on the Controller and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	r := &Reconciler{
+		connecter: &clusterConnecter{kube: mgr.GetClient()},
+		kube:      mgr.GetClient(),
+	}
+	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return errors.Wrap(err, "cannot create Kubernetes controller")
+	}
+
+	err = c.Watch(
+		&source.Kind{Type: &v1alpha1.KubernetesApplicationResource{}},
+		&handler.EnqueueRequestForObject{},
+		&predicate.Funcs{CreateFunc: CreatePredicate, UpdateFunc: UpdatePredicate},
+	)
+	return errors.Wrapf(err, "cannot watch for %s", v1alpha1.KubernetesApplicationResourceKind)
+}
+
+// A syncer can sync resources with a KubernetesCluster.
+type syncer interface {
+	// sync the supplied resource with the external store. Returns true if the
+	// resource requires further reconciliation.
+	sync(ctx context.Context, ar *v1alpha1.KubernetesApplicationResource, secrets []corev1.Secret) reconcile.Result
+}
+
+// A deleter can delete resources from a KubernetesCluster.
+type deleter interface {
+	// delete the supplied resource from the external store. Returns true if the
+	// resource requires further reconciliation.
+	delete(ctx context.Context, ar *v1alpha1.KubernetesApplicationResource, secrets []corev1.Secret) reconcile.Result
+}
+
+// A syncdeleter can sync and delete KubernetesApplicationResources in a
+// KubernetesCluster.
+type syncdeleter interface {
+	syncer
+	deleter
+}
+
+type unstructuredSyncer interface {
+	sync(ctx context.Context, template *unstructured.Unstructured) (*v1alpha1.RemoteStatus, error)
+}
+
+type unstructuredDeleter interface {
+	delete(ctx context.Context, template *unstructured.Unstructured) error
+}
+
+type unstructuredSyncDeleter interface {
+	unstructuredSyncer
+	unstructuredDeleter
+}
+
+type secretSyncer interface {
+	sync(ctx context.Context, template *corev1.Secret) error
+}
+
+type secretDeleter interface {
+	delete(ctx context.Context, template *corev1.Secret) error
+}
+
+type secretSyncDeleter interface {
+	secretSyncer
+	secretDeleter
+}
+
+type remoteCluster struct {
+	unstructured unstructuredSyncDeleter
+	secret       secretSyncDeleter
+}
+
+func (c *remoteCluster) sync(ctx context.Context, ar *v1alpha1.KubernetesApplicationResource, secrets []corev1.Secret) reconcile.Result {
+	util.AddFinalizer(ar, finalizerName)
+	ar.Status.UnsetAllConditions()
+
+	// Our CRD requires template to be specified, but just in case...
+	if ar.Spec.Template == nil {
+		ar.Status.State = v1alpha1.KubernetesApplicationResourceStateFailed
+		ar.Status.SetFailed(reasonSyncingResource, messageMissingTemplate)
+		return reconcile.Result{Requeue: true}
+	}
+
+	templates := createSecretTemplates(secrets, ar.Spec.Template.GetNamespace(), ar.GetName())
+	for i := range templates {
+		template := &templates[i]
+		ensureNamespace(template)
+		setRemoteController(ar, template)
+
+		if err := c.secret.sync(ctx, template); err != nil {
+			ar.Status.State = v1alpha1.KubernetesApplicationResourceStateFailed
+			ar.Status.SetFailed(reasonSyncingSecret, err.Error())
+			return reconcile.Result{Requeue: true}
+		}
+	}
+
+	// We copy the resource template here so we can modify its namespace and
+	// remote controller annotations without persisting those changes back to
+	// the KubernetesApplicationResource.
+	template := ar.Spec.Template.DeepCopy()
+	ensureNamespace(template)
+	setRemoteController(ar, template)
+
+	status, err := c.unstructured.sync(ctx, template)
+	if err != nil {
+		ar.Status.State = v1alpha1.KubernetesApplicationResourceStateFailed
+		ar.Status.SetFailed(reasonSyncingResource, err.Error())
+		return reconcile.Result{Requeue: true}
+	}
+
+	ar.Status.Remote = status
+	ar.Status.SetReady()
+	ar.Status.State = v1alpha1.KubernetesApplicationResourceStateSubmitted
+	return reconcile.Result{Requeue: false}
+}
+
+func (c *remoteCluster) delete(ctx context.Context, ar *v1alpha1.KubernetesApplicationResource, secrets []corev1.Secret) reconcile.Result {
+	ar.Status.UnsetAllConditions()
+	ar.Status.SetDeleting()
+
+	// Our CRD requires template to be specified, but just in case...
+	if ar.Spec.Template == nil {
+		ar.Status.State = v1alpha1.KubernetesApplicationResourceStateFailed
+		ar.Status.SetFailed(reasonDeletingResource, messageMissingTemplate)
+		return reconcile.Result{Requeue: true}
+	}
+
+	// We copy the resource template here so we can modify its namespace and
+	// remote controller annotations without persisting those changes back to
+	// the KubernetesApplicationResource.
+	template := ar.Spec.Template.DeepCopy()
+	ensureNamespace(template)
+	setRemoteController(ar, template)
+
+	if err := c.unstructured.delete(ctx, template); err != nil {
+		ar.Status.State = v1alpha1.KubernetesApplicationResourceStateFailed
+		ar.Status.SetFailed(reasonDeletingResource, err.Error())
+		return reconcile.Result{Requeue: true}
+	}
+
+	templates := createSecretTemplates(secrets, ar.Spec.Template.GetNamespace(), ar.GetName())
+	for i := range templates {
+		template := &templates[i]
+		ensureNamespace(template)
+		setRemoteController(ar, template)
+
+		if err := c.secret.delete(ctx, template); err != nil {
+			ar.Status.State = v1alpha1.KubernetesApplicationResourceStateFailed
+			ar.Status.SetFailed(reasonDeletingSecret, err.Error())
+			return reconcile.Result{Requeue: true}
+		}
+	}
+	util.RemoveFinalizer(ar, finalizerName)
+	return reconcile.Result{Requeue: false}
+}
+
+func createSecretTemplates(local []corev1.Secret, namespace, namePrefix string) []corev1.Secret {
+	templates := make([]corev1.Secret, len(local))
+	for i, l := range local {
+		templates[i] = corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:   namespace,
+				Name:        fmt.Sprintf("%s-%s", namePrefix, l.GetName()),
+				Labels:      l.GetLabels(),
+				Annotations: l.GetAnnotations(),
+			},
+			Data: l.Data,
+		}
+	}
+	return templates
+}
+
+type unstructuredClient struct {
+	kube client.Client
+}
+
+func (c *unstructuredClient) sync(ctx context.Context, template *unstructured.Unstructured) (*v1alpha1.RemoteStatus, error) {
+	// We make another copy of our template here so we can compare the template
+	// as passed to this method with the remote resource.
+	remote := template.DeepCopy()
+
+	// TODO(negz): Handle immutable, server-populated, fields such as a
+	// Service's ClusterIP. For example:
+	// spec.clusterIP: Invalid value: "": field is immutable
+	// Generate a JSON patch from the two unstructured contents?
+
+	var rs *v1alpha1.RemoteStatus
+
+	err := util.CreateOrUpdate(ctx, c.kube, remote, func() error {
+		// Inside this anonymous function remote could either be unchanged (if
+		// it does not exist in the API server) or updated to reflect its
+		// current state according to the API server.
+
+		if !hasSameController(remote, template) {
+			return errors.Errorf("%s %s/%s exists and is not controlled by %s %s",
+				remote.GetObjectKind().GroupVersionKind().Kind, remote.GetNamespace(), remote.GetName(),
+				v1alpha1.KubernetesApplicationResourceKind, template.GetAnnotations()[RemoteControllerName])
+		}
+
+		// Propagate the 'status' field of remote (if any) before we overwrite
+		// it with our template.
+		rs = getRemoteStatus(remote)
+
+		existing := remote.DeepCopy()
+		template.DeepCopyInto(remote)
+
+		// Keep important metadata from any existing resource.
+		remote.SetUID(existing.GetUID())
+		remote.SetResourceVersion(existing.GetResourceVersion())
+		remote.SetNamespace(existing.GetNamespace())
+
+		return nil
+	})
+
+	return rs, errors.Wrap(err, "cannot sync resource")
+}
+
+func getRemoteStatus(u runtime.Unstructured) *v1alpha1.RemoteStatus {
+	status, ok := u.UnstructuredContent()["status"]
+	if !ok {
+		// This object does not have a status.
+		return nil
+	}
+
+	j, err := json.Marshal(status)
+	if err != nil {
+		// This object's status cannot be represented as JSON.
+		return nil
+	}
+
+	remote := &v1alpha1.RemoteStatus{}
+	if err := json.Unmarshal(j, remote); err != nil {
+		// This object's status cannot be represented as JSON.
+		return nil
+	}
+
+	return remote
+}
+
+func (c *unstructuredClient) delete(ctx context.Context, template *unstructured.Unstructured) error {
+	n := types.NamespacedName{Namespace: template.GetNamespace(), Name: template.GetName()}
+	remote := template.DeepCopy()
+	if err := c.kube.Get(ctx, n, remote); err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "cannot get resource %s", n)
+	}
+
+	// The object exists, but we don't own it.
+	if !hasSameController(remote, template) {
+		return nil
+	}
+
+	// The object exists and we own it. Delete it.
+	return errors.Wrapf(c.kube.Delete(ctx, remote), "cannot delete resource %s", n)
+}
+
+type secretClient struct {
+	kube client.Client
+}
+
+func (c *secretClient) sync(ctx context.Context, template *corev1.Secret) error {
+	// We make another copy of our template here so we can compare the template
+	// as passed to this method with the remote resource.
+	remote := template.DeepCopy()
+
+	err := util.CreateOrUpdate(ctx, c.kube, remote, func() error {
+		// Inside this anonymous function remote could either be unchanged (if
+		// it does not exist in the API server) or updated to reflect its
+		// current state according to the API server.
+
+		if !hasSameController(remote, template) {
+			return errors.Errorf("secret %s/%s exists and is not controlled by %s %s",
+				remote.GetNamespace(), remote.GetName(),
+				v1alpha1.KubernetesApplicationResourceKind, template.GetAnnotations()[RemoteControllerName])
+		}
+
+		existing := remote.DeepCopy()
+		template.DeepCopyInto(remote)
+
+		// Keep important metadata from any existing resource.
+		remote.SetUID(existing.GetUID())
+		remote.SetResourceVersion(existing.GetResourceVersion())
+		remote.SetNamespace(existing.GetNamespace())
+
+		return nil
+	})
+
+	return errors.Wrap(err, "cannot sync secret")
+}
+
+func (c *secretClient) delete(ctx context.Context, template *corev1.Secret) error {
+	n := types.NamespacedName{Namespace: template.GetNamespace(), Name: template.GetName()}
+	remote := template.DeepCopy()
+	if err := c.kube.Get(ctx, n, remote); err != nil {
+		// No object exists.
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "cannot get secret %s", n)
+	}
+
+	// We don't own the existing object.
+	if !hasSameController(remote, template) {
+		return nil
+	}
+
+	// We own the existing object. delete it.
+	return errors.Wrapf(c.kube.Delete(ctx, remote), "cannot delete secret %s", n)
+}
+
+// A connecter returns a createsyncdeletekeyer that can create, sync, and delete
+// application resources with a remote Kubernetes cluster.
+type connecter interface {
+	connect(context.Context, *v1alpha1.KubernetesApplicationResource) (syncdeleter, error)
+}
+
+type clusterConnecter struct {
+	kube    client.Client
+	options client.Options
+}
+
+func (c *clusterConnecter) config(ctx context.Context, ar *v1alpha1.KubernetesApplicationResource) (*rest.Config, error) {
+	n := types.NamespacedName{Namespace: ar.GetNamespace(), Name: ar.GetName()}
+	if ar.Status.Cluster == nil {
+		return nil, errors.Errorf("%s %s is not scheduled", v1alpha1.KubernetesApplicationResourceKind, n)
+	}
+
+	n = types.NamespacedName{Namespace: ar.Status.Cluster.Namespace, Name: ar.Status.Cluster.Name}
+	k := &computev1alpha1.KubernetesCluster{}
+	if err := c.kube.Get(ctx, n, k); err != nil {
+		return nil, errors.Wrapf(err, "cannot get %s %s", computev1alpha1.KubernetesClusterKind, n)
+	}
+
+	n = types.NamespacedName{Namespace: k.GetNamespace(), Name: k.Status.CredentialsSecretRef.Name}
+	s := &corev1.Secret{}
+	if err := c.kube.Get(ctx, n, s); err != nil {
+		return nil, errors.Wrapf(err, "cannot get secret %s", n)
+	}
+
+	u, err := url.Parse(string(s.Data[corev1alpha1.ResourceCredentialsSecretEndpointKey]))
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot parse Kubernetes endpoint as URL")
+	}
+
+	config := &rest.Config{
+		Host:     u.String(),
+		Username: string(s.Data[corev1alpha1.ResourceCredentialsSecretUserKey]),
+		Password: string(s.Data[corev1alpha1.ResourceCredentialsSecretPasswordKey]),
+		TLSClientConfig: rest.TLSClientConfig{
+			// This field's godoc claims clients will use 'the hostname used to
+			// contact the server' when it is left unset. In practice clients
+			// appear to use the URL, including scheme and port.
+			ServerName: u.Hostname(),
+			CAData:     s.Data[corev1alpha1.ResourceCredentialsSecretCAKey],
+			CertData:   s.Data[corev1alpha1.ResourceCredentialsSecretClientCertKey],
+			KeyData:    s.Data[corev1alpha1.ResourceCredentialsSecretClientKeyKey],
+		},
+		BearerToken: string(s.Data[corev1alpha1.ResourceCredentialsTokenKey]),
+	}
+
+	return config, nil
+}
+
+// connect returns a syncdeleter backed by a KubernetesCluster.
+// Cluster credentials are read from a Crossplane connection secret.
+func (c *clusterConnecter) connect(ctx context.Context, ar *v1alpha1.KubernetesApplicationResource) (syncdeleter, error) {
+	config, err := c.config(ctx, ar)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create Kubernetes client configuration")
+	}
+
+	kc, err := client.New(config, c.options)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create Kubernetes client")
+	}
+
+	return &remoteCluster{unstructured: &unstructuredClient{kube: kc}, secret: &secretClient{kube: kc}}, nil
+}
+
+// Reconciler reconciles a Instance object
+type Reconciler struct {
+	connecter
+	kube client.Client
+}
+
+// Reconcile scheduled Kubernetes application resources by propagating them to
+// their scheduled Kubernetes cluster.
+func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) {
+	log.V(logging.Debug).Info("reconciling", "kind", v1alpha1.KubernetesApplicationResourceKindAPIVersion, "request", req)
+
+	ctx, cancel := context.WithTimeout(context.Background(), reconcileTimeout)
+	defer cancel()
+
+	ar := &v1alpha1.KubernetesApplicationResource{}
+	if err := r.kube.Get(ctx, req.NamespacedName, ar); err != nil {
+		if kerrors.IsNotFound(err) {
+			return reconcile.Result{Requeue: false}, nil
+		}
+		return reconcile.Result{Requeue: false}, errors.Wrapf(err, "cannot get %s %s", v1alpha1.KubernetesApplicationResourceKind, req.NamespacedName)
+	}
+
+	cluster, err := r.connect(ctx, ar)
+	if err != nil {
+		// TODO(negz): If err indicates the KubernetesCluster no longer exists
+		// we should just delete the resource, or we'll be stuck forever.
+		ar.Status.SetFailed(reasonFetchingClient, err.Error())
+		return reconcile.Result{Requeue: true}, errors.Wrapf(r.kube.Update(ctx, ar), "cannot update %s %s", v1alpha1.KubernetesApplicationResourceKind, req.NamespacedName)
+	}
+
+	secrets := r.getConnectionSecrets(ctx, ar)
+
+	if ar.GetDeletionTimestamp() != nil {
+		return cluster.delete(ctx, ar, secrets), errors.Wrapf(r.kube.Update(ctx, ar), "cannot update %s %s", v1alpha1.KubernetesApplicationResourceKind, req.NamespacedName)
+	}
+
+	return cluster.sync(ctx, ar, secrets), errors.Wrapf(r.kube.Update(ctx, ar), "cannot update %s %s", v1alpha1.KubernetesApplicationResourceKind, req.NamespacedName)
+}
+
+func (r *Reconciler) getConnectionSecrets(ctx context.Context, ar *v1alpha1.KubernetesApplicationResource) []corev1.Secret {
+	secrets := make([]corev1.Secret, 0, len(ar.Spec.Secrets))
+	for _, ref := range ar.Spec.Secrets {
+		s := corev1.Secret{}
+		n := types.NamespacedName{Namespace: ar.GetNamespace(), Name: ref.Name}
+		if err := r.kube.Get(ctx, n, &s); err != nil {
+			ar.Status.SetFailed(reasonGettingSecret, err.Error())
+			continue
+		}
+		secrets = append(secrets, s)
+	}
+	return secrets
+}
+
+func setRemoteController(ctrl metav1.Object, obj metav1.Object) {
+	a := obj.GetAnnotations()
+
+	// Unstructured objects can return a nil map of annotations.
+	if a == nil {
+		a = map[string]string{}
+	}
+
+	a[RemoteControllerNamespace] = ctrl.GetNamespace()
+	a[RemoteControllerName] = ctrl.GetName()
+	a[RemoteControllerUID] = string(ctrl.GetUID())
+	obj.SetAnnotations(a)
+}
+
+func hasController(obj metav1.Object) bool {
+	a := obj.GetAnnotations()
+	if a[RemoteControllerNamespace] == "" {
+		return false
+	}
+
+	if a[RemoteControllerName] == "" {
+		return false
+	}
+
+	if a[RemoteControllerUID] == "" {
+		return false
+	}
+
+	return true
+}
+
+func hasSameController(a, b metav1.Object) bool {
+	// We do not consider two objects without any controller to have
+	// the same controller.
+	if !hasController(a) {
+		return false
+	}
+
+	return a.GetAnnotations()[RemoteControllerUID] == b.GetAnnotations()[RemoteControllerUID]
+}
+
+func ensureNamespace(obj metav1.Object) {
+	if obj.GetNamespace() != "" {
+		return
+	}
+	obj.SetNamespace(corev1.NamespaceDefault)
+}

--- a/pkg/controller/workload/kubernetes/resource/resource_test.go
+++ b/pkg/controller/workload/kubernetes/resource/resource_test.go
@@ -1,0 +1,1487 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/go-test/deep"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	kmeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	computev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/compute/v1alpha1"
+	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/apis/workload/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/test"
+)
+
+const (
+	namespace       = "coolNamespace"
+	name            = "coolAR"
+	uid             = types.UID("definitely-a-uuid")
+	resourceVersion = "coolVersion"
+)
+
+// Frequently used conditions.
+var (
+	deleting = corev1alpha1.Condition{Type: corev1alpha1.Deleting, Status: corev1.ConditionTrue}
+	ready    = corev1alpha1.Condition{Type: corev1alpha1.Ready, Status: corev1.ConditionTrue}
+)
+
+var (
+	errorBoom = errors.New("boom")
+	meta      = metav1.ObjectMeta{
+		Namespace:  namespace,
+		Name:       name,
+		UID:        uid,
+		Finalizers: []string{},
+	}
+	ctx = context.Background()
+
+	cluster = &computev1alpha1.KubernetesCluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "coolCluster"},
+		Status: corev1alpha1.ResourceClaimStatus{
+			CredentialsSecretRef: corev1.LocalObjectReference{Name: secret.GetName()},
+		},
+	}
+
+	apiServerURL, _ = url.Parse("https://example.org")
+	malformedURL    = ":wat:"
+
+	secret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "coolSecret",
+			Namespace: namespace,
+			Annotations: map[string]string{
+				RemoteControllerNamespace: meta.GetNamespace(),
+				RemoteControllerName:      meta.GetName(),
+				RemoteControllerUID:       string(meta.GetUID()),
+			},
+		},
+		Data: map[string][]byte{
+			corev1alpha1.ResourceCredentialsSecretEndpointKey:   []byte(apiServerURL.String()),
+			corev1alpha1.ResourceCredentialsSecretUserKey:       []byte("user"),
+			corev1alpha1.ResourceCredentialsSecretPasswordKey:   []byte("password"),
+			corev1alpha1.ResourceCredentialsSecretCAKey:         []byte("secretCA"),
+			corev1alpha1.ResourceCredentialsSecretClientCertKey: []byte("clientCert"),
+			corev1alpha1.ResourceCredentialsSecretClientKeyKey:  []byte("clientKey"),
+			corev1alpha1.ResourceCredentialsTokenKey:            []byte("token"),
+		},
+	}
+
+	existingSecret = func() *corev1.Secret {
+		s := secret.DeepCopy()
+		s.Data["extrafield"] = []byte("somuchmore!")
+		return s
+	}()
+
+	secretLocalObjectRef = corev1.LocalObjectReference{Name: secret.GetName()}
+
+	serviceWithoutNamespace = &corev1.Service{
+		// Note we purposefully omit the namespace here in order to test our
+		// namespace defaulting logic.
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "coolService",
+			Annotations: map[string]string{
+				RemoteControllerNamespace: meta.GetNamespace(),
+				RemoteControllerName:      meta.GetName(),
+				RemoteControllerUID:       string(meta.GetUID()),
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{Hostname: "coolservice.crossplane.io"},
+				},
+			},
+		},
+	}
+
+	service = func() *corev1.Service {
+		s := serviceWithoutNamespace.DeepCopy()
+		s.SetNamespace(namespace)
+		return s
+	}()
+
+	existingService = func() *corev1.Service {
+		s := service.DeepCopy()
+		s.Spec.Type = corev1.ServiceTypeClusterIP
+		return s
+	}()
+
+	remoteStatus = func() *v1alpha1.RemoteStatus {
+		raw, _ := json.Marshal(serviceWithoutNamespace.Status)
+		return &v1alpha1.RemoteStatus{Raw: json.RawMessage(raw)}
+	}()
+)
+
+func template(s *corev1.Service) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = scheme.Convert(s, u, nil)
+	return u
+}
+
+type kubeARModifier func(*v1alpha1.KubernetesApplicationResource)
+
+func withFinalizers(f ...string) kubeARModifier {
+	return func(r *v1alpha1.KubernetesApplicationResource) { r.ObjectMeta.Finalizers = f }
+}
+
+func withConditions(c ...corev1alpha1.Condition) kubeARModifier {
+	return func(r *v1alpha1.KubernetesApplicationResource) { r.Status.ConditionedStatus.Conditions = c }
+}
+
+func withState(s v1alpha1.KubernetesApplicationResourceState) kubeARModifier {
+	return func(r *v1alpha1.KubernetesApplicationResource) { r.Status.State = s }
+}
+
+func withRemoteStatus(s *v1alpha1.RemoteStatus) kubeARModifier {
+	return func(r *v1alpha1.KubernetesApplicationResource) { r.Status.Remote = s }
+}
+
+func withDeletionTimestamp(t time.Time) kubeARModifier {
+	return func(r *v1alpha1.KubernetesApplicationResource) {
+		r.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: t}
+	}
+}
+
+func withCluster(c *corev1.ObjectReference) kubeARModifier {
+	return func(r *v1alpha1.KubernetesApplicationResource) {
+		r.Status.Cluster = c
+	}
+}
+
+func withSecrets(s ...corev1.LocalObjectReference) kubeARModifier {
+	return func(r *v1alpha1.KubernetesApplicationResource) {
+		r.Spec.Secrets = s
+	}
+}
+
+func withTemplate(t *unstructured.Unstructured) kubeARModifier {
+	return func(r *v1alpha1.KubernetesApplicationResource) {
+		r.Spec.Template = t
+	}
+}
+
+func kubeAR(rm ...kubeARModifier) *v1alpha1.KubernetesApplicationResource {
+	r := &v1alpha1.KubernetesApplicationResource{ObjectMeta: meta}
+
+	for _, m := range rm {
+		m(r)
+	}
+
+	return r
+}
+
+func TestCreatePredicate(t *testing.T) {
+	cases := []struct {
+		name  string
+		event event.CreateEvent
+		want  bool
+	}{
+		{
+			name: "ScheduledCluster",
+			event: event.CreateEvent{
+				Object: &v1alpha1.KubernetesApplicationResource{
+					Status: v1alpha1.KubernetesApplicationResourceStatus{
+						Cluster: cluster.ObjectReference(),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "UnscheduledCluster",
+			event: event.CreateEvent{
+				Object: &v1alpha1.KubernetesApplicationResource{},
+			},
+			want: false,
+		},
+		{
+			name: "NotAKubernetesApplicationResource",
+			event: event.CreateEvent{
+				Object: &v1alpha1.KubernetesApplication{},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CreatePredicate(tc.event)
+			if got != tc.want {
+				t.Errorf("CreatePredicate(...): got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+func TestUpdatePredicate(t *testing.T) {
+	cases := []struct {
+		name  string
+		event event.UpdateEvent
+		want  bool
+	}{
+		{
+			name: "ScheduledCluster",
+			event: event.UpdateEvent{
+				ObjectNew: &v1alpha1.KubernetesApplicationResource{
+					Status: v1alpha1.KubernetesApplicationResourceStatus{
+						Cluster: cluster.ObjectReference(),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "UnscheduledCluster",
+			event: event.UpdateEvent{
+				ObjectNew: &v1alpha1.KubernetesApplicationResource{},
+			},
+			want: false,
+		},
+		{
+			name: "NotAKubernetesApplicationResource",
+			event: event.UpdateEvent{
+				ObjectNew: &v1alpha1.KubernetesApplication{},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := UpdatePredicate(tc.event)
+			if got != tc.want {
+				t.Errorf("UpdatePredicate(...): got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+type mockSyncUnstructuredFn func(ctx context.Context, template *unstructured.Unstructured) (*v1alpha1.RemoteStatus, error)
+
+func newMockSyncUnstructuredFn(s *v1alpha1.RemoteStatus, err error) mockSyncUnstructuredFn {
+	return func(_ context.Context, _ *unstructured.Unstructured) (*v1alpha1.RemoteStatus, error) {
+		return s, err
+	}
+}
+
+type mockDeleteUnstructuredFn func(ctx context.Context, template *unstructured.Unstructured) error
+
+func newMockDeleteUnstructuredFn(err error) mockDeleteUnstructuredFn {
+	return func(_ context.Context, _ *unstructured.Unstructured) error {
+		return err
+	}
+}
+
+type mockUnstructuredClient struct {
+	mockSync   mockSyncUnstructuredFn
+	mockDelete mockDeleteUnstructuredFn
+}
+
+func (m *mockUnstructuredClient) sync(ctx context.Context, template *unstructured.Unstructured) (*v1alpha1.RemoteStatus, error) {
+	return m.mockSync(ctx, template)
+}
+
+func (m *mockUnstructuredClient) delete(ctx context.Context, template *unstructured.Unstructured) error {
+	return m.mockDelete(ctx, template)
+}
+
+type mockSyncSecretFn func(ctx context.Context, template *corev1.Secret) error
+
+func newMockSyncSecretFn(err error) mockSyncSecretFn {
+	return func(ctx context.Context, template *corev1.Secret) error { return err }
+}
+
+type mockDeleteSecretFn func(ctx context.Context, template *corev1.Secret) error
+
+func newMockDeleteSecretFn(err error) mockDeleteSecretFn {
+	return func(ctx context.Context, template *corev1.Secret) error { return err }
+}
+
+type mockSecretClient struct {
+	mockSync   mockSyncSecretFn
+	mockDelete mockDeleteSecretFn
+}
+
+func (m *mockSecretClient) sync(ctx context.Context, template *corev1.Secret) error {
+	return m.mockSync(ctx, template)
+}
+
+func (m *mockSecretClient) delete(ctx context.Context, template *corev1.Secret) error {
+	return m.mockDelete(ctx, template)
+}
+
+func TestSync(t *testing.T) {
+	cases := []struct {
+		name       string
+		syncer     syncer
+		ar         *v1alpha1.KubernetesApplicationResource
+		secrets    []corev1.Secret
+		wantAR     *v1alpha1.KubernetesApplicationResource
+		wantResult reconcile.Result
+	}{
+		{
+			name: "Successful",
+			syncer: &remoteCluster{
+				unstructured: &mockUnstructuredClient{
+					mockSync: func(_ context.Context, got *unstructured.Unstructured) (*v1alpha1.RemoteStatus, error) {
+						want := template(serviceWithoutNamespace)
+						want.SetNamespace(corev1.NamespaceDefault)
+						want.SetAnnotations(map[string]string{
+							RemoteControllerNamespace: meta.GetNamespace(),
+							RemoteControllerName:      meta.GetName(),
+							RemoteControllerUID:       string(meta.GetUID()),
+						})
+						if diff := deep.Equal(want, got); diff != nil {
+							return nil, errors.Errorf("mockSync: want != got: %s", diff)
+						}
+
+						return remoteStatus, nil
+					},
+				},
+				secret: &mockSecretClient{
+					mockSync: func(_ context.Context, got *corev1.Secret) error {
+						want := secret.DeepCopy()
+						want.SetName(fmt.Sprintf("%s-%s", meta.GetName(), secret.GetName()))
+						want.SetNamespace(corev1.NamespaceDefault)
+						want.SetAnnotations(map[string]string{
+							RemoteControllerNamespace: meta.GetNamespace(),
+							RemoteControllerName:      meta.GetName(),
+							RemoteControllerUID:       string(meta.GetUID()),
+						})
+						if diff := deep.Equal(want, got); diff != nil {
+							return errors.Errorf("mockSync: want != got: %s", diff)
+						}
+
+						return nil
+					},
+				},
+			},
+			ar:      kubeAR(withTemplate(template(serviceWithoutNamespace))),
+			secrets: []corev1.Secret{*secret},
+			wantAR: kubeAR(
+				withTemplate(template(serviceWithoutNamespace)),
+				withFinalizers(finalizerName),
+				withConditions(ready),
+				withState(v1alpha1.KubernetesApplicationResourceStateSubmitted),
+				withRemoteStatus(remoteStatus),
+			),
+			wantResult: reconcile.Result{Requeue: false},
+		},
+		{
+			name:   "MissingTemplate",
+			syncer: &remoteCluster{},
+			ar:     kubeAR(),
+			wantAR: kubeAR(
+				withFinalizers(finalizerName),
+				withConditions(
+					corev1alpha1.Condition{
+						Type:    corev1alpha1.Failed,
+						Status:  corev1.ConditionTrue,
+						Reason:  reasonSyncingResource,
+						Message: messageMissingTemplate,
+					},
+				),
+				withState(v1alpha1.KubernetesApplicationResourceStateFailed),
+			),
+			wantResult: reconcile.Result{Requeue: true},
+		},
+		{
+			name: "SecretSyncFailed",
+			syncer: &remoteCluster{
+				secret: &mockSecretClient{mockSync: newMockSyncSecretFn(errorBoom)},
+			},
+			ar:      kubeAR(withTemplate(template(serviceWithoutNamespace))),
+			secrets: []corev1.Secret{*secret},
+			wantAR: kubeAR(
+				withTemplate(template(serviceWithoutNamespace)),
+				withFinalizers(finalizerName),
+				withConditions(
+					corev1alpha1.Condition{
+						Type:    corev1alpha1.Failed,
+						Status:  corev1.ConditionTrue,
+						Reason:  reasonSyncingSecret,
+						Message: errorBoom.Error(),
+					},
+				),
+				withState(v1alpha1.KubernetesApplicationResourceStateFailed),
+			),
+			wantResult: reconcile.Result{Requeue: true},
+		},
+		{
+			name: "ResourceSyncFailed",
+			syncer: &remoteCluster{
+				unstructured: &mockUnstructuredClient{mockSync: newMockSyncUnstructuredFn(nil, errorBoom)},
+			},
+			ar: kubeAR(withTemplate(template(serviceWithoutNamespace))),
+			wantAR: kubeAR(
+				withTemplate(template(serviceWithoutNamespace)),
+				withFinalizers(finalizerName),
+				withConditions(
+					corev1alpha1.Condition{
+						Type:    corev1alpha1.Failed,
+						Status:  corev1.ConditionTrue,
+						Reason:  reasonSyncingResource,
+						Message: errorBoom.Error(),
+					},
+				),
+				withState(v1alpha1.KubernetesApplicationResourceStateFailed),
+			),
+			wantResult: reconcile.Result{Requeue: true},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotResult := tc.syncer.sync(ctx, tc.ar, tc.secrets)
+
+			if diff := deep.Equal(tc.wantResult, gotResult); diff != nil {
+				t.Errorf("tc.syncer.sync(...): want != got:\n%s", diff)
+			}
+
+			if diff := deep.Equal(tc.wantAR, tc.ar); diff != nil {
+				t.Errorf("app: want != got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	cases := []struct {
+		name       string
+		deleter    deleter
+		ar         *v1alpha1.KubernetesApplicationResource
+		secrets    []corev1.Secret
+		wantAR     *v1alpha1.KubernetesApplicationResource
+		wantResult reconcile.Result
+	}{
+		{
+			name: "Successful",
+			deleter: &remoteCluster{
+				unstructured: &mockUnstructuredClient{
+					mockDelete: func(_ context.Context, got *unstructured.Unstructured) error {
+						want := template(service)
+						want.SetAnnotations(map[string]string{
+							RemoteControllerNamespace: meta.GetNamespace(),
+							RemoteControllerName:      meta.GetName(),
+							RemoteControllerUID:       string(meta.GetUID()),
+						})
+						if diff := deep.Equal(want, got); diff != nil {
+							errors.Errorf("unstructured mockDelete: want != got: %s", diff)
+						}
+
+						return nil
+					},
+				},
+				secret: &mockSecretClient{
+					mockDelete: func(_ context.Context, got *corev1.Secret) error {
+						want := secret.DeepCopy()
+						want.SetName(fmt.Sprintf("%s-%s", meta.GetName(), secret.GetName()))
+						want.SetNamespace(service.GetNamespace())
+						want.SetAnnotations(map[string]string{
+							RemoteControllerNamespace: meta.GetNamespace(),
+							RemoteControllerName:      meta.GetName(),
+							RemoteControllerUID:       string(meta.GetUID()),
+						})
+						if diff := deep.Equal(want, got); diff != nil {
+							return errors.Errorf("secret mockDelete: want != got: %s", diff)
+						}
+
+						return nil
+					},
+				},
+			},
+			ar: kubeAR(
+				withFinalizers(finalizerName),
+				withTemplate(template(service)),
+			),
+			secrets: []corev1.Secret{*secret},
+			wantAR: kubeAR(
+				withConditions(deleting),
+				withTemplate(template(service)),
+			),
+			wantResult: reconcile.Result{Requeue: false},
+		},
+		{
+			name:    "MissingTemplate",
+			deleter: &remoteCluster{},
+			ar: kubeAR(
+				withFinalizers(finalizerName),
+			),
+			wantAR: kubeAR(
+				withFinalizers(finalizerName),
+				withConditions(
+					deleting,
+					corev1alpha1.Condition{
+						Type:    corev1alpha1.Failed,
+						Status:  corev1.ConditionTrue,
+						Reason:  reasonDeletingResource,
+						Message: messageMissingTemplate,
+					},
+				),
+				withState(v1alpha1.KubernetesApplicationResourceStateFailed),
+			),
+			wantResult: reconcile.Result{Requeue: true},
+		},
+		{
+			name: "SecretDeleteFailed",
+			deleter: &remoteCluster{
+				unstructured: &mockUnstructuredClient{mockDelete: newMockDeleteUnstructuredFn(nil)},
+				secret:       &mockSecretClient{mockDelete: newMockDeleteSecretFn(errorBoom)},
+			},
+			ar: kubeAR(
+				withFinalizers(finalizerName),
+				withTemplate(template(serviceWithoutNamespace)),
+			),
+			secrets: []corev1.Secret{*secret},
+			wantAR: kubeAR(
+				withFinalizers(finalizerName),
+				withTemplate(template(serviceWithoutNamespace)),
+				withConditions(
+					deleting,
+					corev1alpha1.Condition{
+						Type:    corev1alpha1.Failed,
+						Status:  corev1.ConditionTrue,
+						Reason:  reasonDeletingSecret,
+						Message: errorBoom.Error(),
+					},
+				),
+				withState(v1alpha1.KubernetesApplicationResourceStateFailed),
+			),
+			wantResult: reconcile.Result{Requeue: true},
+		},
+		{
+			name: "ResourceDeleteFailed",
+			deleter: &remoteCluster{
+				unstructured: &mockUnstructuredClient{mockDelete: newMockDeleteUnstructuredFn(errorBoom)},
+			},
+			ar: kubeAR(
+				withFinalizers(finalizerName),
+				withTemplate(template(serviceWithoutNamespace)),
+			),
+			wantAR: kubeAR(
+				withFinalizers(finalizerName),
+				withTemplate(template(serviceWithoutNamespace)),
+				withConditions(
+					deleting,
+					corev1alpha1.Condition{
+						Type:    corev1alpha1.Failed,
+						Status:  corev1.ConditionTrue,
+						Reason:  reasonDeletingResource,
+						Message: errorBoom.Error(),
+					},
+				),
+				withState(v1alpha1.KubernetesApplicationResourceStateFailed),
+			),
+			wantResult: reconcile.Result{Requeue: true},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotResult := tc.deleter.delete(ctx, tc.ar, tc.secrets)
+
+			if diff := deep.Equal(tc.wantResult, gotResult); diff != nil {
+				t.Errorf("tc.deleter.delete(...): want != got:\n%s", diff)
+			}
+
+			if diff := deep.Equal(tc.wantAR, tc.ar); diff != nil {
+				t.Errorf("AR: want != got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSyncUnstructured(t *testing.T) {
+	cases := []struct {
+		name         string
+		unstructured unstructuredSyncer
+		template     *unstructured.Unstructured
+		wantStatus   *v1alpha1.RemoteStatus
+		wantErr      error
+	}{
+		{
+			name: "Successful",
+			unstructured: &unstructuredClient{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj runtime.Object) error {
+						// The existing service is slightly different from the
+						// updated service because CreateOrUpdate does not call
+						// Update if the object did not change.
+						existing := template(existingService)
+						existing.SetResourceVersion(resourceVersion)
+						*obj.(*unstructured.Unstructured) = *existing
+						return nil
+					},
+					MockUpdate: func(_ context.Context, obj runtime.Object) error {
+						// We compare resource versions to ensure we preserved
+						// the existing service's important object metadata.
+						want := resourceVersion
+						got := obj.(*unstructured.Unstructured).GetResourceVersion()
+						if got != want {
+							return errors.Errorf("MockUpdate: obj.GetResourceVersion(): want %s, got %s", want, got)
+						}
+						return nil
+					},
+				},
+			},
+			template:   template(service),
+			wantStatus: remoteStatus,
+			wantErr:    nil,
+		},
+		{
+			name: "ExistingResourceHasDifferentController",
+			unstructured: &unstructuredClient{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj runtime.Object) error {
+						existing := template(existingService)
+						existing.SetAnnotations(map[string]string{})
+						*obj.(*unstructured.Unstructured) = *existing
+						return nil
+					},
+				},
+			},
+			template:   template(service),
+			wantStatus: nil,
+			wantErr: errors.WithStack(errors.Errorf("cannot sync resource: could not mutate object for update: Service %s/%s exists and is not controlled by %s %s",
+				existingService.GetNamespace(),
+				existingService.GetName(),
+				v1alpha1.KubernetesApplicationResourceKind,
+				meta.GetName(),
+			)),
+		},
+		{
+			name: "CreateOrUpdateFailed",
+			unstructured: &unstructuredClient{
+				kube: &test.MockClient{MockGet: test.NewMockGetFn(errorBoom)},
+			},
+			template:   template(service),
+			wantStatus: nil,
+			wantErr:    errors.Wrap(errorBoom, "cannot sync resource: could not get object"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotStatus, gotErr := tc.unstructured.sync(ctx, tc.template)
+
+			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+				t.Errorf("tc.unstructured.sync(...): want error != got error:\n%s", diff)
+			}
+
+			if diff := deep.Equal(tc.wantStatus, gotStatus); diff != nil {
+				t.Errorf("tc.unstructured.sync(...): want != got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetRemoteStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		remote runtime.Unstructured
+		want   *v1alpha1.RemoteStatus
+	}{
+		{
+			name:   "Successful",
+			remote: template(service),
+			want:   remoteStatus,
+		},
+		{
+			name:   "MissingStatus",
+			remote: &unstructured.Unstructured{},
+			want:   nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getRemoteStatus(tc.remote)
+			if diff := deep.Equal(tc.want, got); diff != nil {
+				t.Errorf("getRemoteStatus(...): want != got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDeleteUnstructured(t *testing.T) {
+	cases := []struct {
+		name         string
+		unstructured unstructuredDeleter
+		template     *unstructured.Unstructured
+		wantErr      error
+	}{
+		{
+			name: "Successful",
+			unstructured: &unstructuredClient{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj runtime.Object) error {
+						*obj.(*unstructured.Unstructured) = *(template(existingService))
+						return nil
+					},
+					MockDelete: test.NewMockDeleteFn(nil),
+				},
+			},
+			template: template(service),
+			wantErr:  nil,
+		},
+		{
+			name: "ExistingResourceNotFound",
+			unstructured: &unstructuredClient{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
+						return kerrors.NewNotFound(schema.GroupResource{}, key.Name)
+					},
+				},
+			},
+			template: template(service),
+		},
+		{
+			name: "ExistingResourceHasNoRemoteController",
+			unstructured: &unstructuredClient{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj runtime.Object) error {
+						existing := template(existingService)
+						existing.SetAnnotations(map[string]string{})
+						*obj.(*unstructured.Unstructured) = *existing
+						return nil
+					},
+				},
+			},
+			template: template(service),
+		},
+		{
+			name: "GetExistingResourceFailed",
+			unstructured: &unstructuredClient{
+				kube: &test.MockClient{MockGet: test.NewMockGetFn(errorBoom)},
+			},
+			template: template(service),
+			wantErr:  errors.Wrapf(errorBoom, "cannot get resource %s/%s", service.GetNamespace(), service.GetName()),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotErr := tc.unstructured.delete(ctx, tc.template)
+
+			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+				t.Errorf("tc.unstructured.delete(...): want error != got error:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSyncSecret(t *testing.T) {
+	cases := []struct {
+		name     string
+		secret   secretSyncer
+		template *corev1.Secret
+		wantErr  error
+	}{
+		{
+			name: "Successful",
+			secret: &secretClient{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj runtime.Object) error {
+						// The existing service is slightly different from the
+						// updated service because CreateOrUpdate does not call
+						// Update if the object did not change.
+						existing := existingSecret.DeepCopy()
+						existing.SetResourceVersion(resourceVersion)
+						*obj.(*corev1.Secret) = *existing
+						return nil
+					},
+					MockUpdate: func(_ context.Context, obj runtime.Object) error {
+						// We compare resource versions to ensure we preserved
+						// the existing service's important object metadata.
+						want := resourceVersion
+						got := obj.(*corev1.Secret).GetResourceVersion()
+						if got != want {
+							return errors.Errorf("MockUpdate: obj.GetResourceVersion(): want %s, got %s", want, got)
+						}
+						return nil
+					},
+				},
+			},
+			template: secret,
+			wantErr:  nil,
+		},
+		{
+			name: "ExistingResourceHasDifferentController",
+			secret: &secretClient{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj runtime.Object) error {
+						existing := existingSecret.DeepCopy()
+						existing.SetAnnotations(map[string]string{})
+						*obj.(*corev1.Secret) = *existing
+						return nil
+					},
+				},
+			},
+			template: secret,
+			wantErr: errors.WithStack(errors.Errorf("cannot sync secret: could not mutate object for update: secret %s/%s exists and is not controlled by %s %s",
+				existingSecret.GetNamespace(),
+				existingSecret.GetName(),
+				v1alpha1.KubernetesApplicationResourceKind,
+				meta.GetName(),
+			)),
+		},
+		{
+			name: "CreateOrUpdateFailed",
+			secret: &secretClient{
+				kube: &test.MockClient{
+					MockGet: test.NewMockGetFn(errorBoom),
+				},
+			},
+			template: secret,
+			wantErr:  errors.Wrap(errorBoom, "cannot sync secret: could not get object"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotErr := tc.secret.sync(ctx, tc.template)
+
+			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+				t.Errorf("tc.unstructured.sync(...): want error != got error:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDeleteSecret(t *testing.T) {
+	cases := []struct {
+		name     string
+		secret   secretDeleter
+		template *corev1.Secret
+		wantErr  error
+	}{
+		{
+			name: "Successful",
+			secret: &secretClient{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj runtime.Object) error {
+						*obj.(*corev1.Secret) = *existingSecret
+						return nil
+					},
+					MockDelete: test.NewMockDeleteFn(nil),
+				},
+			},
+			template: secret,
+			wantErr:  nil,
+		},
+		{
+			name: "ExistingResourceNotFound",
+			secret: &secretClient{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
+						return kerrors.NewNotFound(schema.GroupResource{}, key.Name)
+					},
+				},
+			},
+			template: secret,
+		},
+		{
+			name: "ExistingResourceHasNoRemoteController",
+			secret: &secretClient{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj runtime.Object) error {
+						existing := existingSecret
+						existing.SetAnnotations(map[string]string{})
+						*obj.(*corev1.Secret) = *existing
+						return nil
+					},
+				},
+			},
+			template: secret,
+		},
+		{
+			name: "GetExistingResourceFailed",
+			secret: &secretClient{
+				kube: &test.MockClient{MockGet: test.NewMockGetFn(errorBoom)},
+			},
+			template: secret,
+			wantErr:  errors.Wrapf(errorBoom, "cannot get secret %s/%s", secret.GetNamespace(), secret.GetName()),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotErr := tc.secret.delete(ctx, tc.template)
+
+			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+				t.Errorf("tc.secret.delete(...): want error != got error:\n%s", diff)
+			}
+		})
+	}
+}
+
+// We pass in a mock RESTMapper when testing in order to prevent
+// client.New() trying to create one itself, because creating a new
+// RESTMapper involves connecting to the API server.
+type mockRESTMapper struct {
+	kmeta.RESTMapper
+}
+
+func TestConnectConfig(t *testing.T) {
+	cases := []struct {
+		name       string
+		connecter  *clusterConnecter
+		ar         *v1alpha1.KubernetesApplicationResource
+		wantConfig *rest.Config
+		wantErr    error
+	}{
+		{
+			name: "Successful",
+			connecter: &clusterConnecter{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, got client.ObjectKey, obj runtime.Object) error {
+						switch actual := obj.(type) {
+						case *computev1alpha1.KubernetesCluster:
+							want := client.ObjectKey{
+								Namespace: cluster.GetNamespace(),
+								Name:      cluster.GetName(),
+							}
+							if diff := deep.Equal(want, got); diff != nil {
+								return errors.Errorf("MockGet(Secret): want != got: %s", diff)
+							}
+							*actual = *cluster
+
+						case *corev1.Secret:
+							want := client.ObjectKey{
+								Namespace: cluster.GetNamespace(),
+								Name:      secret.GetName(),
+							}
+							if diff := deep.Equal(want, got); diff != nil {
+								return errors.Errorf("MockGet(Secret): want != got: %s", diff)
+							}
+
+							*actual = *secret
+
+						}
+						return nil
+					},
+				},
+				options: client.Options{Mapper: mockRESTMapper{}},
+			},
+			ar: kubeAR(withCluster(cluster.ObjectReference())),
+			wantConfig: &rest.Config{
+				Host:     apiServerURL.String(),
+				Username: string(secret.Data[corev1alpha1.ResourceCredentialsSecretUserKey]),
+				Password: string(secret.Data[corev1alpha1.ResourceCredentialsSecretPasswordKey]),
+				TLSClientConfig: rest.TLSClientConfig{
+					ServerName: apiServerURL.Hostname(),
+					CAData:     secret.Data[corev1alpha1.ResourceCredentialsSecretCAKey],
+					CertData:   secret.Data[corev1alpha1.ResourceCredentialsSecretClientCertKey],
+					KeyData:    secret.Data[corev1alpha1.ResourceCredentialsSecretClientKeyKey],
+				},
+				BearerToken: string(secret.Data[corev1alpha1.ResourceCredentialsTokenKey]),
+			},
+			wantErr: nil,
+		},
+		{
+			name:      "KubernetesApplicationResourceNotScheduled",
+			connecter: &clusterConnecter{},
+			ar:        kubeAR(),
+			wantErr: errors.Errorf("%s %s/%s is not scheduled",
+				v1alpha1.KubernetesApplicationResourceKind, meta.GetNamespace(), meta.GetName()),
+		},
+		{
+			name: "GetKubernetesClusterFailed",
+			connecter: &clusterConnecter{
+				kube:    &test.MockClient{MockGet: test.NewMockGetFn(errorBoom)},
+				options: client.Options{Mapper: mockRESTMapper{}},
+			},
+			ar: kubeAR(withCluster(cluster.ObjectReference())),
+			wantErr: errors.Wrapf(errorBoom, "cannot get %s %s/%s",
+				computev1alpha1.KubernetesClusterKind, cluster.GetNamespace(), cluster.GetName()),
+		},
+		{
+			name: "GetConnectionSecretFailed",
+			connecter: &clusterConnecter{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj runtime.Object) error {
+						switch actual := obj.(type) {
+						case *computev1alpha1.KubernetesCluster:
+							*actual = *cluster
+						case *corev1.Secret:
+							return errorBoom
+						}
+						return nil
+					},
+				},
+				options: client.Options{Mapper: mockRESTMapper{}},
+			},
+			ar:      kubeAR(withCluster(cluster.ObjectReference())),
+			wantErr: errors.Wrapf(errorBoom, "cannot get secret %s/%s", secret.GetNamespace(), secret.GetName()),
+		},
+		{
+			name: "ParseEndpointFailed",
+			connecter: &clusterConnecter{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj runtime.Object) error {
+						if actual, ok := obj.(*corev1.Secret); ok {
+							s := secret.DeepCopy()
+							s.Data[corev1alpha1.ResourceCredentialsSecretEndpointKey] = []byte(malformedURL)
+							*actual = *s
+						}
+						return nil
+					},
+				},
+				options: client.Options{Mapper: mockRESTMapper{}},
+			},
+			ar:      kubeAR(withCluster(cluster.ObjectReference())),
+			wantErr: errors.WithStack(errors.Errorf("cannot parse Kubernetes endpoint as URL: parse %s: missing protocol scheme", malformedURL)),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotConfig, gotErr := tc.connecter.config(ctx, tc.ar)
+
+			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+				t.Errorf("tc.connecter.config(...): want error != got error:\n%s", diff)
+			}
+
+			if diff := deep.Equal(tc.wantConfig, gotConfig); diff != nil {
+				t.Errorf("tc.connecter.config(...): want != got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestConnect(t *testing.T) {
+	cases := []struct {
+		name      string
+		connecter connecter
+		ar        *v1alpha1.KubernetesApplicationResource
+		wantSD    syncdeleter
+		wantErr   error
+	}{
+		{
+			name: "Successful",
+			connecter: &clusterConnecter{
+				kube:    &test.MockClient{MockGet: test.NewMockGetFn(nil)},
+				options: client.Options{Mapper: mockRESTMapper{}},
+			},
+			ar: kubeAR(withCluster(cluster.ObjectReference())),
+
+			// This empty struct is 'identical' to the actual, populated struct
+			// returned by tc.connecter.connect() because deep.Equal does not
+			// compare unexported fields by default. We don't inspect these
+			// unexported fields because doing so would mostly be testing
+			// controller-runtime's client.New() code, not ours.
+			wantSD:  &remoteCluster{},
+			wantErr: nil,
+		},
+		{
+			name: "ConfigFailure",
+			connecter: &clusterConnecter{
+				kube: &test.MockClient{MockGet: test.NewMockGetFn(errorBoom)},
+			},
+			ar: kubeAR(withCluster(cluster.ObjectReference())),
+			wantErr: errors.Wrapf(errorBoom, "cannot create Kubernetes client configuration: cannot get %s %s/%s",
+				computev1alpha1.KubernetesClusterKind, cluster.GetNamespace(), cluster.GetName()),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			gotSD, gotErr := tc.connecter.connect(ctx, tc.ar)
+
+			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+				t.Errorf("tc.connecter.connect(...): want error != got error:\n%s", diff)
+			}
+
+			if diff := deep.Equal(tc.wantSD, gotSD); diff != nil {
+				t.Errorf("tc.connecter.connect(...): want != got:\n%s", diff)
+			}
+		})
+	}
+}
+
+type mockSyncFn func(ctx context.Context, ar *v1alpha1.KubernetesApplicationResource, secrets []corev1.Secret) reconcile.Result
+
+func newMockSyncFn(r reconcile.Result) mockSyncFn {
+	return func(ctx context.Context, ar *v1alpha1.KubernetesApplicationResource, secrets []corev1.Secret) reconcile.Result {
+		return r
+	}
+}
+
+type mockDeleteFn func(ctx context.Context, ar *v1alpha1.KubernetesApplicationResource, secrets []corev1.Secret) reconcile.Result
+
+func newMockDeleteFn(r reconcile.Result) mockDeleteFn {
+	return func(ctx context.Context, ar *v1alpha1.KubernetesApplicationResource, secrets []corev1.Secret) reconcile.Result {
+		return r
+	}
+}
+
+type mockSyncDeleter struct {
+	mockSync   mockSyncFn
+	mockDelete mockDeleteFn
+}
+
+func (m *mockSyncDeleter) sync(ctx context.Context, ar *v1alpha1.KubernetesApplicationResource, secrets []corev1.Secret) reconcile.Result {
+	return m.mockSync(ctx, ar, secrets)
+}
+
+func (m *mockSyncDeleter) delete(ctx context.Context, ar *v1alpha1.KubernetesApplicationResource, secrets []corev1.Secret) reconcile.Result {
+	return m.mockDelete(ctx, ar, secrets)
+}
+
+var noopSyncDeleter = &mockSyncDeleter{
+	mockSync:   newMockSyncFn(reconcile.Result{Requeue: false}),
+	mockDelete: newMockDeleteFn(reconcile.Result{Requeue: false}),
+}
+
+type mockConnectFn func(ctx context.Context, ar *v1alpha1.KubernetesApplicationResource) (syncdeleter, error)
+
+func newMockConnectFn(sd syncdeleter, err error) mockConnectFn {
+	return func(ctx context.Context, ar *v1alpha1.KubernetesApplicationResource) (syncdeleter, error) {
+		return sd, err
+	}
+}
+
+type mockConnecter struct {
+	mockConnect mockConnectFn
+}
+
+func (m *mockConnecter) connect(ctx context.Context, ar *v1alpha1.KubernetesApplicationResource) (syncdeleter, error) {
+	return m.mockConnect(ctx, ar)
+}
+
+func TestReconcile(t *testing.T) {
+	cases := []struct {
+		name       string
+		rec        *Reconciler
+		req        reconcile.Request
+		wantResult reconcile.Result
+		wantErr    error
+	}{
+		{
+			name: "FailedToGetNonExistentKubernetesApplication",
+			rec: &Reconciler{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, _ runtime.Object) error {
+						return kerrors.NewNotFound(schema.GroupResource{}, key.Name)
+					},
+				},
+			},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+			wantResult: reconcile.Result{Requeue: false},
+			wantErr:    nil,
+		},
+		{
+			name: "FailedToGetExtantKubernetesApplication",
+			rec: &Reconciler{
+				kube: &test.MockClient{MockGet: test.NewMockGetFn(errorBoom)},
+			},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+			wantResult: reconcile.Result{Requeue: false},
+			wantErr:    errors.Wrapf(errorBoom, "cannot get %s %s/%s", v1alpha1.KubernetesApplicationResourceKind, namespace, name),
+		},
+		{
+			name: "FailedToConnect",
+			rec: &Reconciler{
+				connecter: &mockConnecter{mockConnect: newMockConnectFn(nil, errorBoom)},
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj runtime.Object) error {
+						*obj.(*v1alpha1.KubernetesApplicationResource) = *(kubeAR())
+						return nil
+					},
+					MockUpdate: func(_ context.Context, obj runtime.Object) error {
+						got := obj.(*v1alpha1.KubernetesApplicationResource)
+
+						want := kubeAR(
+							withConditions(
+								corev1alpha1.Condition{
+									Type:    corev1alpha1.Failed,
+									Status:  corev1.ConditionTrue,
+									Reason:  reasonFetchingClient,
+									Message: errorBoom.Error(),
+								},
+							),
+						)
+
+						if diff := deep.Equal(want, got); diff != nil {
+							return errors.Errorf("MockUpdate: want != got: %s", diff)
+						}
+
+						return nil
+					},
+				},
+			},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+			wantResult: reconcile.Result{Requeue: true},
+		},
+		{
+			name: "ApplicationDeletedSuccessfully",
+			rec: &Reconciler{
+				connecter: &mockConnecter{mockConnect: newMockConnectFn(noopSyncDeleter, nil)},
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj runtime.Object) error {
+						*obj.(*v1alpha1.KubernetesApplicationResource) = *(kubeAR(withDeletionTimestamp(time.Now())))
+						return nil
+					},
+					MockUpdate: test.NewMockUpdateFn(nil),
+				},
+			},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+			wantResult: reconcile.Result{Requeue: false},
+		},
+
+		{
+			name: "ApplicationDeleteFailure",
+			rec: &Reconciler{
+				connecter: &mockConnecter{mockConnect: newMockConnectFn(noopSyncDeleter, nil)},
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj runtime.Object) error {
+						*obj.(*v1alpha1.KubernetesApplicationResource) = *(kubeAR(withDeletionTimestamp(time.Now())))
+						return nil
+					},
+					MockUpdate: test.NewMockUpdateFn(errorBoom),
+				},
+			},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+			wantResult: reconcile.Result{Requeue: false},
+			wantErr:    errors.Wrapf(errorBoom, "cannot update %s %s/%s", v1alpha1.KubernetesApplicationResourceKind, namespace, name),
+		},
+		{
+			name: "ApplicationSyncedSuccessfully",
+			rec: &Reconciler{
+				connecter: &mockConnecter{mockConnect: newMockConnectFn(noopSyncDeleter, nil)},
+				kube:      &test.MockClient{MockGet: test.NewMockGetFn(nil), MockUpdate: test.NewMockUpdateFn(nil)},
+			},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+			wantResult: reconcile.Result{Requeue: false},
+		},
+		{
+			name: "ApplicationSyncFailure",
+			rec: &Reconciler{
+				connecter: &mockConnecter{mockConnect: newMockConnectFn(noopSyncDeleter, nil)},
+				kube:      &test.MockClient{MockGet: test.NewMockGetFn(nil), MockUpdate: test.NewMockUpdateFn(errorBoom)},
+			},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+			wantResult: reconcile.Result{Requeue: false},
+			wantErr:    errors.Wrapf(errorBoom, "cannot update %s %s/%s", v1alpha1.KubernetesApplicationResourceKind, namespace, name),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotResult, gotErr := tc.rec.Reconcile(tc.req)
+
+			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
+			}
+
+			if diff := deep.Equal(tc.wantResult, gotResult); diff != nil {
+				t.Errorf("tc.rec.Reconcile(...): want != got:\n%s", diff)
+			}
+		})
+	}
+}
+func TestGetConnectionSecrets(t *testing.T) {
+	cases := []struct {
+		name        string
+		rec         *Reconciler
+		ar          *v1alpha1.KubernetesApplicationResource
+		wantAR      *v1alpha1.KubernetesApplicationResource
+		wantSecrets []corev1.Secret
+	}{
+		{
+			name: "Successful",
+			rec: &Reconciler{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, _ client.ObjectKey, obj runtime.Object) error {
+						*obj.(*corev1.Secret) = *secret
+						return nil
+					},
+				},
+			},
+			ar: kubeAR(
+				withSecrets(secretLocalObjectRef),
+			),
+			wantAR: kubeAR(
+				withSecrets(secretLocalObjectRef),
+			),
+			wantSecrets: []corev1.Secret{*secret},
+		},
+		{
+			name: "Failed",
+			rec: &Reconciler{
+				kube: &test.MockClient{MockGet: test.NewMockGetFn(errorBoom)},
+			},
+			ar: kubeAR(
+				withSecrets(secretLocalObjectRef),
+			),
+			wantAR: kubeAR(
+				withSecrets(secretLocalObjectRef),
+				withConditions(
+					corev1alpha1.Condition{
+						Type:    corev1alpha1.Failed,
+						Status:  corev1.ConditionTrue,
+						Reason:  reasonGettingSecret,
+						Message: errorBoom.Error(),
+					},
+				),
+			),
+			wantSecrets: []corev1.Secret{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotSecrets := tc.rec.getConnectionSecrets(ctx, tc.ar)
+
+			if diff := deep.Equal(tc.wantSecrets, gotSecrets); diff != nil {
+				t.Errorf("tc.rec.getConnectionSecrets(...): want != got:\n%s", diff)
+			}
+
+			if diff := deep.Equal(tc.wantAR, tc.ar); diff != nil {
+				t.Errorf("AR: want != got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestHasController(t *testing.T) {
+	cases := []struct {
+		name string
+		obj  metav1.Object
+		want bool
+	}{
+		{
+			name: "HasController",
+			obj:  service,
+			want: true,
+		},
+		{
+			name: "MissingNamespace",
+			obj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						RemoteControllerName: name,
+						RemoteControllerUID:  string(uid),
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "MissingName",
+			obj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						RemoteControllerNamespace: namespace,
+						RemoteControllerUID:       string(uid),
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "MissingUID",
+			obj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						RemoteControllerNamespace: namespace,
+						RemoteControllerName:      name,
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hasController(tc.obj)
+			if got != tc.want {
+				t.Errorf("hasController(...): want %t, got %t", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestHasSameController(t *testing.T) {
+	cases := []struct {
+		name string
+		a    metav1.Object
+		b    metav1.Object
+		want bool
+	}{
+		{
+			name: "HasSameController",
+			a:    service,
+			b:    existingService,
+			want: true,
+		},
+		{
+			name: "HasNoController",
+			a:    &corev1.Service{},
+			b:    existingService,
+			want: false,
+		},
+		{
+			name: "HasDifferentController",
+			a:    service,
+			b: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						RemoteControllerNamespace: namespace,
+						RemoteControllerName:      name,
+						RemoteControllerUID:       "imdifferent!",
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hasSameController(tc.a, tc.b)
+			if got != tc.want {
+				t.Errorf("hasController(...): want %t, got %t", tc.want, got)
+			}
+		})
+	}
+}

--- a/pkg/controller/workload/kubernetes/scheduler/scheduler.go
+++ b/pkg/controller/workload/kubernetes/scheduler/scheduler.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License
+*/
+
+package scheduler
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	computev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/compute/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/apis/workload/v1alpha1"
+	workloadv1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/workload/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/controller/core"
+	"github.com/crossplaneio/crossplane/pkg/logging"
+)
+
+const (
+	controllerName   = "scheduler.workload.crossplane.io"
+	reconcileTimeout = 1 * time.Minute
+
+	reasonUnschedulable = "failed to schedule " + workloadv1alpha1.KubernetesApplicationKind
+	errorNoclusters     = "no clusters matched label selector"
+)
+
+var log = logging.Logger.WithName("controller." + controllerName)
+
+type scheduler interface {
+	schedule(ctx context.Context, app *workloadv1alpha1.KubernetesApplication) reconcile.Result
+}
+
+type roundRobinScheduler struct {
+	kube             client.Client
+	lastClusterIndex uint64
+}
+
+func (s *roundRobinScheduler) schedule(ctx context.Context, app *workloadv1alpha1.KubernetesApplication) reconcile.Result {
+	app.Status.State = workloadv1alpha1.KubernetesApplicationStatePending
+	app.Status.SetPending()
+
+	sel, err := metav1.LabelSelectorAsSelector(app.Spec.ClusterSelector)
+	if err != nil {
+		app.Status.SetFailed(reasonUnschedulable, err.Error())
+		return reconcile.Result{Requeue: true}
+	}
+
+	clusters := &computev1alpha1.KubernetesClusterList{}
+	if err := s.kube.List(ctx, &client.ListOptions{LabelSelector: sel}, clusters); err != nil {
+		app.Status.SetFailed(reasonUnschedulable, err.Error())
+		return reconcile.Result{Requeue: true}
+	}
+
+	if len(clusters.Items) == 0 {
+		// TODO(negz): Do we really want to set the status to failed here? We
+		// 'failed' to schedule only because no clusters match yet. Remaining in
+		// pending may be more appropriate.
+		app.Status.SetFailed(reasonUnschedulable, errorNoclusters)
+		return reconcile.Result{Requeue: true}
+	}
+
+	// Round-robin cluster selection
+	index := int(s.lastClusterIndex % uint64(len(clusters.Items)))
+	cluster := clusters.Items[index]
+	s.lastClusterIndex++
+
+	app.Status.Cluster = cluster.ObjectReference()
+	app.Status.State = workloadv1alpha1.KubernetesApplicationStateScheduled
+	app.Status.UnsetAllConditions()
+	app.Status.SetReady()
+
+	return reconcile.Result{Requeue: false}
+}
+
+// CreatePredicate accepts KubernetesApplications that have not yet been
+// scheduled to a KubernetesCluster.
+func CreatePredicate(e event.CreateEvent) bool {
+	wl, ok := e.Object.(*workloadv1alpha1.KubernetesApplication)
+	if !ok {
+		return false
+	}
+	return wl.Status.Cluster == nil
+}
+
+// UpdatePredicate accepts KubernetesApplications that have not yet been
+// scheduled to a KubernetesCluster.
+func UpdatePredicate(e event.UpdateEvent) bool {
+	wl, ok := e.ObjectNew.(*workloadv1alpha1.KubernetesApplication)
+	if !ok {
+		return false
+	}
+	return wl.Status.Cluster == nil
+}
+
+// Add the KubernetesApplication scheduler reconciler to the supplied manager.
+func Add(mgr manager.Manager) error {
+	r := &Reconciler{
+		kube:      mgr.GetClient(),
+		scheduler: &roundRobinScheduler{kube: mgr.GetClient()},
+	}
+
+	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	err = c.Watch(
+		&source.Kind{Type: &workloadv1alpha1.KubernetesApplication{}},
+		&handler.EnqueueRequestForObject{},
+		&predicate.Funcs{CreateFunc: CreatePredicate, UpdateFunc: UpdatePredicate},
+	)
+	return errors.Wrapf(err, "cannot watch for %s", v1alpha1.KubernetesApplicationKind)
+}
+
+// A Reconciler schedules KubernetesApplications to KubernetesClusters.
+type Reconciler struct {
+	kube      client.Client
+	scheduler scheduler
+}
+
+// Reconcile attempts to schedule a KubernetesApplication to a KubernetesCluster
+// that matches its cluster selector.
+func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) {
+	log.V(logging.Debug).Info("reconciling", "kind", workloadv1alpha1.KubernetesApplicationKindAPIVersion, "request", req)
+
+	ctx, cancel := context.WithTimeout(context.Background(), reconcileTimeout)
+	defer cancel()
+
+	app := &workloadv1alpha1.KubernetesApplication{}
+	if err := r.kube.Get(ctx, req.NamespacedName, app); err != nil {
+		if kerrors.IsNotFound(err) {
+			return reconcile.Result{Requeue: false}, nil
+		}
+		return reconcile.Result{Requeue: false}, errors.Wrapf(err, "cannot get %s %s", workloadv1alpha1.KubernetesApplicationKind, req.NamespacedName)
+	}
+
+	// This application has been deleted.
+	if app.GetDeletionTimestamp() != nil {
+		return reconcile.Result{Requeue: false}, nil
+	}
+
+	// Someone already scheduled this application.
+	if app.Status.Cluster != nil {
+		return reconcile.Result{RequeueAfter: core.RequeueOnSuccess}, nil
+	}
+
+	return r.scheduler.schedule(ctx, app), errors.Wrapf(r.kube.Update(ctx, app), "cannot update %s %s", workloadv1alpha1.KubernetesApplicationKind, req.NamespacedName)
+}

--- a/pkg/controller/workload/kubernetes/scheduler/scheduler_test.go
+++ b/pkg/controller/workload/kubernetes/scheduler/scheduler_test.go
@@ -1,0 +1,452 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License
+*/
+
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-test/deep"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	computev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/compute/v1alpha1"
+	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
+	workloadv1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/workload/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/controller/core"
+	"github.com/crossplaneio/crossplane/pkg/test"
+)
+
+const (
+	namespace = "coolNamespace"
+	name      = "coolApp"
+	uid       = types.UID("definitely-a-uuid")
+)
+
+var (
+	errorBoom = errors.New("boom")
+	meta      = metav1.ObjectMeta{Namespace: namespace, Name: name, UID: uid}
+	ctx       = context.Background()
+
+	selectorAll     = &metav1.LabelSelector{}
+	selectorInvalid = &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{Operator: metav1.LabelSelectorOperator("wat")},
+		},
+	}
+
+	clusterA = &computev1alpha1.KubernetesCluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "coolClusterA"},
+	}
+	clusterB = &computev1alpha1.KubernetesCluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "coolClusterB"},
+	}
+
+	clusters = &computev1alpha1.KubernetesClusterList{
+		Items: []computev1alpha1.KubernetesCluster{*clusterA, *clusterB},
+	}
+)
+
+// Frequently used conditions.
+var (
+	ready   = corev1alpha1.Condition{Type: corev1alpha1.Ready, Status: corev1.ConditionTrue}
+	pending = corev1alpha1.Condition{Type: corev1alpha1.Pending, Status: corev1.ConditionTrue}
+)
+
+type kubeAppModifier func(*workloadv1alpha1.KubernetesApplication)
+
+func withConditions(c ...corev1alpha1.Condition) kubeAppModifier {
+	return func(r *workloadv1alpha1.KubernetesApplication) { r.Status.ConditionedStatus.Conditions = c }
+}
+
+func withState(s workloadv1alpha1.KubernetesApplicationState) kubeAppModifier {
+	return func(r *workloadv1alpha1.KubernetesApplication) { r.Status.State = s }
+}
+
+func withDeletionTimestamp(t time.Time) kubeAppModifier {
+	return func(r *workloadv1alpha1.KubernetesApplication) {
+		r.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: t}
+	}
+}
+
+func withCluster(c *corev1.ObjectReference) kubeAppModifier {
+	return func(r *workloadv1alpha1.KubernetesApplication) {
+		r.Status.Cluster = c
+	}
+}
+
+func withClusterSelector(s *metav1.LabelSelector) kubeAppModifier {
+	return func(r *workloadv1alpha1.KubernetesApplication) {
+		r.Spec.ClusterSelector = s
+	}
+}
+
+func kubeApp(rm ...kubeAppModifier) *workloadv1alpha1.KubernetesApplication {
+	r := &workloadv1alpha1.KubernetesApplication{ObjectMeta: meta}
+
+	for _, m := range rm {
+		m(r)
+	}
+
+	return r
+}
+
+func TestCreatePredicate(t *testing.T) {
+	cases := []struct {
+		name  string
+		event event.CreateEvent
+		want  bool
+	}{
+		{
+			name: "UnscheduledCluster",
+			event: event.CreateEvent{
+				Object: &workloadv1alpha1.KubernetesApplication{
+					Status: workloadv1alpha1.KubernetesApplicationStatus{
+						Cluster: nil,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "ScheduledCluster",
+			event: event.CreateEvent{
+				Object: &workloadv1alpha1.KubernetesApplication{
+					Status: workloadv1alpha1.KubernetesApplicationStatus{
+						Cluster: &corev1.ObjectReference{Name: "coolClustetr"},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "NotAKubernetesApplication",
+			event: event.CreateEvent{
+				Object: &workloadv1alpha1.KubernetesApplicationResource{},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CreatePredicate(tc.event)
+			if got != tc.want {
+				t.Errorf("CreatePredicate(...): got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+func TestUpdatePredicate(t *testing.T) {
+	cases := []struct {
+		name  string
+		event event.UpdateEvent
+		want  bool
+	}{
+		{
+			name: "UnscheduledCluster",
+			event: event.UpdateEvent{
+				ObjectNew: &workloadv1alpha1.KubernetesApplication{
+					Status: workloadv1alpha1.KubernetesApplicationStatus{
+						Cluster: nil,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "ScheduledCluster",
+			event: event.UpdateEvent{
+				ObjectNew: &workloadv1alpha1.KubernetesApplication{
+					Status: workloadv1alpha1.KubernetesApplicationStatus{
+						Cluster: &corev1.ObjectReference{Name: "coolCluster"},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "NotAKubernetesApplication",
+			event: event.UpdateEvent{
+				ObjectNew: &workloadv1alpha1.KubernetesApplicationResource{},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := UpdatePredicate(tc.event)
+			if got != tc.want {
+				t.Errorf("UpdatePredicate(...): got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSchedule(t *testing.T) {
+	cases := []struct {
+		name       string
+		scheduler  scheduler
+		app        *workloadv1alpha1.KubernetesApplication
+		wantApp    *workloadv1alpha1.KubernetesApplication
+		wantResult reconcile.Result
+	}{
+		{
+			name: "SuccessfulSchedule",
+			scheduler: &roundRobinScheduler{
+				kube: &test.MockClient{
+					MockList: func(_ context.Context, _ *client.ListOptions, obj runtime.Object) error {
+						*obj.(*computev1alpha1.KubernetesClusterList) = *clusters
+						return nil
+					},
+				},
+			},
+			app: kubeApp(withClusterSelector(selectorAll)),
+			wantApp: kubeApp(
+				withClusterSelector(selectorAll),
+				withCluster(clusterA.ObjectReference()),
+				withState(workloadv1alpha1.KubernetesApplicationStateScheduled),
+				withConditions(
+					corev1alpha1.Condition{
+						Type:   corev1alpha1.Pending,
+						Status: corev1.ConditionFalse,
+					},
+					ready,
+				),
+			),
+			wantResult: reconcile.Result{Requeue: false},
+		},
+		{
+			name: "InvalidLabelSelector",
+			scheduler: &roundRobinScheduler{
+				kube: &test.MockClient{
+					MockList: func(_ context.Context, _ *client.ListOptions, obj runtime.Object) error {
+						*obj.(*computev1alpha1.KubernetesClusterList) = *clusters
+						return nil
+					},
+				},
+			},
+			app: kubeApp(withClusterSelector(selectorInvalid)),
+			wantApp: kubeApp(
+				withClusterSelector(selectorInvalid),
+				withState(workloadv1alpha1.KubernetesApplicationStatePending),
+				withConditions(
+					pending,
+					corev1alpha1.Condition{
+						Type:    corev1alpha1.Failed,
+						Status:  corev1.ConditionTrue,
+						Reason:  reasonUnschedulable,
+						Message: "\"wat\" is not a valid pod selector operator",
+					},
+				),
+			),
+			wantResult: reconcile.Result{Requeue: true},
+		},
+		{
+			name: "ErrorListingClusters",
+			scheduler: &roundRobinScheduler{
+				kube: &test.MockClient{MockList: test.NewMockListFn(errorBoom)},
+			},
+			app: kubeApp(withClusterSelector(selectorAll)),
+			wantApp: kubeApp(
+				withClusterSelector(selectorAll),
+				withState(workloadv1alpha1.KubernetesApplicationStatePending),
+				withConditions(
+					pending,
+					corev1alpha1.Condition{
+						Type:    corev1alpha1.Failed,
+						Status:  corev1.ConditionTrue,
+						Reason:  reasonUnschedulable,
+						Message: errorBoom.Error(),
+					},
+				),
+			),
+			wantResult: reconcile.Result{Requeue: true},
+		},
+		{
+			name: "NoMatchingClusters",
+			scheduler: &roundRobinScheduler{
+				kube: &test.MockClient{
+					MockList: func(_ context.Context, _ *client.ListOptions, obj runtime.Object) error {
+						*obj.(*computev1alpha1.KubernetesClusterList) = computev1alpha1.KubernetesClusterList{}
+						return nil
+					},
+				},
+			},
+			app: kubeApp(withClusterSelector(selectorAll)),
+			wantApp: kubeApp(
+				withClusterSelector(selectorAll),
+				withState(workloadv1alpha1.KubernetesApplicationStatePending),
+				withConditions(
+					pending,
+					corev1alpha1.Condition{
+						Type:    corev1alpha1.Failed,
+						Status:  corev1.ConditionTrue,
+						Reason:  reasonUnschedulable,
+						Message: errorNoclusters,
+					},
+				),
+			),
+			wantResult: reconcile.Result{Requeue: true},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotResult := tc.scheduler.schedule(ctx, tc.app)
+
+			if diff := deep.Equal(tc.wantResult, gotResult); diff != nil {
+				t.Errorf("tc.scheduler.Schedule(...): want != got:\n%s", diff)
+			}
+
+			if diff := deep.Equal(tc.wantApp, tc.app); diff != nil {
+				t.Errorf("app: want != got:\n%s", diff)
+			}
+		})
+	}
+}
+
+type mockScheduleFn func(ctx context.Context, app *workloadv1alpha1.KubernetesApplication) reconcile.Result
+
+func newMockscheduleFn(r reconcile.Result) mockScheduleFn {
+	return func(_ context.Context, _ *workloadv1alpha1.KubernetesApplication) reconcile.Result { return r }
+}
+
+type mockScheduler struct {
+	mockSchedule mockScheduleFn
+}
+
+func (s *mockScheduler) schedule(ctx context.Context, app *workloadv1alpha1.KubernetesApplication) reconcile.Result {
+	return s.mockSchedule(ctx, app)
+}
+
+func TestReconcile(t *testing.T) {
+	cases := []struct {
+		name       string
+		rec        *Reconciler
+		req        reconcile.Request
+		wantResult reconcile.Result
+		wantErr    error
+	}{
+		{
+			name: "FailedToGetNonExistentKubernetesApplication",
+			rec: &Reconciler{
+				kube: &test.MockClient{
+					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, name)),
+				},
+			},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+			wantResult: reconcile.Result{Requeue: false},
+			wantErr:    nil,
+		},
+		{
+			name: "FailedToGetExtantKubernetesApplication",
+			rec: &Reconciler{
+				kube: &test.MockClient{MockGet: test.NewMockGetFn(errorBoom)},
+			},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+			wantResult: reconcile.Result{Requeue: false},
+			wantErr:    errors.Wrapf(errorBoom, "cannot get %s %s/%s", workloadv1alpha1.KubernetesApplicationKind, namespace, name),
+		},
+		{
+			name: "KubernetesApplicationWasDeleted",
+			rec: &Reconciler{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
+						*obj.(*workloadv1alpha1.KubernetesApplication) = *(kubeApp(withDeletionTimestamp(time.Now())))
+						return nil
+					},
+				},
+			},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+			wantResult: reconcile.Result{Requeue: false},
+			wantErr:    nil,
+		},
+		{
+			name: "KubernetesApplicationAlreadyScheduled",
+			rec: &Reconciler{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
+						*obj.(*workloadv1alpha1.KubernetesApplication) = *(kubeApp(
+							withCluster(&corev1.ObjectReference{Name: "coolCluster"}),
+						))
+						return nil
+					},
+				},
+			},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+			wantResult: reconcile.Result{RequeueAfter: core.RequeueOnSuccess},
+			wantErr:    nil,
+		},
+		{
+			name: "SchedulingSuccessful",
+			rec: &Reconciler{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
+						*obj.(*workloadv1alpha1.KubernetesApplication) = *(kubeApp())
+						return nil
+					},
+					MockUpdate: test.NewMockUpdateFn(nil),
+				},
+				scheduler: &mockScheduler{mockSchedule: newMockscheduleFn(reconcile.Result{Requeue: false})},
+			},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+			wantResult: reconcile.Result{Requeue: false},
+			wantErr:    nil,
+		},
+		{
+			name: "SchedulingFailed",
+			rec: &Reconciler{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
+						*obj.(*workloadv1alpha1.KubernetesApplication) = *(kubeApp())
+						return nil
+					},
+					MockUpdate: test.NewMockUpdateFn(errorBoom),
+				},
+				scheduler: &mockScheduler{mockSchedule: newMockscheduleFn(reconcile.Result{Requeue: false})},
+			},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
+			wantResult: reconcile.Result{Requeue: false},
+			wantErr:    errors.Wrapf(errorBoom, "cannot update %s %s/%s", workloadv1alpha1.KubernetesApplicationKind, namespace, name),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotResult, gotErr := tc.rec.Reconcile(tc.req)
+
+			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
+			}
+
+			if diff := deep.Equal(tc.wantResult, gotResult); diff != nil {
+				t.Errorf("tc.rec.Reconcile(...): want != got:\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/workload/workload.go
+++ b/pkg/controller/workload/workload.go
@@ -14,30 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package workload
 
 import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/crossplaneio/crossplane/pkg/controller/aws"
-	"github.com/crossplaneio/crossplane/pkg/controller/azure"
-	"github.com/crossplaneio/crossplane/pkg/controller/cache"
-	"github.com/crossplaneio/crossplane/pkg/controller/compute"
-	"github.com/crossplaneio/crossplane/pkg/controller/gcp"
-	"github.com/crossplaneio/crossplane/pkg/controller/storage"
-	"github.com/crossplaneio/crossplane/pkg/controller/workload"
+	"github.com/crossplaneio/crossplane/pkg/controller/workload/kubernetes/application"
+	"github.com/crossplaneio/crossplane/pkg/controller/workload/kubernetes/resource"
+	"github.com/crossplaneio/crossplane/pkg/controller/workload/kubernetes/scheduler"
 )
 
 func init() {
-	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
 	AddToManagerFuncs = append(AddToManagerFuncs,
-		aws.AddToManager,
-		azure.AddToManager,
-		cache.AddToManager,
-		compute.AddToManager,
-		gcp.AddToManager,
-		storage.AddToManager,
-		workload.AddToManager,
+		application.Add,
+		resource.Add,
+		scheduler.Add,
 	)
 }
 

--- a/pkg/test/fake.go
+++ b/pkg/test/fake.go
@@ -25,32 +25,77 @@ import (
 
 var _ client.Client = &MockClient{}
 
+// A MockGetFn is used to mock client.Client's Get implementation.
+type MockGetFn func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error
+
+// A MockListFn is used to mock client.Client's List implementation.
+type MockListFn func(ctx context.Context, opts *client.ListOptions, list runtime.Object) error
+
+// A MockCreateFn is used to mock client.Client's Create implementation.
+type MockCreateFn func(ctx context.Context, obj runtime.Object) error
+
+// A MockDeleteFn is used to mock client.Client's Delete implementation.
+type MockDeleteFn func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOptionFunc) error
+
+// A MockUpdateFn is used to mock client.Client's Update implementation.
+type MockUpdateFn func(ctx context.Context, obj runtime.Object) error
+
+// A MockStatusUpdateFn is used to mock client.Client's StatusUpdate implementation.
+type MockStatusUpdateFn func(ctx context.Context, obj runtime.Object) error
+
+// NewMockGetFn returns a MockGetFn that returns the supplied error.
+func NewMockGetFn(err error) MockGetFn {
+	return func(_ context.Context, _ client.ObjectKey, _ runtime.Object) error { return err }
+}
+
+// NewMockListFn returns a MockListFn that returns the supplied error.
+func NewMockListFn(err error) MockListFn {
+	return func(_ context.Context, _ *client.ListOptions, _ runtime.Object) error { return err }
+}
+
+// NewMockCreateFn returns a MockCreateFn that returns the supplied error.
+func NewMockCreateFn(err error) MockCreateFn {
+	return func(_ context.Context, _ runtime.Object) error { return err }
+}
+
+// NewMockDeleteFn returns a MockDeleteFn that returns the supplied error.
+func NewMockDeleteFn(err error) MockDeleteFn {
+	return func(_ context.Context, _ runtime.Object, _ ...client.DeleteOptionFunc) error { return err }
+}
+
+// NewMockUpdateFn returns a MockUpdateFn that returns the supplied error.
+func NewMockUpdateFn(err error) MockUpdateFn {
+	return func(_ context.Context, _ runtime.Object) error { return err }
+}
+
+// NewMockStatusUpdateFn returns a MockStatusUpdateFn that returns the supplied error.
+func NewMockStatusUpdateFn(err error) MockStatusUpdateFn {
+	return func(_ context.Context, _ runtime.Object) error { return err }
+}
+
 // MockClient implements controller-runtime's Client interface, allowing each
 // method to be overridden for testing. The controller-runtime provides a fake
 // client, but it is has surprising side effects (e.g. silently calling
 // os.Exit(1)) and does not allow us control over the errors it returns.
 type MockClient struct {
-	MockGet          func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error
-	MockList         func(ctx context.Context, opts *client.ListOptions, list runtime.Object) error
-	MockCreate       func(ctx context.Context, obj runtime.Object) error
-	MockDelete       func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOptionFunc) error
-	MockUpdate       func(ctx context.Context, obj runtime.Object) error
-	MockStatusUpdate func(ctx context.Context, obj runtime.Object) error
+	MockGet          MockGetFn
+	MockList         MockListFn
+	MockCreate       MockCreateFn
+	MockDelete       MockDeleteFn
+	MockUpdate       MockUpdateFn
+	MockStatusUpdate MockStatusUpdateFn
 }
 
 // NewMockClient returns a MockClient that does nothing when its methods are
 // called.
 func NewMockClient() *MockClient {
 	return &MockClient{
-		//MockStatusClient: &MockStatusClient{
-		//	MockUpdate: func(ctx context.Context, obj runtime.Object) error { return nil },
-		//},
-		MockGet:          func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error { return nil },
-		MockList:         func(ctx context.Context, opts *client.ListOptions, list runtime.Object) error { return nil },
-		MockCreate:       func(ctx context.Context, obj runtime.Object) error { return nil },
-		MockDelete:       func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOptionFunc) error { return nil },
-		MockUpdate:       func(ctx context.Context, obj runtime.Object) error { return nil },
-		MockStatusUpdate: func(ctx context.Context, obj runtime.Object) error { return nil },
+		MockGet:          NewMockGetFn(nil),
+		MockList:         NewMockListFn(nil),
+		MockCreate:       NewMockCreateFn(nil),
+		MockDelete:       NewMockDeleteFn(nil),
+		MockUpdate:       NewMockUpdateFn(nil),
+		MockStatusUpdate: NewMockStatusUpdateFn(nil),
 	}
 }
 
@@ -88,7 +133,7 @@ func (c *MockClient) Status() client.StatusWriter {
 
 // MockStatusWriter provides mock functionality for status sub-resource
 type MockStatusWriter struct {
-	MockUpdate func(ctx context.Context, obj runtime.Object) error
+	MockUpdate MockStatusUpdateFn
 }
 
 // Update status sub-resource

--- a/pkg/util/crud.go
+++ b/pkg/util/crud.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// https://github.com/kubernetes-sigs/controller-runtime/blob/6100e07/pkg/controller/controllerutil/controllerutil.go#L117
+//
+// This file contains a fork of the above function. At the time of writing the
+// latest release of controller-runtime is v0.1.10, which contains a buggy
+// CreateOrUpdate implementation.
+// TODO(negz): Revert to mainline CreateOrUpdate once we're running v0.2.0 or
+// higher per https://github.com/crossplaneio/crossplane/issues/426.
+
+// CreateOrUpdate creates or updates the given object in the Kubernetes
+// cluster. The object's desired state must be reconciled with the existing
+// state inside the passed in callback MutateFn. The MutateFn is called
+// regardless of creating or updating an object.
+func CreateOrUpdate(ctx context.Context, c client.Client, obj runtime.Object, f MutateFn) error {
+	key, err := client.ObjectKeyFromObject(obj)
+	if err != nil {
+		return errors.Wrap(err, "cannot get object key")
+	}
+
+	if err := c.Get(ctx, key, obj); err != nil {
+		if !kerrors.IsNotFound(err) {
+			return errors.Wrap(err, "could not get object")
+		}
+		if err := f(); err != nil {
+			return errors.Wrap(err, "could not mutate object for creation")
+		}
+		if err := c.Create(ctx, obj); err != nil {
+			return errors.Wrap(err, "could not create object")
+		}
+		return nil
+	}
+
+	existing := obj.DeepCopyObject()
+	if err := f(); err != nil {
+		return errors.Wrap(err, "could not mutate object for update")
+	}
+
+	if reflect.DeepEqual(existing, obj) {
+		return nil
+	}
+
+	return errors.Wrap(c.Update(ctx, obj), "could not update object")
+}
+
+// MutateFn is a function which mutates the existing object into its desired
+// state.
+type MutateFn func() error

--- a/pkg/util/crud_test.go
+++ b/pkg/util/crud_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplaneio/crossplane/pkg/test"
+)
+
+const (
+	namespace = "coolNamespace"
+	name      = "coolService"
+	uid       = types.UID("definitely-a-uuid")
+)
+
+var (
+	ctx       = context.Background()
+	errorBoom = errors.New("boom")
+	meta      = metav1.ObjectMeta{Namespace: namespace, Name: name, UID: uid}
+	service   = &corev1.Service{
+		ObjectMeta: meta,
+		Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+	}
+)
+
+type mockObjectKind struct {
+	schema.ObjectKind
+}
+
+type weirdObject struct{}
+
+func (o *weirdObject) GetObjectKind() schema.ObjectKind {
+	return mockObjectKind{}
+}
+
+func (o *weirdObject) DeepCopyObject() runtime.Object {
+	return o
+}
+
+func TestCreateOrUpdate(t *testing.T) {
+	cases := []struct {
+		name    string
+		kube    client.Client
+		obj     runtime.Object
+		f       MutateFn
+		wantErr error
+	}{
+		{
+			name: "SuccessfulCreate",
+			kube: &test.MockClient{
+				MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+				MockCreate: test.NewMockCreateFn(nil),
+			},
+			obj: service,
+			f:   func() error { return nil },
+		},
+		{
+			name: "SuccessfulUpdate",
+			kube: &test.MockClient{
+				MockGet: func(_ context.Context, _ client.ObjectKey, obj runtime.Object) error {
+					*obj.(*corev1.Service) = *service
+					return nil
+				},
+				MockUpdate: test.NewMockUpdateFn(nil),
+			},
+			obj: service,
+			f: func() error {
+				service.Spec.Type = corev1.ServiceTypeClusterIP
+				return nil
+			},
+		},
+		{
+			name: "NoopUpdate",
+			kube: &test.MockClient{
+				MockGet: func(_ context.Context, _ client.ObjectKey, obj runtime.Object) error {
+					*obj.(*corev1.Service) = *service
+					return nil
+				},
+			},
+			obj: service,
+			f:   func() error { return nil },
+		},
+		{
+			name:    "MissingObjectMeta",
+			kube:    &test.MockClient{},
+			obj:     &weirdObject{},
+			wantErr: errors.WithStack(errors.New("cannot get object key: object does not implement the Object interfaces")),
+		},
+		{
+			name: "FailedGet",
+			kube: &test.MockClient{
+				MockGet: test.NewMockGetFn(errorBoom),
+			},
+			obj:     service,
+			wantErr: errors.Wrap(errorBoom, "could not get object"),
+		},
+		{
+			name: "FailedMutateForCreate",
+			kube: &test.MockClient{
+				MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+			},
+			obj:     service,
+			f:       func() error { return errorBoom },
+			wantErr: errors.Wrap(errorBoom, "could not mutate object for creation"),
+		},
+		{
+			name: "FailedCreate",
+			kube: &test.MockClient{
+				MockGet:    test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, "")),
+				MockCreate: test.NewMockCreateFn(errorBoom),
+			},
+			obj:     service,
+			f:       func() error { return nil },
+			wantErr: errors.Wrap(errorBoom, "could not create object"),
+		},
+		{
+			name: "FailedMutateForUpdate",
+			kube: &test.MockClient{
+				MockGet: func(_ context.Context, _ client.ObjectKey, obj runtime.Object) error {
+					*obj.(*corev1.Service) = *service
+					return nil
+				},
+			},
+			obj:     service,
+			f:       func() error { return errorBoom },
+			wantErr: errors.Wrap(errorBoom, "could not mutate object for update"),
+		},
+		{
+			name: "FailedUpdate",
+			kube: &test.MockClient{
+				MockGet: func(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
+					*obj.(*corev1.Service) = *service
+					return nil
+				},
+				MockUpdate: test.NewMockUpdateFn(errorBoom),
+			},
+			obj: service,
+			f: func() error {
+				service.Spec.Type = corev1.ServiceTypeExternalName
+				return nil
+			},
+			wantErr: errors.Wrap(errorBoom, "could not update object"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotErr := CreateOrUpdate(ctx, tc.kube, tc.obj, tc.f)
+
+			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](../blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to Crossplane! -->

**Description of your changes:** This Pull request implements support for "Complex Workloads" as described in revision 1.0 of the [Complex Workloads design document](https://github.com/crossplaneio/crossplane/blob/a65d7f1/design/complex-workloads.md). Note that it does not remove support for contemporary workloads, which continue to exist in the `compute.crossplane.io` API group, alongside complex workloads in the new `workload.crossplane.io` API group.

Complex workloads are implemented as three controllers:
* One to schedule `KubernetesApplications` to `KubernetesClusters`.
* One to create `KubernetesApplicationResources` from a `KubernetesApplication`.
* One to create resources in from a `KubernetesApplicationResource` in their scheduled `KubernetesCluster`.

**Which issue is resolved by this Pull Request:**
Resolves #411

That said, there is some follow on work that I'd like to do in future PRs. Namely:
* Adding webhooks to validate our CRDs. Currently it's possible to submit a CRD that will break our reconcile logic, for example a `KubernetesApplication` consisting of multiple `KubernetesApplicationResources` with the same name.
* Support for updating immutable spec properties such as `Service`'s `.spec.clusterIP`. Currently we support creating and updating most Kubernetes kinds, but updates will break for any resource with an immutable field that is set by anything other than its `KubernetesApplicationResource` template.

The above two issues are currently only tracked by TODOs, so I'll need to write up issues to track them when we resolve #411.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [x] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [x] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [x] RBAC permissions in `clusterrole.yaml` have been updated to include new types, if necessary
- [x] All related commits have been squashed to improve readability.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
