### PR TITLE
azure: cleaning up comment typos in resource groups

### DIFF
--- a/pkg/clients/azure/resourcegroup/resourcegroup.go
+++ b/pkg/clients/azure/resourcegroup/resourcegroup.go
@@ -40,7 +40,7 @@ const (
 // A GroupsClient handles CRUD operations for Azure Resource Group resources.
 type GroupsClient resourcesapi.GroupsClientAPI
 
-// NewClient returns a new Azure Cache for Redis client. Credentials must be
+// NewClient returns a new Azure Resource Groups client. Credentials must be
 // passed as JSON encoded data.
 func NewClient(credentials []byte) (GroupsClient, error) {
 	c := azure.Credentials{}

--- a/pkg/controller/azure/provider/resourcegroup.go
+++ b/pkg/controller/azure/provider/resourcegroup.go
@@ -76,16 +76,15 @@ type deleter interface {
 	Delete(ctx context.Context, r *v1alpha1.ResourceGroup) (requeue bool)
 }
 
-// A createsyncdeletekeyer an create, sync, and delete resources in an external
-// store - e.g. the Azure API. It can also return keys (i.e. credentials) for
-// resources.
+// A createsyncdeleter can create, sync, and delete resources in an external
+// store - e.g. the Azure API.
 type createsyncdeleter interface {
 	creator
 	syncer
 	deleter
 }
 
-// azureResourceGroup is a createsyncdeletr using the Azure Groups API.
+// azureResourceGroup is a createsyncdeleter using the Azure Groups API.
 type azureResourceGroup struct {
 	client resourcegroup.GroupsClient
 }


### PR DESCRIPTION
This commit cleans up some minor typos in the azure resource group comments.

Signed-off-by: HashedDan <georgedanielmangum@gmail.com>

<!-- Please take a look at our [Contributing](../blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to Crossplane! -->

**Description of your changes:** Correction to some minor typos.

**Which issue is resolved by this Pull Request:**
Resolves: N/A

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [x] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [x] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [x] RBAC permissions in `clusterrole.yaml` have been updated to include new types, if necessary
- [x] All related commits have been squashed to improve readability.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
