### PR TITLE
Convert unit tests from deep.Equal to cmp.Diff

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -295,10 +295,11 @@
   revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
 
 [[projects]]
-  digest = "1:bf40199583e5143d1472fc34d10d6f4b69d97572142acf343b3e43136da40823"
+  digest = "1:010d46ea3c1e730897e53058d1013a963f3f987675dda87df64f891b945281db"
   name = "github.com/google/go-cmp"
   packages = [
     "cmp",
+    "cmp/cmpopts",
     "cmp/internal/diff",
     "cmp/internal/flags",
     "cmp/internal/function",
@@ -1335,6 +1336,7 @@
     "github.com/go-ini/ini",
     "github.com/go-logr/logr",
     "github.com/google/go-cmp/cmp",
+    "github.com/google/go-cmp/cmp/cmpopts",
     "github.com/google/uuid",
     "github.com/googleapis/gax-go",
     "github.com/onsi/gomega",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -243,14 +243,6 @@
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:7f89e0c888fb99c61055c646f5678aae645b0b0a1443d9b2dcd9964d850827ce"
-  name = "github.com/go-test/deep"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "6592d9cc0a499ad2d5f574fde80a2b5c5cc3b4f5"
-  version = "v1.0.1"
-
-[[projects]]
   digest = "1:07829a6a0523929f5edc92b2a2dbb05ef3f335780bac9f06c44aa27c6cfc467a"
   name = "github.com/gobuffalo/envy"
   packages = ["."]
@@ -301,6 +293,20 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
+
+[[projects]]
+  digest = "1:bf40199583e5143d1472fc34d10d6f4b69d97572142acf343b3e43136da40823"
+  name = "github.com/google/go-cmp"
+  packages = [
+    "cmp",
+    "cmp/internal/diff",
+    "cmp/internal/flags",
+    "cmp/internal/function",
+    "cmp/internal/value",
+  ]
+  pruneopts = "UT"
+  revision = "6f77996f0c42f7b84e5a2b252227263f93432e9b"
+  version = "v0.3.0"
 
 [[projects]]
   branch = "master"
@@ -1328,7 +1334,7 @@
     "github.com/ghodss/yaml",
     "github.com/go-ini/ini",
     "github.com/go-logr/logr",
-    "github.com/go-test/deep",
+    "github.com/google/go-cmp/cmp",
     "github.com/google/uuid",
     "github.com/googleapis/gax-go",
     "github.com/onsi/gomega",

--- a/pkg/apis/aws/cache/v1alpha1/replication_group_types_test.go
+++ b/pkg/apis/aws/cache/v1alpha1/replication_group_types_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -202,7 +202,7 @@ func TestNewReplicationGroupSpec(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewReplicationGroupSpec(tc.properties)
-			if diff := deep.Equal(got, tc.want); diff != nil {
+			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("got != want:\n%v", diff)
 			}
 		})

--- a/pkg/apis/azure/cache/v1alpha1/redis_types_test.go
+++ b/pkg/apis/azure/cache/v1alpha1/redis_types_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -170,7 +170,7 @@ func TestNewRedisSpec(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewRedisSpec(tc.properties)
-			if diff := deep.Equal(got, tc.want); diff != nil {
+			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("got != want:\n%v", diff)
 			}
 		})

--- a/pkg/apis/azure/storage/v1alpha1/account_test.go
+++ b/pkg/apis/azure/storage/v1alpha1/account_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2017-06-01/storage"
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -49,7 +49,7 @@ func Test_newCustomDomain(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := newCustomDomain(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("newCustomDomain() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -77,7 +77,7 @@ func Test_toStorageCustomDomain(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := toStorageCustomDomain(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("CustomDomain.ToStorageCustomDomain() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -111,7 +111,7 @@ func Test_newEnabledEncryptionServices(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := newEnabledEncryptionServices(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("newEnabledEncryptionServices() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -143,7 +143,7 @@ func Test_toStorageEncryptedServices(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := toStorageEncryptedServices(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("EnabledEncryptionServices.ToStorageEncryptedServices() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -166,7 +166,7 @@ func Test_newEncryption(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := newEncryption(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("newEncryption() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -209,7 +209,7 @@ func Test_toStorageEncryption(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := toStorageEncryption(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("Encryption.ToStorageEncryption() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -241,7 +241,7 @@ func Test_newEndpoints(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := newEndpoints(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("newEndpoints() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -271,7 +271,7 @@ func Test_newIdentity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := newIdentity(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("newIdentity() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -302,7 +302,7 @@ func Test_toStorageIdentity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := toStorageIdentity(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("Identity.ToStorageIdentity() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -330,7 +330,7 @@ func Test_newIPRule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := newIPRule(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("newIPRule() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -358,7 +358,7 @@ func Test_toStorageIPRule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := toStorageIPRule(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("IPRule.ToStroageIPRule() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -389,7 +389,7 @@ func Test_newKeyVaultProperties(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := newKeyVaultProperties(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("newKeyVaultProperties() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -420,7 +420,7 @@ func Test_toStorageKeyVaultProperties(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := toStorageKeyVaultProperties(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("KeyVaultProperties.ToStorageKeyVaultProperties() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -472,7 +472,7 @@ func Test_newNetworkRuleSet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := newNetworkRuleSet(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("newNetworkRuleSet() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -520,7 +520,7 @@ func Test_toStorageNetworkRuleSet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := toStorageNetworkRuleSet(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("NetworkRuleSet.ToStorageNetworkRuleSet() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -538,7 +538,7 @@ func Test_newSkuCapability(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := newSkuCapability(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("newSkuCapability() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -560,7 +560,7 @@ func Test_toStorageSkuCapability(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := toStorageSkuCapability(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("skuCapability.ToStorageSkuCapability() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -597,7 +597,7 @@ func Test_newSku(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := newSku(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("newSku() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -643,7 +643,7 @@ func Test_toStorageSku(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := toStorageSku(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("Sku.ToStorageSku() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -661,7 +661,7 @@ func Test_newVirtualNetworkRule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := newVirtualNetworkRule(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("newVirtualNetworkRule() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -689,7 +689,7 @@ func Test_toStorageVirtualNetworkRule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := toStorageVirtualNetworkRule(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("VirtualNetworkRule.ToStorageVirtualNetworkRule() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -712,7 +712,7 @@ func Test_newStorageAccountSpecProperties(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := newStorageAccountSpecProperties(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("newStorageAccountSpecProperties() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -753,7 +753,7 @@ func Test_toStorageAccountCreateProperties(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := toStorageAccountCreateProperties(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("StorageAccountSpecProperties.ToStorageAccountCreateProperties() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -782,7 +782,7 @@ func Test_toStorageAccountUpdateProperties(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := toStorageAccountUpdateProperties(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("StorageAccountSpecProperties.ToStorageAccountUpdateProperties() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -810,7 +810,7 @@ func Test_newStorageAccountStatusProperties(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := newStorageAccountStatusProperties(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("newStorageAccountStatusProperties() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -835,7 +835,7 @@ func Test_NewStorageAccountSpec(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewStorageAccountSpec(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("NewStorageAccountSpec() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -878,7 +878,7 @@ func Test_toStorageAccountCreate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ToStorageAccountCreate(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("StorageAccountSpec.toStorageAccountCreate() = \n%v, want \n%v\n%s", got, tt.want, diff)
 			}
 		})
@@ -919,7 +919,7 @@ func Test_toStorageAccountUpdate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ToStorageAccountUpdate(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("StorageAccountSpec.toStorageAccountUpdate() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -942,7 +942,7 @@ func Test_NewStorageAccountStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewStorageAccountStatus(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("NewStorageAccountStatus() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -1026,7 +1026,7 @@ func Test_parseStorageAccountSpec(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := parseStorageAccountSpec(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("parseStorageAccountSpec() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -1045,7 +1045,7 @@ func Test_toStringPtr(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := toStringPtr(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("toStringPtr() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})

--- a/pkg/apis/azure/storage/v1alpha1/types_test.go
+++ b/pkg/apis/azure/storage/v1alpha1/types_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
@@ -102,7 +102,7 @@ func TestParseAccountSpec(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ParseAccountSpec(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("ParseAccountSpec() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -163,7 +163,7 @@ func TestAccount_ConnectionSecret(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.account.ConnectionSecret()
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("Bucket.ConnectionSecret() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -181,7 +181,7 @@ func TestAccount_ObjectReference(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.bucket.ObjectReference()
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("Account.ObjectReference() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -199,7 +199,7 @@ func TestAccount_OwnerReference(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.bucket.OwnerReference()
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("Account.OwnerReference() = \n%+v, want \n%+v\n%s", got, tt.want, diff)
 			}
 		})
@@ -382,7 +382,7 @@ func TestContainer_ObjectReference(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.bucket.ObjectReference()
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("Container.ObjectReference() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -400,7 +400,7 @@ func TestContainer_OwnerReference(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.bucket.OwnerReference()
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("Container.OwnerReference() = \n%+v, want \n%+v\n%s", got, tt.want, diff)
 			}
 		})
@@ -518,7 +518,7 @@ func TestParseContainerSpec(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ParseContainerSpec(tt.args.p)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("ParseContainerSpec() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})

--- a/pkg/apis/azure/storage/v1alpha1/types_test.go
+++ b/pkg/apis/azure/storage/v1alpha1/types_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
@@ -541,8 +540,9 @@ func Test_parsePublicAccessType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := parsePublicAccessType(tt.args.s); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("parsePublicAccessType() = %v, want %v", got, tt.want)
+			got := parsePublicAccessType(tt.args.s)
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("parsePublicAccessType(): got != want:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/apis/core/v1alpha1/bindingphase_test.go
+++ b/pkg/apis/core/v1alpha1/bindingphase_test.go
@@ -20,9 +20,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
-
-	"github.com/go-test/deep"
 )
 
 const jsonQuote = "\""
@@ -50,7 +49,7 @@ func TestBindingStateMarshalJSON(t *testing.T) {
 			if err != nil {
 				t.Errorf("BindingState.MarshalJSON(): %v", err)
 			}
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("BindingState.MarshalJSON(): want != got\n %+v", diff)
 			}
 		})
@@ -96,11 +95,11 @@ func TestBindingStateUnmarshalJSON(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var got BindingState
 			gotErr := got.UnmarshalJSON(tc.s)
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("BindingState.UnmarshalJSON(): want error != got error\n %+v", diff)
 			}
 
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("BindingState.UnmarshalJSON(): want != got\n %+v", diff)
 			}
 		})

--- a/pkg/apis/core/v1alpha1/bindingphase_test.go
+++ b/pkg/apis/core/v1alpha1/bindingphase_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+
+	"github.com/crossplaneio/crossplane/pkg/test"
 )
 
 const jsonQuote = "\""
@@ -95,7 +97,7 @@ func TestBindingStateUnmarshalJSON(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var got BindingState
 			gotErr := got.UnmarshalJSON(tc.s)
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("BindingState.UnmarshalJSON(): want error != got error\n %+v", diff)
 			}
 

--- a/pkg/apis/gcp/cache/v1alpha1/cloudmemorystore_instance_types_test.go
+++ b/pkg/apis/gcp/cache/v1alpha1/cloudmemorystore_instance_types_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -155,7 +155,7 @@ func TestNewCloudMemorystoreInstanceSpec(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewCloudMemorystoreInstanceSpec(tc.properties)
-			if diff := deep.Equal(got, tc.want); diff != nil {
+			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("got != want:\n%v", diff)
 			}
 		})

--- a/pkg/apis/gcp/compute/v1alpha1/types_test.go
+++ b/pkg/apis/gcp/compute/v1alpha1/types_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -152,7 +152,7 @@ func TestParseClusterSpec(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ParseClusterSpec(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("ParseClusterSpec() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})

--- a/pkg/apis/gcp/storage/v1alpha1/types_test.go
+++ b/pkg/apis/gcp/storage/v1alpha1/types_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
@@ -101,11 +101,11 @@ func TestProjectTeam(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := CopyToProjectTeam(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("CopyToProjectTeam() = %v, want %v\n%s", got, tt.want, diff)
 			}
 			gotBack := NewProjectTeam(got)
-			if diff := deep.Equal(gotBack, tt.args); diff != nil {
+			if diff := cmp.Diff(gotBack, tt.args); diff != "" {
 				t.Errorf("NewProjectTeam() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -145,7 +145,7 @@ func TestNewBucketPolicyOnly(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewBucketPolicyOnly(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("NewBucketPolicyOnly() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -164,7 +164,7 @@ func TestCopyToBucketPolicyOnly(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := CopyToBucketPolicyOnly(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("CopyToBucketPolicyOnly() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -183,11 +183,11 @@ func TestACLRule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := CopyToACLRule(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("CopyToACLRule() = %v, want %v\n%s", got, tt.want, diff)
 			}
 			gotBack := NewACLRule(got)
-			if diff := deep.Equal(gotBack, tt.args); diff != nil {
+			if diff := cmp.Diff(gotBack, tt.args); diff != "" {
 				t.Errorf("NewACLRule() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -207,7 +207,7 @@ func TestNewACLRules(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewACLRules(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("CopyToACLRules() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -227,7 +227,7 @@ func TestCopyToACLRules(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := CopyToACLRules(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("CopyToACLRules() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -257,7 +257,7 @@ func TestNewLifecyleAction(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewLifecyleAction(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("NewLifecyleAction() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -275,7 +275,7 @@ func TestCopyToLifecyleAction(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := CopyToLifecyleAction(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("CopyToLifecyleAction() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -313,7 +313,7 @@ func TestNewLifecycleCondition(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewLifecycleCondition(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("NewLifecycleCondition() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -331,7 +331,7 @@ func TestCopyToLifecycleCondition(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := CopyToLifecycleCondition(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("CopyToLifecycleCondition() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -361,7 +361,7 @@ func TestNewLifecycleRule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewLifecycleRule(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("NewLifecycleRule() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -379,7 +379,7 @@ func TestCopyToLifecyleRule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := CopyToLifecyleRule(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("CopyToLifecyleRule() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -403,7 +403,7 @@ func TestNewLifecycle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewLifecycle(tt.args)
-			if diff := deep.Equal(*got, tt.want); diff != nil {
+			if diff := cmp.Diff(*got, tt.want); diff != "" {
 				t.Errorf("NewLifecycle() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -423,7 +423,7 @@ func TestCopyToLifecycle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := CopyToLifecycle(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("CopyToLifecycle() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -507,7 +507,7 @@ func TestNewRetentionPolicyStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewRetentionPolicyStatus(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("NewRetentionPolicyStatus() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -531,7 +531,7 @@ func TestNewBucketEncryption(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewBucketEncryption(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("NewBucketEncryption() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -550,7 +550,7 @@ func TestCopyToBucketEncryption(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := CopyToBucketEncryption(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("CopyToBucketEncryption() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -581,7 +581,7 @@ func TestNewBucketLogging(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewBucketLogging(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("NewBucketLogging() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -600,7 +600,7 @@ func TestCopyToBucketLogging(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := CopyToBucketLogging(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("CopyToBucketLogging() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -634,7 +634,7 @@ func TestNewCORS(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewCORS(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("NewCORS() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -652,7 +652,7 @@ func TestCopyToCORS(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := CopyToCORS(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("CopyToCORS() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -672,7 +672,7 @@ func TestNewCORSs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewCORSList(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("NewCORSList() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -692,7 +692,7 @@ func TestCopyToCORSs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := CopyToCORSList(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("CopyToCORSList() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -716,7 +716,7 @@ func TestNewBucketWebsite(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewBucketWebsite(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("NewBucketWebsite() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -735,7 +735,7 @@ func TestCopyToBucketWebsite(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := CopyToBucketWebsite(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("CopyToBucketWebsite() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -801,7 +801,7 @@ func TestNewBucketUpdateAttrs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewBucketUpdatableAttrs(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("NewBucketUpdatableAttrs() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -826,7 +826,7 @@ func TestCopyToBucketAttrs(t *testing.T) {
 			} else {
 				got := CopyToBucketAttrs(tt.args)
 				got.RetentionPolicy = nil
-				if diff := deep.Equal(got, tt.want); diff != nil {
+				if diff := cmp.Diff(got, tt.want); diff != "" {
 					t.Errorf("CopyToBucketAttrs() = %+v, want %+v\n%s", got, tt.want, diff)
 				}
 			}
@@ -855,7 +855,7 @@ func TestCopyToBucketUpdateAttrs(t *testing.T) {
 		tt.want.DeleteLabel("foo")
 		t.Run(tt.name, func(t *testing.T) {
 			got := CopyToBucketUpdateAttrs(tt.args.ba, tt.args.labels)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("CopyToBucketUpdateAttrs()\n%+v, want \n%+v\n%s", got, tt.want, diff)
 			}
 		})
@@ -903,7 +903,7 @@ func TestNewBucketSpecAttrs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewBucketSpecAttrs(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("NewBucketSpecAttrs() = \n%+v, want \n%+v\n%s", got, tt.want, diff)
 			}
 		})
@@ -925,7 +925,7 @@ func TestCopyBucketSpecAttrs(t *testing.T) {
 				tt.want.RetentionPolicy = &storage.RetentionPolicy{RetentionPeriod: time.Duration(0)}
 			}
 			got := CopyBucketSpecAttrs(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("CopyBucketSpecAttrs() = \n%+v, want \n%+v\n%s", got, tt.want, diff)
 			}
 		})
@@ -958,7 +958,7 @@ func TestNewBucketOutputAttrs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewBucketOutputAttrs(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("NewBucketOutputAttrs() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -1018,7 +1018,7 @@ func TestBucket_ConnectionSecret(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.bucket.ConnectionSecret()
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("Bucket.ConnectionSecret() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -1036,7 +1036,7 @@ func TestBucket_ObjectReference(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.bucket.ObjectReference()
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("Bucket.ObjectReference() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -1054,7 +1054,7 @@ func TestBucket_OwnerReference(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.bucket.OwnerReference()
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("Bucket.OwnerReference() = \n%+v, want \n%+v\n%s", got, tt.want, diff)
 			}
 		})
@@ -1161,7 +1161,7 @@ func Test_parseCORSList(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := parseCORSList(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("parseCORSList() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -1207,7 +1207,7 @@ func Test_parseLifecycle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := parseLifecycle(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("parseLifecycle() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -1231,7 +1231,7 @@ func Test_parseLogging(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := parseLogging(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("parseLogging() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -1255,7 +1255,7 @@ func Test_parseWebsite(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := parseWebsite(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("parseWebsite() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -1328,7 +1328,7 @@ func Test_parseACLRules(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := parseACLRules(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("parseACLRules() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -1431,7 +1431,7 @@ func TestParseBucketSpec(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ParseBucketSpec(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("ParseBucketSpec() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})

--- a/pkg/apis/gcp/storage/v1alpha1/types_test.go
+++ b/pkg/apis/gcp/storage/v1alpha1/types_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
@@ -819,16 +818,13 @@ func TestCopyToBucketAttrs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.args == nil {
-				if got := CopyToBucketAttrs(tt.args); !reflect.DeepEqual(got, tt.want) {
-					t.Errorf("CopyToBucketAttrs() = %+v, want %+v", got, tt.want)
-				}
-			} else {
-				got := CopyToBucketAttrs(tt.args)
+			got := CopyToBucketAttrs(tt.args)
+			if tt.args != nil {
 				got.RetentionPolicy = nil
-				if diff := cmp.Diff(got, tt.want); diff != "" {
-					t.Errorf("CopyToBucketAttrs() = %+v, want %+v\n%s", got, tt.want, diff)
-				}
+			}
+
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("CopyToBucketAttrs() = %+v, want %+v\n%s", got, tt.want, diff)
 			}
 		})
 	}
@@ -855,7 +851,7 @@ func TestCopyToBucketUpdateAttrs(t *testing.T) {
 		tt.want.DeleteLabel("foo")
 		t.Run(tt.name, func(t *testing.T) {
 			got := CopyToBucketUpdateAttrs(tt.args.ba, tt.args.labels)
-			if diff := cmp.Diff(got, tt.want); diff != "" {
+			if diff := cmp.Diff(got, tt.want, cmp.AllowUnexported(storage.BucketAttrsToUpdate{})); diff != "" {
 				t.Errorf("CopyToBucketUpdateAttrs()\n%+v, want \n%+v\n%s", got, tt.want, diff)
 			}
 		})

--- a/pkg/apis/workload/v1alpha1/types_test.go
+++ b/pkg/apis/workload/v1alpha1/types_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	appsv1 "k8s.io/api/apps/v1"
@@ -171,7 +171,7 @@ func TestRemoteStatus(t *testing.T) {
 				t.Fatalf("json.Unmarshal(...): %s", err)
 			}
 
-			if diff := deep.Equal(string(rs.Raw), string(tc.want)); diff != nil {
+			if diff := cmp.Diff(string(rs.Raw), string(tc.want)); diff != "" {
 				t.Errorf("json.Unmarshal(...): got != want: %s", diff)
 			}
 
@@ -180,7 +180,7 @@ func TestRemoteStatus(t *testing.T) {
 				t.Fatalf("json.Marshal(...): %s", err)
 			}
 
-			if diff := deep.Equal(string(got), string(tc.want)); diff != nil {
+			if diff := cmp.Diff(string(got), string(tc.want)); diff != "" {
 				t.Errorf("json.Marshal(...): got != want: %s", diff)
 			}
 		})

--- a/pkg/clients/aws/elasticache/elasticache_test.go
+++ b/pkg/clients/aws/elasticache/elasticache_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -219,7 +219,7 @@ func TestNewCreateReplicationGroupInput(t *testing.T) {
 			if err := got.Validate(); err != nil {
 				t.Errorf("NewCreateReplicationGroupInput(...): invalid input: %v", err)
 			}
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("NewCreateReplicationGroupInput(...): want != got:\n%s", diff)
 			}
 		})
@@ -280,7 +280,7 @@ func TestNewModifyReplicationGroupInput(t *testing.T) {
 			if err := got.Validate(); err != nil {
 				t.Errorf("NewModifyReplicationGroupInput(...): invalid input: %v", err)
 			}
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("NewModifyReplicationGroupInput(...): want != got:\n%s", diff)
 			}
 		})
@@ -307,7 +307,7 @@ func TestNewDeleteReplicationGroupInput(t *testing.T) {
 			if err := got.Validate(); err != nil {
 				t.Errorf("NewDeleteReplicationGroupInput(...): invalid input: %v", err)
 			}
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("NewDeleteReplicationGroupInput(...): want != got:\n%s", diff)
 			}
 		})
@@ -330,7 +330,7 @@ func TestNewDescribeReplicationGroupsInput(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewDescribeReplicationGroupsInput(tc.group)
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("NewDescribeReplicationGroupsInput(...): want != got:\n%s", diff)
 			}
 		})
@@ -353,7 +353,7 @@ func TestNewDescribeCacheClustersInput(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewDescribeCacheClustersInput(tc.cluster)
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("NewDescribeCacheClustersInput(...): want != got:\n%s", diff)
 			}
 		})
@@ -643,7 +643,7 @@ func TestConnectionEndpoint(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := ConnectionEndpoint(tc.rg)
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("ConnectionEndpoint(...): want != got:\n%s", diff)
 			}
 		})

--- a/pkg/clients/azure/redis/redis_test.go
+++ b/pkg/clients/azure/redis/redis_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	redismgmt "github.com/Azure/azure-sdk-for-go/services/redis/mgmt/2018-03-01/redis"
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -108,7 +108,7 @@ func TestNewCreateParameters(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewCreateParameters(tc.r)
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("NewCreateParameters(...): want != got\n%s", diff)
 			}
 		})
@@ -186,7 +186,7 @@ func TestNewUpdateParameters(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewUpdateParameters(tc.r)
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("NewUpdateParameters(...): want != got\n%s", diff)
 			}
 		})

--- a/pkg/clients/azure/resourcegroup/resourcegroup_test.go
+++ b/pkg/clients/azure/resourcegroup/resourcegroup_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
 
 	"github.com/crossplaneio/crossplane/pkg/apis/azure/v1alpha1"
@@ -56,7 +56,7 @@ func TestNewParameters(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewParameters(tc.r)
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("NewParameters(...): want != got\n%s", diff)
 			}
 		})

--- a/pkg/clients/azure/storage/account_test.go
+++ b/pkg/clients/azure/storage/account_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2017-06-01/storage"
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 )
 
@@ -56,7 +56,7 @@ func TestNewStorageAccountClient(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := NewStorageAccountClient(tt.args)
-			if diff := deep.Equal(err, tt.wantErr); diff != nil {
+			if diff := cmp.Diff(err, tt.wantErr); diff != "" {
 				t.Errorf("NewStorageAccountClient() error = %v, wantErr %v\n%s", err, tt.wantErr, diff)
 			}
 			if err != nil && got != nil {
@@ -97,7 +97,7 @@ func TestNewAccountHandle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewAccountHandle(tt.args.client, tt.args.groupName, tt.args.accountName)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("NewAccountHandle() = %v, wantErr %v\n%s", got, tt.want, diff)
 			}
 		})

--- a/pkg/clients/azure/storage/account_test.go
+++ b/pkg/clients/azure/storage/account_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2017-06-01/storage"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+
+	"github.com/crossplaneio/crossplane/pkg/test"
 )
 
 func TestNewStorageAccountClient(t *testing.T) {
@@ -56,7 +58,7 @@ func TestNewStorageAccountClient(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := NewStorageAccountClient(tt.args)
-			if diff := cmp.Diff(err, tt.wantErr); diff != "" {
+			if diff := cmp.Diff(err, tt.wantErr, test.EquateErrors()); diff != "" {
 				t.Errorf("NewStorageAccountClient() error = %v, wantErr %v\n%s", err, tt.wantErr, diff)
 			}
 			if err != nil && got != nil {
@@ -97,7 +99,7 @@ func TestNewAccountHandle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewAccountHandle(tt.args.client, tt.args.groupName, tt.args.accountName)
-			if diff := cmp.Diff(got, tt.want); diff != "" {
+			if diff := cmp.Diff(got, tt.want, cmp.AllowUnexported(AccountHandle{})); diff != "" {
 				t.Errorf("NewAccountHandle() = %v, wantErr %v\n%s", got, tt.want, diff)
 			}
 		})

--- a/pkg/clients/gcp/cloudmemorystore/cloudmemorystore_test.go
+++ b/pkg/clients/gcp/cloudmemorystore/cloudmemorystore_test.go
@@ -18,11 +18,12 @@ package cloudmemorystore
 import (
 	"testing"
 
-	"github.com/go-test/deep"
 	redisv1pb "google.golang.org/genproto/googleapis/cloud/redis/v1"
 	"google.golang.org/genproto/protobuf/field_mask"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/crossplaneio/crossplane/pkg/apis/gcp/cache/v1alpha1"
 )
@@ -91,7 +92,7 @@ func TestInstanceID(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewInstanceID(tc.project, tc.i)
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("NewInstanceID(...): want != got:\n%s", diff)
 			}
 
@@ -173,7 +174,7 @@ func TestNewCreateInstanceRequest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			id := NewInstanceID(tc.project, tc.i)
 			got := NewCreateInstanceRequest(id, tc.i)
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("NewCreateInstanceRequest(...): want != got:\n%v", diff)
 			}
 		})
@@ -233,7 +234,7 @@ func TestNewUpdateInstanceRequest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			id := NewInstanceID(tc.project, tc.i)
 			got := NewUpdateInstanceRequest(id, tc.i)
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("NewUpdateInstanceRequest(...): want != got:\n%v", diff)
 			}
 		})
@@ -329,7 +330,7 @@ func TestNewDeleteInstanceRequest(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewDeleteInstanceRequest(tc.id)
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("NewDeleteInstanceRequest(...): want != got:\n%v", diff)
 			}
 		})
@@ -354,7 +355,7 @@ func TestNewGetInstanceRequest(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewGetInstanceRequest(tc.id)
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("NewGetInstanceRequest(...): want != got:\n%v", diff)
 			}
 		})

--- a/pkg/clients/gcp/gke/gke_test.go
+++ b/pkg/clients/gcp/gke/gke_test.go
@@ -20,7 +20,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"golang.org/x/oauth2/google"
+
+	"github.com/crossplaneio/crossplane/pkg/test"
 )
 
 func TestNewClusterClient(t *testing.T) {
@@ -38,11 +41,16 @@ func TestNewClusterClient(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := NewClusterClient(tt.args)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("NewClusterClient() error = %v, want.err %v\n%s", err, tt.want.err, diff)
 				return
 			}
-			if diff := cmp.Diff(got, tt.want.res); diff != "" {
+
+			// TODO(negz): Do we really want to ignore unexported fields? I did
+			// so to match the previous deep.Equal semantics here, but
+			// ClusterClient _only_ has unexported fields so we're only testing
+			// that NewClusterClient returns the expected type here.
+			if diff := cmp.Diff(got, tt.want.res, cmpopts.IgnoreUnexported(ClusterClient{})); diff != "" {
 				t.Errorf("NewClusterClient() = %v, want %v\n%s", got, tt.want.res, diff)
 			}
 		})

--- a/pkg/clients/gcp/gke/gke_test.go
+++ b/pkg/clients/gcp/gke/gke_test.go
@@ -19,8 +19,7 @@ package gke
 import (
 	"testing"
 
-	"github.com/go-test/deep"
-
+	"github.com/google/go-cmp/cmp"
 	"golang.org/x/oauth2/google"
 )
 
@@ -39,11 +38,11 @@ func TestNewClusterClient(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := NewClusterClient(tt.args)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("NewClusterClient() error = %v, want.err %v\n%s", err, tt.want.err, diff)
 				return
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("NewClusterClient() = %v, want %v\n%s", got, tt.want.res, diff)
 			}
 		})

--- a/pkg/controller/aws/cache/replicationgroup_test.go
+++ b/pkg/controller/aws/cache/replicationgroup_test.go
@@ -826,11 +826,11 @@ func TestConnect(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, gotErr := tc.conn.Connect(ctx, tc.i)
 
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("tc.conn.Connect(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(elastiCache{})); diff != "" {
 				t.Errorf("tc.conn.Connect(...): want != got:\n%s", diff)
 			}
 		})
@@ -1084,7 +1084,7 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotResult, gotErr := tc.rec.Reconcile(tc.req)
 
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
 			}
 

--- a/pkg/controller/aws/cache/replicationgroup_test.go
+++ b/pkg/controller/aws/cache/replicationgroup_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -226,7 +226,7 @@ func TestCreate(t *testing.T) {
 				t.Errorf("tc.csd.Create(...): want: %t got: %t", tc.wantRequeue, gotRequeue)
 			}
 
-			if diff := deep.Equal(tc.want, tc.r); diff != nil {
+			if diff := cmp.Diff(tc.want, tc.r); diff != "" {
 				t.Errorf("r: want != got:\n%s", diff)
 			}
 		})
@@ -645,7 +645,7 @@ func TestSync(t *testing.T) {
 				t.Errorf("tc.csd.Sync(...): want: %t got: %t", tc.wantRequeue, gotRequeue)
 			}
 
-			if diff := deep.Equal(tc.want, tc.r); diff != nil {
+			if diff := cmp.Diff(tc.want, tc.r); diff != "" {
 				t.Errorf("r: want != got:\n%s", diff)
 			}
 		})
@@ -720,7 +720,7 @@ func TestDelete(t *testing.T) {
 				t.Errorf("tc.csd.Delete(...): want: %t got: %t", tc.wantRequeue, gotRequeue)
 			}
 
-			if diff := deep.Equal(tc.want, tc.r); diff != nil {
+			if diff := cmp.Diff(tc.want, tc.r); diff != "" {
 				t.Errorf("r: want != got:\n%s", diff)
 			}
 		})
@@ -826,11 +826,11 @@ func TestConnect(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, gotErr := tc.conn.Connect(ctx, tc.i)
 
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("tc.conn.Connect(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("tc.conn.Connect(...): want != got:\n%s", diff)
 			}
 		})
@@ -990,7 +990,7 @@ func TestReconcile(t *testing.T) {
 							},
 						))
 						got := obj.(*v1alpha1.ReplicationGroup)
-						if diff := deep.Equal(want, got); diff != nil {
+						if diff := cmp.Diff(want, got); diff != "" {
 							t.Errorf("kube.Update(...): want != got:\n%s", diff)
 						}
 						return nil
@@ -1028,7 +1028,7 @@ func TestReconcile(t *testing.T) {
 								},
 							))
 						got := obj.(*v1alpha1.ReplicationGroup)
-						if diff := deep.Equal(want, got); diff != nil {
+						if diff := cmp.Diff(want, got); diff != "" {
 							t.Errorf("kube.Update(...): want != got:\n%s", diff)
 						}
 						return nil
@@ -1067,7 +1067,7 @@ func TestReconcile(t *testing.T) {
 								},
 							))
 						got := obj.(*v1alpha1.ReplicationGroup)
-						if diff := deep.Equal(want, got); diff != nil {
+						if diff := cmp.Diff(want, got); diff != "" {
 							t.Errorf("kube.Update(...): want != got:\n%s", diff)
 						}
 						return nil
@@ -1084,11 +1084,11 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotResult, gotErr := tc.rec.Reconcile(tc.req)
 
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.want, gotResult); diff != nil {
+			if diff := cmp.Diff(tc.want, gotResult); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want != got:\n%s", diff)
 			}
 		})
@@ -1148,7 +1148,7 @@ func TestConnectionSecretWithPassword(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := connectionSecretWithPassword(tc.r, tc.password)
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("connectionSecretWithPassword(...): want != got:\n%s", diff)
 			}
 		})

--- a/pkg/controller/azure/cache/redis_test.go
+++ b/pkg/controller/azure/cache/redis_test.go
@@ -711,11 +711,11 @@ func TestConnect(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, gotErr := tc.conn.Connect(ctx, tc.i)
 
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("tc.conn.Connect(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(azureRedisCache{})); diff != "" {
 				t.Errorf("tc.conn.Connect(...): want != got:\n%s", diff)
 			}
 		})
@@ -1012,7 +1012,7 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotResult, gotErr := tc.rec.Reconcile(tc.req)
 
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
 			}
 

--- a/pkg/controller/azure/cache/redis_test.go
+++ b/pkg/controller/azure/cache/redis_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	redismgmt "github.com/Azure/azure-sdk-for-go/services/redis/mgmt/2018-03-01/redis"
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -227,7 +227,7 @@ func TestCreate(t *testing.T) {
 				t.Errorf("tc.csdk.Create(...): want: %t got: %t", tc.wantRequeue, gotRequeue)
 			}
 
-			if diff := deep.Equal(tc.want, tc.r); diff != nil {
+			if diff := cmp.Diff(tc.want, tc.r); diff != "" {
 				t.Errorf("r: want != got:\n%s", diff)
 			}
 		})
@@ -476,7 +476,7 @@ func TestSync(t *testing.T) {
 				t.Errorf("tc.csdk.Sync(...): want: %t got: %t", tc.wantRequeue, gotRequeue)
 			}
 
-			if diff := deep.Equal(tc.want, tc.r); diff != nil {
+			if diff := cmp.Diff(tc.want, tc.r); diff != "" {
 				t.Errorf("r: want != got:\n%s", diff)
 			}
 		})
@@ -551,7 +551,7 @@ func TestDelete(t *testing.T) {
 				t.Errorf("tc.csdk.Delete(...): want: %t got: %t", tc.wantRequeue, gotRequeue)
 			}
 
-			if diff := deep.Equal(tc.want, tc.r); diff != nil {
+			if diff := cmp.Diff(tc.want, tc.r); diff != "" {
 				t.Errorf("r: want != got:\n%s", diff)
 			}
 		})
@@ -605,7 +605,7 @@ func TestKey(t *testing.T) {
 				t.Errorf("tc.csdk.Key(...): want: %s got: %s", tc.wantKey, gotKey)
 			}
 
-			if diff := deep.Equal(tc.want, tc.r); diff != nil {
+			if diff := cmp.Diff(tc.want, tc.r); diff != "" {
 				t.Errorf("r: want != got:\n%s", diff)
 			}
 		})
@@ -711,11 +711,11 @@ func TestConnect(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, gotErr := tc.conn.Connect(ctx, tc.i)
 
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("tc.conn.Connect(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("tc.conn.Connect(...): want != got:\n%s", diff)
 			}
 		})
@@ -873,7 +873,7 @@ func TestReconcile(t *testing.T) {
 							},
 						))
 						got := obj.(*v1alpha1.Redis)
-						if diff := deep.Equal(want, got); diff != nil {
+						if diff := cmp.Diff(want, got); diff != "" {
 							t.Errorf("kube.Update(...): want != got:\n%s", diff)
 						}
 						return nil
@@ -912,7 +912,7 @@ func TestReconcile(t *testing.T) {
 								},
 							))
 						got := obj.(*v1alpha1.Redis)
-						if diff := deep.Equal(want, got); diff != nil {
+						if diff := cmp.Diff(want, got); diff != "" {
 							t.Errorf("kube.Update(...): want != got:\n%s", diff)
 						}
 						return nil
@@ -951,7 +951,7 @@ func TestReconcile(t *testing.T) {
 								},
 							))
 						got := obj.(*v1alpha1.Redis)
-						if diff := deep.Equal(want, got); diff != nil {
+						if diff := cmp.Diff(want, got); diff != "" {
 							t.Errorf("kube.Update(...): want != got:\n%s", diff)
 						}
 						return nil
@@ -994,7 +994,7 @@ func TestReconcile(t *testing.T) {
 										Message: errors.Wrapf(errorBoom, "cannot update secret %s/%s", namespace, connectionSecretName).Error(),
 									},
 								))
-							if diff := deep.Equal(want, got); diff != nil {
+							if diff := cmp.Diff(want, got); diff != "" {
 								t.Errorf("kube.Update(...): want != got:\n%s", diff)
 							}
 						}
@@ -1012,11 +1012,11 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotResult, gotErr := tc.rec.Reconcile(tc.req)
 
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.want, gotResult); diff != nil {
+			if diff := cmp.Diff(tc.want, gotResult); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want != got:\n%s", diff)
 			}
 		})
@@ -1056,7 +1056,7 @@ func TestConnectionSecret(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := connectionSecret(tc.r, tc.password)
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("connectionSecret(...): want != got:\n%s", diff)
 			}
 		})

--- a/pkg/controller/azure/provider/resourcegroup_test.go
+++ b/pkg/controller/azure/provider/resourcegroup_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -199,7 +199,7 @@ func TestCreate(t *testing.T) {
 				t.Errorf("tc.csd.CreateOrUpdate(...): want: %t got: %t", tc.wantRequeue, gotRequeue)
 			}
 
-			if diff := deep.Equal(tc.want, tc.r); diff != nil {
+			if diff := cmp.Diff(tc.want, tc.r); diff != "" {
 				t.Errorf("r: want != got:\n%s", diff)
 			}
 		})
@@ -319,7 +319,7 @@ func TestSync(t *testing.T) {
 				t.Errorf("tc.csd.CheckExistence(...): want: %t got: %t", tc.wantRequeue, gotRequeue)
 			}
 
-			if diff := deep.Equal(tc.want, tc.r); diff != nil {
+			if diff := cmp.Diff(tc.want, tc.r); diff != "" {
 				t.Errorf("r: want != got:\n%s", diff)
 			}
 		})
@@ -394,7 +394,7 @@ func TestDelete(t *testing.T) {
 				t.Errorf("tc.csd.Delete(...): want: %t got: %t", tc.wantRequeue, gotRequeue)
 			}
 
-			if diff := deep.Equal(tc.want, tc.r); diff != nil {
+			if diff := cmp.Diff(tc.want, tc.r); diff != "" {
 				t.Errorf("r: want != got:\n%s", diff)
 			}
 		})
@@ -508,11 +508,11 @@ func TestConnect(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, gotErr := tc.conn.Connect(ctx, tc.i)
 
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("tc.conn.Connect(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("tc.conn.Connect(...): want != got:\n%s", diff)
 			}
 		})
@@ -659,7 +659,7 @@ func TestReconcile(t *testing.T) {
 							},
 						))
 						got := obj.(*v1alpha1.ResourceGroup)
-						if diff := deep.Equal(want, got); diff != nil {
+						if diff := cmp.Diff(want, got); diff != "" {
 							t.Errorf("kube.Update(...): want != got:\n%s", diff)
 						}
 						return nil
@@ -676,11 +676,11 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotResult, gotErr := tc.rec.Reconcile(tc.req)
 
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.want, gotResult); diff != nil {
+			if diff := cmp.Diff(tc.want, gotResult); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want != got:\n%s", diff)
 			}
 		})

--- a/pkg/controller/azure/provider/resourcegroup_test.go
+++ b/pkg/controller/azure/provider/resourcegroup_test.go
@@ -508,11 +508,11 @@ func TestConnect(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, gotErr := tc.conn.Connect(ctx, tc.i)
 
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("tc.conn.Connect(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(azureResourceGroup{})); diff != "" {
 				t.Errorf("tc.conn.Connect(...): want != got:\n%s", diff)
 			}
 		})
@@ -676,7 +676,7 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotResult, gotErr := tc.rec.Reconcile(tc.req)
 
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
 			}
 

--- a/pkg/controller/azure/storage/account/account_test.go
+++ b/pkg/controller/azure/storage/account/account_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2017-06-01/storage"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -311,11 +311,11 @@ func TestReconciler_Reconcile(t *testing.T) {
 				syncdeleterMaker: tt.fields.maker,
 			}
 			got, err := r.Reconcile(req)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("Reconciler.Reconcile() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 				return
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("Reconciler.Reconcile() result = %v, wantRs %v\n%s", got, tt.want.res, diff)
 			}
 			if tt.want.acct != nil {
@@ -323,7 +323,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 				if err := r.Get(ctx, key, b); err != nil {
 					t.Errorf("Reconciler.Reconcile() account error: %s", err)
 				}
-				if diff := deep.Equal(b, tt.want.acct); diff != nil {
+				if diff := cmp.Diff(b, tt.want.acct); diff != "" {
 					t.Errorf("Reconciler.Reconcile() account = \n%+v, wantObj \n%+v\n%s", b, tt.want.acct, diff)
 				}
 			}
@@ -406,11 +406,11 @@ func Test_accountHandleMaker_newHandler(t *testing.T) {
 				Client: tt.kube,
 			}
 			got, err := m.newSyncdeleter(ctx, tt.acct)
-			if diff := deep.Equal(err, tt.wantErr); diff != nil {
+			if diff := cmp.Diff(err, tt.wantErr); diff != "" {
 				t.Errorf("accountSyncdeleterMaker.newSyncdeleter() error = \n%v, wantErr: \n%v\n%s", err, tt.wantErr, diff)
 				return
 			}
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("accountSyncdeleterMaker.newSyncdeleter() = \n%+v, want \n%+v\n%s", got, tt.want, diff)
 			}
 		})
@@ -528,15 +528,15 @@ func Test_syncdeleter_delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			bh := newAccountSyncDeleter(tt.fields.ao, tt.fields.cc, tt.fields.acct)
 			got, err := bh.delete(ctx)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("accountSyncDeleter.delete() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 				return
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("accountSyncDeleter.delete() result = %v, wantRes %v\n%s", got, tt.want.res, diff)
 				return
 			}
-			if diff := deep.Equal(tt.fields.acct, tt.want.acct); diff != nil {
+			if diff := cmp.Diff(tt.fields.acct, tt.want.acct); diff != "" {
 				t.Errorf("accountSyncDeleter.delete() account = \n%+v, wantObj \n%+v\n%s", tt.fields.acct, tt.want.acct, diff)
 				return
 			}
@@ -633,15 +633,15 @@ func Test_syncdeleter_sync(t *testing.T) {
 			}
 
 			got, err := bh.sync(ctx)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("accountSyncDeleter.delete() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 				return
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("accountSyncDeleter.delete() result = %v, wantRes %v\n%s", got, tt.want.res, diff)
 				return
 			}
-			if diff := deep.Equal(tt.fields.acct, tt.want.acct); diff != nil {
+			if diff := cmp.Diff(tt.fields.acct, tt.want.acct); diff != "" {
 				t.Errorf("accountSyncDeleter.delete() account = \n%+v, wantObj \n%+v\n%s", tt.fields.acct, tt.want.acct, diff)
 				return
 			}
@@ -741,15 +741,15 @@ func Test_createupdater_create(t *testing.T) {
 				projectID:         tt.fields.projectID,
 			}
 			got, err := bh.create(ctx)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("accountCreateUpdater.create() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 				return
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("accountCreateUpdater.create() result = %v, wantRes %v\n%s", got, tt.want.res, diff)
 				return
 			}
-			if diff := deep.Equal(tt.fields.acct, tt.want.obj); diff != nil {
+			if diff := cmp.Diff(tt.fields.acct, tt.want.obj); diff != "" {
 				t.Errorf("accountCreateUpdater.create() account = \n%+v, wantObj \n%+v\n%s", tt.fields.acct, tt.want.obj, diff)
 				return
 			}
@@ -885,15 +885,15 @@ func Test_bucketCreateUpdater_update(t *testing.T) {
 				acct:              tt.fields.acct,
 			}
 			got, err := bh.update(ctx, tt.attrs)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("accountCreateUpdater.update() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 				return
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("accountCreateUpdater.update() result = %v, wantRes %v\n%s", got, tt.want.res, diff)
 				return
 			}
-			if diff := deep.Equal(tt.fields.acct, tt.want.acct); diff != nil {
+			if diff := cmp.Diff(tt.fields.acct, tt.want.acct); diff != "" {
 				t.Errorf("accountCreateUpdater.update() account = \n%+v, wantObj \n%+v\n%s", tt.fields.acct, tt.want.acct, diff)
 				return
 			}
@@ -1022,15 +1022,15 @@ func Test_accountSyncBacker_syncback(t *testing.T) {
 				acct:          tt.fields.acct,
 			}
 			got, err := acu.syncback(ctx, tt.acct)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("accountSyncBackSecretUpdater.syncback() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 				return
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("accountSyncBackSecretUpdater.syncback() result = %v, wantRes %v\n%s", got, tt.want.res, diff)
 				return
 			}
-			if diff := deep.Equal(tt.fields.acct, tt.want.acct); diff != nil {
+			if diff := cmp.Diff(tt.fields.acct, tt.want.acct); diff != "" {
 				t.Errorf("accountSyncBackSecretUpdater.syncback() account = \n%+v, wantObj \n%+v\n%s", tt.fields.acct, tt.want.acct, diff)
 				return
 			}
@@ -1208,7 +1208,7 @@ func Test_accountSecretUpdater_updatesecret(t *testing.T) {
 				kube:              tt.fields.kube,
 			}
 			err := asu.updatesecret(ctx, tt.acct)
-			if diff := deep.Equal(err, tt.wantErr); diff != nil {
+			if diff := cmp.Diff(err, tt.wantErr); diff != "" {
 				t.Errorf("accountSyncBackSecretUpdater.syncback() error = %v, wantErr %v\n%s", err, tt.wantErr, diff)
 				return
 			}

--- a/pkg/controller/azure/storage/container/container_test.go
+++ b/pkg/controller/azure/storage/container/container_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -248,11 +248,11 @@ func TestReconciler_Reconcile(t *testing.T) {
 				syncdeleterMaker: tt.fields.syncdeleterMaker,
 			}
 			got, err := r.Reconcile(req)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("Reconciler.Reconcile() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 				return
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("Reconciler.Reconcile() result = %v, wantRs %v\n%s", got, tt.want.res, diff)
 			}
 			if tt.want.con != nil {
@@ -260,7 +260,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 				if err := tt.fields.Client.Get(ctx, key, c); err != nil {
 					t.Errorf("Reconciler.Reconcile() container error: %s", err)
 				}
-				if diff := deep.Equal(c, tt.want.con); diff != nil {
+				if diff := cmp.Diff(c, tt.want.con); diff != "" {
 					t.Errorf("Reconciler.Reconcile() container = \n%+v, wantObj \n%+v\n%s", c, tt.want.con, diff)
 				}
 			}
@@ -404,7 +404,7 @@ func Test_containerSyncdeleterMaker_newSyncdeleter(t *testing.T) {
 				Client: tt.fields.Client,
 			}
 			got, err := m.newSyncdeleter(tt.args.ctx, tt.args.c)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("containerSyncdeleterMaker.newSyncdeleter() error = \n%v, wantErr \n%v\n%s", err, tt.want.err, diff)
 				return
 			}
@@ -419,7 +419,7 @@ func Test_containerSyncdeleterMaker_newSyncdeleter(t *testing.T) {
 					kube:                tt.fields.Client,
 					container:           tt.args.c,
 				}
-				if diff := deep.Equal(got, tt.want.syndel); diff != nil {
+				if diff := cmp.Diff(got, tt.want.syndel); diff != "" {
 					t.Errorf("containerSyncdeleterMaker.newSyncdeleter() = %v, want %v\n%s", got, tt.want.syndel, diff)
 				}
 			}
@@ -428,7 +428,7 @@ func Test_containerSyncdeleterMaker_newSyncdeleter(t *testing.T) {
 				if err := tt.fields.Client.Get(tt.args.ctx, key, cont); err != nil {
 					t.Errorf("containerSyncdeleterMaker.newSyncdeleter() error validating continer: %v, expected nil", err)
 				}
-				if diff := deep.Equal(cont, tt.want.cont); diff != nil {
+				if diff := cmp.Diff(cont, tt.want.cont); diff != "" {
 					t.Errorf("containerSyncdeleterMaker.newSyncdeleter() container = %v, want %v\n%s", got, tt.want.cont, diff)
 				}
 			}
@@ -529,13 +529,13 @@ func Test_containerSyncdeleter_delete(t *testing.T) {
 				container:           tt.fields.container,
 			}
 			got, err := csd.delete(tt.args.ctx)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("containerSyncdeleter.delete() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("containerSyncdeleter.delete() = %v, want %v\n%s", got, tt.want.res, diff)
 			}
-			if diff := deep.Equal(tt.fields.container, tt.want.cont); diff != nil {
+			if diff := cmp.Diff(tt.fields.container, tt.want.cont); diff != "" {
 				t.Errorf("containerSyncdeleter.delete() container = \n%v, want \n%v\n%s", tt.fields.container, tt.want.cont, diff)
 			}
 		})
@@ -643,13 +643,13 @@ func Test_containerSyncdeleter_sync(t *testing.T) {
 				container:           tt.fields.container,
 			}
 			got, err := csd.sync(tt.args.ctx)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("containerSyncdeleter.sync() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("containerSyncdeleter.sync() = %v, want %v\n%s", got, tt.want.res, diff)
 			}
-			if diff := deep.Equal(tt.fields.container, tt.want.cont); diff != nil {
+			if diff := cmp.Diff(tt.fields.container, tt.want.cont); diff != "" {
 				t.Errorf("containerSyncdeleter.sync() container = \n%v, want \n%v\n%s", tt.fields.container, tt.want.cont, diff)
 			}
 		})
@@ -757,13 +757,13 @@ func Test_containerCreateUpdater_create(t *testing.T) {
 				container:           tt.fields.container,
 			}
 			got, err := ccu.create(tt.args.ctx)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("containerCreateUpdater.create() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("containerCreateUpdater.create() = %v, want %v\n%s", got, tt.want.res, diff)
 			}
-			if diff := deep.Equal(tt.fields.container, tt.want.cont); diff != nil {
+			if diff := cmp.Diff(tt.fields.container, tt.want.cont); diff != "" {
 				t.Errorf("containerCreateUpdater.create() container = \n%v, want \n%v\n%s", tt.fields.container, tt.want.cont, diff)
 			}
 		})
@@ -889,13 +889,13 @@ func Test_containerCreateUpdater_update(t *testing.T) {
 				container:           tt.fields.container,
 			}
 			got, err := ccu.update(tt.args.ctx, tt.args.accessType, tt.args.meta)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("containerCreateUpdater.update() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("containerCreateUpdater.update() = %v, want %v\n%s", got, tt.want.res, diff)
 			}
-			if diff := deep.Equal(tt.fields.container, tt.want.cont); diff != nil {
+			if diff := cmp.Diff(tt.fields.container, tt.want.cont); diff != "" {
 				t.Errorf("containerCreateUpdater.update() container = \n%v, want \n%v\n%s", tt.fields.container, tt.want.cont, diff)
 			}
 		})

--- a/pkg/controller/cache/redis/aws_handler_test.go
+++ b/pkg/controller/cache/redis/aws_handler_test.go
@@ -27,6 +27,7 @@ import (
 	cachev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/cache/v1alpha1"
 	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
 	storagev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/storage/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/test"
 )
 
 const claimversion99 = "9.9"
@@ -97,7 +98,7 @@ func TestResolveAWSClassValues(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			gotErr := resolveAWSClassInstanceValues(tc.class, tc.claim)
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("want error != got error:\n%s", diff)
 			}
 

--- a/pkg/controller/cache/redis/aws_handler_test.go
+++ b/pkg/controller/cache/redis/aws_handler_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
 	"github.com/crossplaneio/crossplane/pkg/apis/aws/cache/v1alpha1"
@@ -97,11 +97,11 @@ func TestResolveAWSClassValues(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			gotErr := resolveAWSClassInstanceValues(tc.class, tc.claim)
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("want error != got error:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.want, tc.class); diff != nil {
+			if diff := cmp.Diff(tc.want, tc.class); diff != "" {
 				t.Errorf("want != got:\n%s", diff)
 			}
 		})

--- a/pkg/controller/cache/redis/azure_handler_test.go
+++ b/pkg/controller/cache/redis/azure_handler_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
 	azurecachev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/azure/cache/v1alpha1"
@@ -58,7 +58,7 @@ func TestResolveAzureClassValues(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := resolveAzureClassValues(tc.claim)
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("want != got:\n%s", diff)
 			}
 		})

--- a/pkg/controller/cache/redis/azure_handler_test.go
+++ b/pkg/controller/cache/redis/azure_handler_test.go
@@ -27,6 +27,7 @@ import (
 	cachev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/cache/v1alpha1"
 	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
 	storagev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/storage/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/test"
 )
 
 func TestResolveAzureClassValues(t *testing.T) {
@@ -58,7 +59,7 @@ func TestResolveAzureClassValues(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := resolveAzureClassValues(tc.claim)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			if diff := cmp.Diff(tc.want, got, test.EquateErrors()); diff != "" {
 				t.Errorf("want != got:\n%s", diff)
 			}
 		})

--- a/pkg/controller/cache/redis/gcp_handler_test.go
+++ b/pkg/controller/cache/redis/gcp_handler_test.go
@@ -27,6 +27,7 @@ import (
 	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
 	gcpcachev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/gcp/cache/v1alpha1"
 	storagev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/storage/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/test"
 )
 
 const (
@@ -88,7 +89,7 @@ func TestResolveGCPClassInstanceValues(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			gotErr := resolveGCPClassInstanceValues(tc.class, tc.claim)
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("want error != got error:\n %+v", diff)
 			}
 

--- a/pkg/controller/cache/redis/gcp_handler_test.go
+++ b/pkg/controller/cache/redis/gcp_handler_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
 	cachev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/cache/v1alpha1"
@@ -88,11 +88,11 @@ func TestResolveGCPClassInstanceValues(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			gotErr := resolveGCPClassInstanceValues(tc.class, tc.claim)
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("want error != got error:\n %+v", diff)
 			}
 
-			if diff := deep.Equal(tc.want, tc.class); diff != nil {
+			if diff := cmp.Diff(tc.want, tc.class); diff != "" {
 				t.Errorf("want != got:\n %+v", diff)
 			}
 		})

--- a/pkg/controller/compute/kubernetes/aws_handler_test.go
+++ b/pkg/controller/compute/kubernetes/aws_handler_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,10 +79,10 @@ func TestEKSClusterHandler_Find(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &EKSClusterHandler{}
 			got, err := r.Find(tt.args.name, tt.args.c)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("EKSClusterHandler.Find() error = %v, want.err %v\n%s", err, tt.want.err, diff)
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("EKSClusterHandler.Find() = %v, want.res %v\n%s", got, tt.want.res, diff)
 			}
 		})
@@ -154,11 +154,11 @@ func TestEKSClusterHandler_Provision(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &EKSClusterHandler{}
 			got, err := r.Provision(tt.args.class, tt.args.claim, tt.args.c)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("EKSClusterHandler.Provision() error = %v, want.err %v\n%s", err, tt.want.err, diff)
 				return
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("EKSClusterHandler.Provision() = \n%v, want.res \n%v\n%s", got, tt.want.res, diff)
 			}
 		})
@@ -260,7 +260,7 @@ func TestEKSClusterHandler_SetBindStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := EKSClusterHandler{}
 			err := r.SetBindStatus(tt.args.name, tt.args.c, tt.args.bound)
-			if diff := deep.Equal(err, tt.want); diff != nil {
+			if diff := cmp.Diff(err, tt.want); diff != "" {
 				t.Errorf("EKSClusterHandler.SetBindStatus() error = %v, want %v\n%s", err, tt.want, diff)
 			}
 		})

--- a/pkg/controller/compute/kubernetes/aws_handler_test.go
+++ b/pkg/controller/compute/kubernetes/aws_handler_test.go
@@ -79,7 +79,7 @@ func TestEKSClusterHandler_Find(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &EKSClusterHandler{}
 			got, err := r.Find(tt.args.name, tt.args.c)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("EKSClusterHandler.Find() error = %v, want.err %v\n%s", err, tt.want.err, diff)
 			}
 			if diff := cmp.Diff(got, tt.want.res); diff != "" {
@@ -154,7 +154,7 @@ func TestEKSClusterHandler_Provision(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &EKSClusterHandler{}
 			got, err := r.Provision(tt.args.class, tt.args.claim, tt.args.c)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("EKSClusterHandler.Provision() error = %v, want.err %v\n%s", err, tt.want.err, diff)
 				return
 			}
@@ -260,7 +260,7 @@ func TestEKSClusterHandler_SetBindStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := EKSClusterHandler{}
 			err := r.SetBindStatus(tt.args.name, tt.args.c, tt.args.bound)
-			if diff := cmp.Diff(err, tt.want); diff != "" {
+			if diff := cmp.Diff(err, tt.want, test.EquateErrors()); diff != "" {
 				t.Errorf("EKSClusterHandler.SetBindStatus() error = %v, want %v\n%s", err, tt.want, diff)
 			}
 		})

--- a/pkg/controller/compute/kubernetes/azure_handler_test.go
+++ b/pkg/controller/compute/kubernetes/azure_handler_test.go
@@ -80,7 +80,7 @@ func TestAKSClusterHandler_Find(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &AKSClusterHandler{}
 			got, err := r.Find(tt.args.name, tt.args.c)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("AKSClusterHandler.Find() error = %v, want.err %v\n%s", err, tt.want.err, diff)
 			}
 			if diff := cmp.Diff(got, tt.want.res); diff != "" {
@@ -156,7 +156,7 @@ func TestAKSClusterHandler_Provision(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &AKSClusterHandler{}
 			got, err := r.Provision(tt.args.class, tt.args.claim, tt.args.c)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("AKSClusterHandler.Provision() error = %v, want.err %v\n%s", err, tt.want.err, diff)
 				return
 			}
@@ -262,7 +262,7 @@ func TestAKSClusterHandler_SetBindStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := AKSClusterHandler{}
 			err := r.SetBindStatus(tt.args.name, tt.args.c, tt.args.bound)
-			if diff := cmp.Diff(err, tt.want); diff != "" {
+			if diff := cmp.Diff(err, tt.want, test.EquateErrors()); diff != "" {
 				t.Errorf("AKSClusterHandler.SetBindStatus() error = %v, want %v\n%s", err, tt.want, diff)
 			}
 		})

--- a/pkg/controller/compute/kubernetes/azure_handler_test.go
+++ b/pkg/controller/compute/kubernetes/azure_handler_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -80,10 +80,10 @@ func TestAKSClusterHandler_Find(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &AKSClusterHandler{}
 			got, err := r.Find(tt.args.name, tt.args.c)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("AKSClusterHandler.Find() error = %v, want.err %v\n%s", err, tt.want.err, diff)
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("AKSClusterHandler.Find() = %v, want.res %v\n%s", got, tt.want.res, diff)
 			}
 		})
@@ -156,11 +156,11 @@ func TestAKSClusterHandler_Provision(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &AKSClusterHandler{}
 			got, err := r.Provision(tt.args.class, tt.args.claim, tt.args.c)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("AKSClusterHandler.Provision() error = %v, want.err %v\n%s", err, tt.want.err, diff)
 				return
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("AKSClusterHandler.Provision() = \n%v, want.res \n%v\n%s", got, tt.want.res, diff)
 			}
 		})
@@ -262,7 +262,7 @@ func TestAKSClusterHandler_SetBindStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := AKSClusterHandler{}
 			err := r.SetBindStatus(tt.args.name, tt.args.c, tt.args.bound)
-			if diff := deep.Equal(err, tt.want); diff != nil {
+			if diff := cmp.Diff(err, tt.want); diff != "" {
 				t.Errorf("AKSClusterHandler.SetBindStatus() error = %v, want %v\n%s", err, tt.want, diff)
 			}
 		})

--- a/pkg/controller/compute/kubernetes/gcp_handler_test.go
+++ b/pkg/controller/compute/kubernetes/gcp_handler_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,10 +79,10 @@ func TestGKEClusterHandler_Find(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &GKEClusterHandler{}
 			got, err := r.Find(tt.args.name, tt.args.c)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("GKEClusterHandler.Find() error = %v, want.err %v\n%s", err, tt.want.err, diff)
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("GKEClusterHandler.Find() = %v, want.res %v\n%s", got, tt.want.res, diff)
 			}
 		})
@@ -154,11 +154,11 @@ func TestGKEClusterHandler_Provision(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &GKEClusterHandler{}
 			got, err := r.Provision(tt.args.class, tt.args.claim, tt.args.c)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("GKEClusterHandler.Provision() error = %v, want.err %v\n%s", err, tt.want.err, diff)
 				return
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("GKEClusterHandler.Provision() = \n%v, want.res \n%v\n%s", got, tt.want.res, diff)
 			}
 		})
@@ -260,7 +260,7 @@ func TestGKEClusterHandler_SetBindStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := GKEClusterHandler{}
 			err := r.SetBindStatus(tt.args.name, tt.args.c, tt.args.bound)
-			if diff := deep.Equal(err, tt.want); diff != nil {
+			if diff := cmp.Diff(err, tt.want); diff != "" {
 				t.Errorf("GKEClusterHandler.SetBindStatus() error = %v, want %v\n%s", err, tt.want, diff)
 			}
 		})

--- a/pkg/controller/compute/kubernetes/gcp_handler_test.go
+++ b/pkg/controller/compute/kubernetes/gcp_handler_test.go
@@ -79,7 +79,7 @@ func TestGKEClusterHandler_Find(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &GKEClusterHandler{}
 			got, err := r.Find(tt.args.name, tt.args.c)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("GKEClusterHandler.Find() error = %v, want.err %v\n%s", err, tt.want.err, diff)
 			}
 			if diff := cmp.Diff(got, tt.want.res); diff != "" {
@@ -154,7 +154,7 @@ func TestGKEClusterHandler_Provision(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &GKEClusterHandler{}
 			got, err := r.Provision(tt.args.class, tt.args.claim, tt.args.c)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("GKEClusterHandler.Provision() error = %v, want.err %v\n%s", err, tt.want.err, diff)
 				return
 			}
@@ -260,7 +260,7 @@ func TestGKEClusterHandler_SetBindStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := GKEClusterHandler{}
 			err := r.SetBindStatus(tt.args.name, tt.args.c, tt.args.bound)
-			if diff := cmp.Diff(err, tt.want); diff != "" {
+			if diff := cmp.Diff(err, tt.want, test.EquateErrors()); diff != "" {
 				t.Errorf("GKEClusterHandler.SetBindStatus() error = %v, want %v\n%s", err, tt.want, diff)
 			}
 		})

--- a/pkg/controller/gcp/cache/cloudmemorystore_instance_test.go
+++ b/pkg/controller/gcp/cache/cloudmemorystore_instance_test.go
@@ -627,11 +627,11 @@ func TestConnect(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, gotErr := tc.conn.Connect(ctx, tc.i)
 
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("tc.conn.Connect(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(cloudMemorystore{})); diff != "" {
 				t.Errorf("tc.conn.Connect(...): want != got:\n%s", diff)
 			}
 		})
@@ -920,7 +920,7 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotResult, gotErr := tc.rec.Reconcile(tc.req)
 
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
 			}
 

--- a/pkg/controller/gcp/cache/cloudmemorystore_instance_test.go
+++ b/pkg/controller/gcp/cache/cloudmemorystore_instance_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	redisv1 "cloud.google.com/go/redis/apiv1"
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	gax "github.com/googleapis/gax-go"
 	"github.com/pkg/errors"
 	redisv1pb "google.golang.org/genproto/googleapis/cloud/redis/v1"
@@ -211,7 +211,7 @@ func TestCreate(t *testing.T) {
 				t.Errorf("tc.csd.Create(...): want: %t got: %t", tc.wantRequeue, gotRequeue)
 			}
 
-			if diff := deep.Equal(tc.want, tc.i); diff != nil {
+			if diff := cmp.Diff(tc.want, tc.i); diff != "" {
 				t.Errorf("i: want != got:\n%s", diff)
 			}
 		})
@@ -437,7 +437,7 @@ func TestSync(t *testing.T) {
 				t.Errorf("tc.csd.Sync(...): want: %t got: %t", tc.wantRequeue, gotRequeue)
 			}
 
-			if diff := deep.Equal(tc.want, tc.i); diff != nil {
+			if diff := cmp.Diff(tc.want, tc.i); diff != "" {
 				t.Errorf("i: want != got:\n%s", diff)
 			}
 		})
@@ -512,7 +512,7 @@ func TestDelete(t *testing.T) {
 				t.Errorf("tc.csd.Delete(...): want: %t got: %t", tc.wantRequeue, gotRequeue)
 			}
 
-			if diff := deep.Equal(tc.want, tc.i); diff != nil {
+			if diff := cmp.Diff(tc.want, tc.i); diff != "" {
 				t.Errorf("i: want != got:\n%s", diff)
 			}
 		})
@@ -627,11 +627,11 @@ func TestConnect(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, gotErr := tc.conn.Connect(ctx, tc.i)
 
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("tc.conn.Connect(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("tc.conn.Connect(...): want != got:\n%s", diff)
 			}
 		})
@@ -781,7 +781,7 @@ func TestReconcile(t *testing.T) {
 							},
 						))
 						got := obj.(*v1alpha1.CloudMemorystoreInstance)
-						if diff := deep.Equal(want, got); diff != nil {
+						if diff := cmp.Diff(want, got); diff != "" {
 							t.Errorf("kube.Update(...): want != got:\n%s", diff)
 						}
 						return nil
@@ -820,7 +820,7 @@ func TestReconcile(t *testing.T) {
 								},
 							))
 						got := obj.(*v1alpha1.CloudMemorystoreInstance)
-						if diff := deep.Equal(want, got); diff != nil {
+						if diff := cmp.Diff(want, got); diff != "" {
 							t.Errorf("kube.Update(...): want != got:\n%s", diff)
 						}
 						return nil
@@ -859,7 +859,7 @@ func TestReconcile(t *testing.T) {
 								},
 							))
 						got := obj.(*v1alpha1.CloudMemorystoreInstance)
-						if diff := deep.Equal(want, got); diff != nil {
+						if diff := cmp.Diff(want, got); diff != "" {
 							t.Errorf("kube.Update(...): want != got:\n%s", diff)
 						}
 						return nil
@@ -902,7 +902,7 @@ func TestReconcile(t *testing.T) {
 										Message: errors.Wrapf(errorBoom, "cannot update secret %s/%s", namespace, connectionSecretName).Error(),
 									},
 								))
-							if diff := deep.Equal(want, got); diff != nil {
+							if diff := cmp.Diff(want, got); diff != "" {
 								t.Errorf("kube.Update(...): want != got:\n%s", diff)
 							}
 						}
@@ -920,11 +920,11 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotResult, gotErr := tc.rec.Reconcile(tc.req)
 
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.want, gotResult); diff != nil {
+			if diff := cmp.Diff(tc.want, gotResult); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want != got:\n%s", diff)
 			}
 		})
@@ -959,7 +959,7 @@ func TestConnectionSecret(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := connectionSecret(tc.i)
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("connectionSecret(...): want != got:\n%s", diff)
 			}
 		})

--- a/pkg/controller/gcp/storage/bucket_operations_test.go
+++ b/pkg/controller/gcp/storage/bucket_operations_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/storage"
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -146,7 +146,7 @@ func Test_bucketHandler_addFinalizer(t *testing.T) {
 			}
 			bc.addFinalizer()
 			got := tt.fields.bucket.Finalizers
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("bucketHandler.addFinalizer() = %v, want %v", got, tt.want)
 			}
 		})
@@ -177,7 +177,7 @@ func Test_bucketHandler_removeFinalizer(t *testing.T) {
 			}
 			bc.removeFinalizer()
 			got := tt.fields.bucket.Finalizers
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("bucketHandler.removeFinalizer() = %v, want %v", got, tt.want)
 			}
 		})
@@ -246,7 +246,7 @@ func Test_bucketHandler_getSpecAttrs(t *testing.T) {
 				Bucket: tt.fields.bucket,
 			}
 			got := bh.getSpecAttrs()
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("bucketHandler.getSpecAttrs() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -278,7 +278,7 @@ func Test_bucketHandler_setSpecAttrs(t *testing.T) {
 			}
 			bh.setSpecAttrs(tt.args)
 			got := tt.fields.bucket.Spec.BucketSpecAttrs
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("bucketHandler.setSpecAttrs() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -309,7 +309,7 @@ func Test_bucketHandler_setStatusAttrs(t *testing.T) {
 			}
 			bh.setStatusAttrs(tt.args)
 			got := tt.fields.bucket.Status.BucketOutputAttrs
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("bucketHandler.setStatusAttrs() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -357,7 +357,7 @@ func Test_bucketHandler_failReconcile(t *testing.T) {
 	if err := bc.failReconcile(ctx, "foo", "bar"); err != nil {
 		t.Errorf("bucketHandler.failReconcile() unexpected error %v", err)
 	}
-	if diff := deep.Equal(bucket, want); diff != nil {
+	if diff := cmp.Diff(bucket, want); diff != "" {
 		t.Errorf("bucketHandler.failReconcile() got = %v, want %v\n%s", bucket, want, diff)
 	}
 
@@ -516,7 +516,7 @@ func Test_bucketHandler_updateSecret(t *testing.T) {
 				kube:   tt.fields.kube,
 			}
 			err := bh.updateSecret(ctx)
-			if diff := deep.Equal(err, tt.want); diff != nil {
+			if diff := cmp.Diff(err, tt.want); diff != "" {
 				t.Errorf("bucketHandler.updateSecret() error = %v, wantErr %v\n%s", err, tt.want, diff)
 			}
 		})
@@ -573,7 +573,7 @@ func Test_bucketHandler_updateBucket(t *testing.T) {
 	if err != nil {
 		t.Errorf("bucketHandler.updateBucket() unexpected error %v", err)
 	}
-	if diff := deep.Equal(got, want); diff != nil {
+	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("bucketHandler.updateBucket() got = %v, want %v\n%s", got, want, diff)
 	}
 }
@@ -608,10 +608,10 @@ func Test_bucketHandler_getAttributes(t *testing.T) {
 				gcp: tt.fields.gcp,
 			}
 			got, err := bh.getAttributes(ctx)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("bucketHandler.getAttributes() error = %v, want.err %v\n%s", err, tt.want.err, diff)
 			}
-			if diff := deep.Equal(got, tt.want.attrs); diff != nil {
+			if diff := cmp.Diff(got, tt.want.attrs); diff != "" {
 				t.Errorf("bucketHandler.getAttributes() = %v, want %v\n%s", got, tt.want.attrs, diff)
 			}
 		})

--- a/pkg/controller/gcp/storage/bucket_operations_test.go
+++ b/pkg/controller/gcp/storage/bucket_operations_test.go
@@ -516,7 +516,7 @@ func Test_bucketHandler_updateSecret(t *testing.T) {
 				kube:   tt.fields.kube,
 			}
 			err := bh.updateSecret(ctx)
-			if diff := cmp.Diff(err, tt.want); diff != "" {
+			if diff := cmp.Diff(err, tt.want, test.EquateErrors()); diff != "" {
 				t.Errorf("bucketHandler.updateSecret() error = %v, wantErr %v\n%s", err, tt.want, diff)
 			}
 		})
@@ -608,7 +608,7 @@ func Test_bucketHandler_getAttributes(t *testing.T) {
 				gcp: tt.fields.gcp,
 			}
 			got, err := bh.getAttributes(ctx)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("bucketHandler.getAttributes() error = %v, want.err %v\n%s", err, tt.want.err, diff)
 			}
 			if diff := cmp.Diff(got, tt.want.attrs); diff != "" {

--- a/pkg/controller/gcp/storage/bucket_test.go
+++ b/pkg/controller/gcp/storage/bucket_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -289,11 +289,11 @@ func TestReconciler_Reconcile(t *testing.T) {
 				factory: tt.fields.factory,
 			}
 			got, err := r.Reconcile(req)
-			if diff := deep.Equal(err, tt.wantErr); diff != nil {
+			if diff := cmp.Diff(err, tt.wantErr); diff != "" {
 				t.Errorf("Reconciler.Reconcile() error = %v, wantErr %v\n%s", err, tt.wantErr, diff)
 				return
 			}
-			if diff := deep.Equal(got, tt.wantRs); diff != nil {
+			if diff := cmp.Diff(got, tt.wantRs); diff != "" {
 				t.Errorf("Reconciler.Reconcile() result = %v, wantRs %v\n%s", got, tt.wantRs, diff)
 			}
 			if tt.wantObj != nil {
@@ -301,7 +301,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 				if err := r.Get(ctx, key, b); err != nil {
 					t.Errorf("Reconciler.Reconcile() bucket error: %s", err)
 				}
-				if diff := deep.Equal(b, tt.wantObj); diff != nil {
+				if diff := cmp.Diff(b, tt.wantObj); diff != "" {
 					t.Errorf("Reconciler.Reconcile() bucket = \n%+v, wantObj \n%+v\n%s", b, tt.wantObj, diff)
 				}
 			}
@@ -400,11 +400,11 @@ func Test_bucketFactory_newHandler(t *testing.T) {
 				Client: tt.Client,
 			}
 			got, err := m.newSyncDeleter(ctx, tt.bucket)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("bucketFactory.newSyncDeleter() error = \n%v, wantErr: \n%v\n%s", err, tt.want.err, diff)
 				return
 			}
-			if diff := deep.Equal(got, tt.want.sd); diff != nil {
+			if diff := cmp.Diff(got, tt.want.sd); diff != "" {
 				t.Errorf("bucketFactory.newSyncDeleter() = \n%+v, want \n%+v\n%s", got, tt.want.sd, diff)
 			}
 		})
@@ -492,11 +492,11 @@ func Test_bucketSyncDeleter_delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			bsd := newBucketSyncDeleter(tt.fields.ops, "")
 			got, err := bsd.delete(ctx)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("bucketSyncDeleter.delete() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 				return
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("bucketSyncDeleter.delete() result = %v, wantRes %v\n%s", got, tt.want.res, diff)
 				return
 			}
@@ -596,11 +596,11 @@ func Test_bucketSyncDeleter_sync(t *testing.T) {
 			}
 
 			got, err := bh.sync(ctx)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("bucketSyncDeleter.sync() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 				return
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("bucketSyncDeleter.sync() result = %v, wantRes %v\n%s", got, tt.want.res, diff)
 				return
 			}
@@ -702,11 +702,11 @@ func Test_bucketCreateUpdater_create(t *testing.T) {
 				projectID:  tt.fields.projectID,
 			}
 			got, err := bh.create(ctx)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("bucketCreateUpdater.create() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 				return
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("bucketCreateUpdater.create() result = %v, wantRes %v\n%s", got, tt.want.res, diff)
 				return
 			}
@@ -815,11 +815,11 @@ func Test_bucketCreateUpdater_update(t *testing.T) {
 				projectID:  tt.fields.projectID,
 			}
 			got, err := bh.update(ctx, tt.args)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("bucketCreateUpdater.update() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 				return
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("bucketCreateUpdater.update() result = %v, wantRes %v\n%s", got, tt.want.res, diff)
 				return
 			}

--- a/pkg/controller/gcp/storage/bucket_test.go
+++ b/pkg/controller/gcp/storage/bucket_test.go
@@ -23,6 +23,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -289,7 +290,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 				factory: tt.fields.factory,
 			}
 			got, err := r.Reconcile(req)
-			if diff := cmp.Diff(err, tt.wantErr); diff != "" {
+			if diff := cmp.Diff(err, tt.wantErr, test.EquateErrors()); diff != "" {
 				t.Errorf("Reconciler.Reconcile() error = %v, wantErr %v\n%s", err, tt.wantErr, diff)
 				return
 			}
@@ -387,6 +388,9 @@ func Test_bucketFactory_newHandler(t *testing.T) {
 				newSecret(ns, secretName).withKeyData(secretKey, secretData).Secret),
 			bucket: newBucket(ns, bucketName).withUID("test-uid").withProvider("test-provider").Bucket,
 			want: want{
+				// BUG(negz): This test is broken. It appears to intend to compare
+				// unexported fields, but does not. This behaviour was maintained
+				// when porting the test from https://github.com/go-test/deep to cmp.
 				sd: newBucketSyncDeleter(
 					newBucketClients(
 						newBucket(ns, bucketName).withUID("test-uid").withProvider("test-provider").Bucket,
@@ -400,11 +404,11 @@ func Test_bucketFactory_newHandler(t *testing.T) {
 				Client: tt.Client,
 			}
 			got, err := m.newSyncDeleter(ctx, tt.bucket)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("bucketFactory.newSyncDeleter() error = \n%v, wantErr: \n%v\n%s", err, tt.want.err, diff)
 				return
 			}
-			if diff := cmp.Diff(got, tt.want.sd); diff != "" {
+			if diff := cmp.Diff(got, tt.want.sd, cmpopts.IgnoreUnexported(bucketSyncDeleter{})); diff != "" {
 				t.Errorf("bucketFactory.newSyncDeleter() = \n%+v, want \n%+v\n%s", got, tt.want.sd, diff)
 			}
 		})
@@ -492,7 +496,7 @@ func Test_bucketSyncDeleter_delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			bsd := newBucketSyncDeleter(tt.fields.ops, "")
 			got, err := bsd.delete(ctx)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("bucketSyncDeleter.delete() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 				return
 			}
@@ -596,7 +600,7 @@ func Test_bucketSyncDeleter_sync(t *testing.T) {
 			}
 
 			got, err := bh.sync(ctx)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("bucketSyncDeleter.sync() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 				return
 			}
@@ -702,7 +706,7 @@ func Test_bucketCreateUpdater_create(t *testing.T) {
 				projectID:  tt.fields.projectID,
 			}
 			got, err := bh.create(ctx)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("bucketCreateUpdater.create() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 				return
 			}
@@ -815,7 +819,7 @@ func Test_bucketCreateUpdater_update(t *testing.T) {
 				projectID:  tt.fields.projectID,
 			}
 			got, err := bh.update(ctx, tt.args)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("bucketCreateUpdater.update() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 				return
 			}

--- a/pkg/controller/storage/bucket/azure_handler_test.go
+++ b/pkg/controller/storage/bucket/azure_handler_test.go
@@ -99,7 +99,7 @@ func TestAzureAccountHandler_Find(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &AzureAccountHandler{}
 			got, err := h.Find(tt.args.n, tt.args.c)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("AzureAccountHandler.Find() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 			}
 			if diff := cmp.Diff(got, tt.want.res); diff != "" {
@@ -209,7 +209,7 @@ func TestAzureAccountHandler_Provision(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &AzureAccountHandler{accountResolver: tt.resolver}
 			got, err := h.Provision(tt.args.class, tt.args.claim, tt.args.c)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("AzureAccountHandler.Provision() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 			}
 			if diff := cmp.Diff(got, tt.want.res); diff != "" {
@@ -259,7 +259,7 @@ func TestAzureContainerHandler_Find(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &AzureContainerHandler{}
 			got, err := h.Find(tt.args.n, tt.args.c)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("AzureContainerHandler.Find() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 			}
 			if diff := cmp.Diff(got, tt.want.res); diff != "" {
@@ -400,7 +400,7 @@ func TestAzureContainerHandler_Provision(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &AzureContainerHandler{}
 			got, err := h.Provision(tt.args.class, tt.args.claim, tt.args.c)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("AzureAccountHandler.Provision() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 			}
 			if diff := cmp.Diff(got, tt.want.res); diff != "" {
@@ -498,7 +498,7 @@ func TestAzureAccountHandler_SetBindStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &AzureAccountHandler{}
 			err := h.SetBindStatus(tt.args.n, tt.args.c, tt.args.bound)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("AzureAccountHandler.SetBindStatus() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 			}
 			if tt.want.act != nil {
@@ -603,7 +603,7 @@ func TestAzureContainerHandler_SetBindStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &AzureContainerHandler{}
 			err := h.SetBindStatus(tt.args.n, tt.args.c, tt.args.bound)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("AzureContainerHandler.SetBindStatus() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 			}
 			if tt.want.con != nil {
@@ -663,7 +663,7 @@ func Test_azureAccountResolver_resolve(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			a := &azureAccountResolver{}
 			err := a.resolve(tt.args.account, tt.args.claim)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("azureAccountResolver.resolve() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 			}
 			if tt.want.act != nil {

--- a/pkg/controller/storage/bucket/azure_handler_test.go
+++ b/pkg/controller/storage/bucket/azure_handler_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -99,10 +99,10 @@ func TestAzureAccountHandler_Find(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &AzureAccountHandler{}
 			got, err := h.Find(tt.args.n, tt.args.c)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("AzureAccountHandler.Find() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("AzureAccountHandler.Find() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -209,10 +209,10 @@ func TestAzureAccountHandler_Provision(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &AzureAccountHandler{accountResolver: tt.resolver}
 			got, err := h.Provision(tt.args.class, tt.args.claim, tt.args.c)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("AzureAccountHandler.Provision() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("AzureAccountHandler.Provision() = \n%v, want \n%v\n%s", got, tt.want.res, diff)
 			}
 		})
@@ -259,10 +259,10 @@ func TestAzureContainerHandler_Find(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &AzureContainerHandler{}
 			got, err := h.Find(tt.args.n, tt.args.c)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("AzureContainerHandler.Find() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("AzureContainerHandler.Find() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -400,10 +400,10 @@ func TestAzureContainerHandler_Provision(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &AzureContainerHandler{}
 			got, err := h.Provision(tt.args.class, tt.args.claim, tt.args.c)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("AzureAccountHandler.Provision() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("AzureAccountHandler.Provision() = \n%v, want \n%v\n%s", got, tt.want.res, diff)
 			}
 		})
@@ -498,7 +498,7 @@ func TestAzureAccountHandler_SetBindStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &AzureAccountHandler{}
 			err := h.SetBindStatus(tt.args.n, tt.args.c, tt.args.bound)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("AzureAccountHandler.SetBindStatus() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 			}
 			if tt.want.act != nil {
@@ -506,7 +506,7 @@ func TestAzureAccountHandler_SetBindStatus(t *testing.T) {
 				if err := tt.args.c.Get(context.TODO(), nn, act); err != nil {
 					t.Errorf("AzureAccountHandler.SetBindStatus() unexected test error getting account: %s", nn)
 				}
-				if diff := deep.Equal(act, tt.want.act); diff != nil {
+				if diff := cmp.Diff(act, tt.want.act); diff != "" {
 					t.Errorf("AzureAccountHandler.SetBindStatus() = %v, want %v\n%s", act, tt.want.act, diff)
 				}
 			}
@@ -603,7 +603,7 @@ func TestAzureContainerHandler_SetBindStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &AzureContainerHandler{}
 			err := h.SetBindStatus(tt.args.n, tt.args.c, tt.args.bound)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("AzureContainerHandler.SetBindStatus() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 			}
 			if tt.want.con != nil {
@@ -611,7 +611,7 @@ func TestAzureContainerHandler_SetBindStatus(t *testing.T) {
 				if err := tt.args.c.Get(context.TODO(), nn, act); err != nil {
 					t.Errorf("AzureContainerHandler.SetBindStatus() unexected test error getting container: %s", nn)
 				}
-				if diff := deep.Equal(act, tt.want.con); diff != nil {
+				if diff := cmp.Diff(act, tt.want.con); diff != "" {
 					t.Errorf("AzureContainerHandler.SetBindStatus() = %v, want %v\n%s", act, tt.want.con, diff)
 				}
 			}
@@ -663,11 +663,11 @@ func Test_azureAccountResolver_resolve(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			a := &azureAccountResolver{}
 			err := a.resolve(tt.args.account, tt.args.claim)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("azureAccountResolver.resolve() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 			}
 			if tt.want.act != nil {
-				if diff := deep.Equal(tt.args.account, tt.want.act); diff != nil {
+				if diff := cmp.Diff(tt.args.account, tt.want.act); diff != "" {
 					t.Errorf("azureAccountResolver.resolve() account = %v, wantErr %v\n%s",
 						tt.args.account, tt.want.act, diff)
 				}

--- a/pkg/controller/storage/bucket/gcp_handler_test.go
+++ b/pkg/controller/storage/bucket/gcp_handler_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -99,10 +99,10 @@ func TestGCSBucketHandler_Find(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &GCSBucketHandler{}
 			got, err := h.Find(tt.args.n, tt.args.c)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("GCSBucketHandler.Find() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("GCSBucketHandler.Find() = %v, want %v\n%s", got, tt.want.res, diff)
 			}
 		})
@@ -165,11 +165,11 @@ func TestGCSBucketHandler_Provision(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &GCSBucketHandler{}
 			got, err := h.Provision(tt.args.class, tt.args.claim, tt.args.c)
-			if diff := deep.Equal(err, tt.want.err); diff != nil {
+			if diff := cmp.Diff(err, tt.want.err); diff != "" {
 				t.Errorf("GCSBucketHandler.Provision() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 				return
 			}
-			if diff := deep.Equal(got, tt.want.res); diff != nil {
+			if diff := cmp.Diff(got, tt.want.res); diff != "" {
 				t.Errorf("GCSBucketHandler.Provision() = \n%+v, want \n%+v\n%s", got, tt.want.res, diff)
 			}
 		})
@@ -228,7 +228,7 @@ func TestGCSBucketHandler_SetBindStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &GCSBucketHandler{}
 			err := h.SetBindStatus(tt.args.n, tt.args.c, tt.args.bound)
-			if diff := deep.Equal(err, tt.wantErr); diff != nil {
+			if diff := cmp.Diff(err, tt.wantErr); diff != "" {
 				t.Errorf("GCSBucketHandler.SetBindStatus() error = %v, wantErr %v\n%s", err, tt.wantErr, diff)
 			}
 		})

--- a/pkg/controller/storage/bucket/gcp_handler_test.go
+++ b/pkg/controller/storage/bucket/gcp_handler_test.go
@@ -99,7 +99,7 @@ func TestGCSBucketHandler_Find(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &GCSBucketHandler{}
 			got, err := h.Find(tt.args.n, tt.args.c)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("GCSBucketHandler.Find() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 			}
 			if diff := cmp.Diff(got, tt.want.res); diff != "" {
@@ -165,7 +165,7 @@ func TestGCSBucketHandler_Provision(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &GCSBucketHandler{}
 			got, err := h.Provision(tt.args.class, tt.args.claim, tt.args.c)
-			if diff := cmp.Diff(err, tt.want.err); diff != "" {
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
 				t.Errorf("GCSBucketHandler.Provision() error = %v, wantErr %v\n%s", err, tt.want.err, diff)
 				return
 			}
@@ -228,7 +228,7 @@ func TestGCSBucketHandler_SetBindStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &GCSBucketHandler{}
 			err := h.SetBindStatus(tt.args.n, tt.args.c, tt.args.bound)
-			if diff := cmp.Diff(err, tt.wantErr); diff != "" {
+			if diff := cmp.Diff(err, tt.wantErr, test.EquateErrors()); diff != "" {
 				t.Errorf("GCSBucketHandler.SetBindStatus() error = %v, wantErr %v\n%s", err, tt.wantErr, diff)
 			}
 		})

--- a/pkg/controller/workload/kubernetes/application/application_test.go
+++ b/pkg/controller/workload/kubernetes/application/application_test.go
@@ -548,7 +548,7 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotResult, gotErr := tc.rec.Reconcile(tc.req)
 
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
 			}
 
@@ -663,7 +663,7 @@ func TestGarbageCollect(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotErr := tc.gc.process(ctx, tc.app)
 
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
 			}
 
@@ -735,7 +735,7 @@ func TestSyncApplicationResource(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotSubmitted, gotErr := tc.ar.sync(ctx, tc.template)
 
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("tc.ar.sync(...): want error != got error:\n%s", diff)
 			}
 

--- a/pkg/controller/workload/kubernetes/application/application_test.go
+++ b/pkg/controller/workload/kubernetes/application/application_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -387,11 +387,11 @@ func TestSync(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotResult := tc.syncer.sync(ctx, tc.app)
 
-			if diff := deep.Equal(tc.wantResult, gotResult); diff != nil {
+			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
 				t.Errorf("tc.sd.Sync(...): want != got:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.wantApp, tc.app); diff != nil {
+			if diff := cmp.Diff(tc.wantApp, tc.app); diff != "" {
 				t.Errorf("app: want != got:\n%s", diff)
 			}
 		})
@@ -422,11 +422,11 @@ func TestDelete(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotResult := tc.deleter.delete(ctx, tc.app)
 
-			if diff := deep.Equal(tc.wantResult, gotResult); diff != nil {
+			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
 				t.Errorf("tc.sd.Sync(...): want != got:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.wantApp, tc.app); diff != nil {
+			if diff := cmp.Diff(tc.wantApp, tc.app); diff != "" {
 				t.Errorf("app: want != got:\n%s", diff)
 			}
 		})
@@ -548,11 +548,11 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotResult, gotErr := tc.rec.Reconcile(tc.req)
 
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.wantResult, gotResult); diff != nil {
+			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want != got:\n%s", diff)
 			}
 		})
@@ -663,11 +663,11 @@ func TestGarbageCollect(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotErr := tc.gc.process(ctx, tc.app)
 
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.wantApp, tc.app); diff != nil {
+			if diff := cmp.Diff(tc.wantApp, tc.app); diff != "" {
 				t.Errorf("app: want != got:\n%s", diff)
 			}
 		})
@@ -735,11 +735,11 @@ func TestSyncApplicationResource(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotSubmitted, gotErr := tc.ar.sync(ctx, tc.template)
 
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("tc.ar.sync(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.wantSubmitted, gotSubmitted); diff != nil {
+			if diff := cmp.Diff(tc.wantSubmitted, gotSubmitted); diff != "" {
 				t.Errorf("tc.ar.Sync(...): want != got:\n%s", diff)
 			}
 		})
@@ -765,7 +765,7 @@ func TestRenderTemplate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := renderTemplate(tc.app, tc.template)
 
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("renderTemplate(...): want != got:\n%s", diff)
 			}
 		})
@@ -851,7 +851,7 @@ func TestHasSameController(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := hasSameController(tc.a, tc.b)
 
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("hasSameController(...): want != got:\n%s", diff)
 			}
 		})
@@ -886,7 +886,7 @@ func TestGetControllerName(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := getControllerName(tc.obj)
 
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("getControllerName(...): want != got:\n%s", diff)
 			}
 		})

--- a/pkg/controller/workload/kubernetes/resource/resource_test.go
+++ b/pkg/controller/workload/kubernetes/resource/resource_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -368,7 +368,7 @@ func TestSync(t *testing.T) {
 							RemoteControllerName:      meta.GetName(),
 							RemoteControllerUID:       string(meta.GetUID()),
 						})
-						if diff := deep.Equal(want, got); diff != nil {
+						if diff := cmp.Diff(want, got); diff != "" {
 							return nil, errors.Errorf("mockSync: want != got: %s", diff)
 						}
 
@@ -385,7 +385,7 @@ func TestSync(t *testing.T) {
 							RemoteControllerName:      meta.GetName(),
 							RemoteControllerUID:       string(meta.GetUID()),
 						})
-						if diff := deep.Equal(want, got); diff != nil {
+						if diff := cmp.Diff(want, got); diff != "" {
 							return errors.Errorf("mockSync: want != got: %s", diff)
 						}
 
@@ -471,11 +471,11 @@ func TestSync(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotResult := tc.syncer.sync(ctx, tc.ar, tc.secrets)
 
-			if diff := deep.Equal(tc.wantResult, gotResult); diff != nil {
+			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
 				t.Errorf("tc.syncer.sync(...): want != got:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.wantAR, tc.ar); diff != nil {
+			if diff := cmp.Diff(tc.wantAR, tc.ar); diff != "" {
 				t.Errorf("app: want != got:\n%s", diff)
 			}
 		})
@@ -502,7 +502,7 @@ func TestDelete(t *testing.T) {
 							RemoteControllerName:      meta.GetName(),
 							RemoteControllerUID:       string(meta.GetUID()),
 						})
-						if diff := deep.Equal(want, got); diff != nil {
+						if diff := cmp.Diff(want, got); diff != "" {
 							errors.Errorf("unstructured mockDelete: want != got: %s", diff)
 						}
 
@@ -519,7 +519,7 @@ func TestDelete(t *testing.T) {
 							RemoteControllerName:      meta.GetName(),
 							RemoteControllerUID:       string(meta.GetUID()),
 						})
-						if diff := deep.Equal(want, got); diff != nil {
+						if diff := cmp.Diff(want, got); diff != "" {
 							return errors.Errorf("secret mockDelete: want != got: %s", diff)
 						}
 
@@ -617,11 +617,11 @@ func TestDelete(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotResult := tc.deleter.delete(ctx, tc.ar, tc.secrets)
 
-			if diff := deep.Equal(tc.wantResult, gotResult); diff != nil {
+			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
 				t.Errorf("tc.deleter.delete(...): want != got:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.wantAR, tc.ar); diff != nil {
+			if diff := cmp.Diff(tc.wantAR, tc.ar); diff != "" {
 				t.Errorf("AR: want != got:\n%s", diff)
 			}
 		})
@@ -701,11 +701,11 @@ func TestSyncUnstructured(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotStatus, gotErr := tc.unstructured.sync(ctx, tc.template)
 
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("tc.unstructured.sync(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.wantStatus, gotStatus); diff != nil {
+			if diff := cmp.Diff(tc.wantStatus, gotStatus); diff != "" {
 				t.Errorf("tc.unstructured.sync(...): want != got:\n%s", diff)
 			}
 		})
@@ -733,7 +733,7 @@ func TestGetRemoteStatus(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := getRemoteStatus(tc.remote)
-			if diff := deep.Equal(tc.want, got); diff != nil {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("getRemoteStatus(...): want != got:\n%s", diff)
 			}
 		})
@@ -800,7 +800,7 @@ func TestDeleteUnstructured(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotErr := tc.unstructured.delete(ctx, tc.template)
 
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("tc.unstructured.delete(...): want error != got error:\n%s", diff)
 			}
 		})
@@ -878,7 +878,7 @@ func TestSyncSecret(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotErr := tc.secret.sync(ctx, tc.template)
 
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("tc.unstructured.sync(...): want error != got error:\n%s", diff)
 			}
 		})
@@ -945,7 +945,7 @@ func TestDeleteSecret(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotErr := tc.secret.delete(ctx, tc.template)
 
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("tc.secret.delete(...): want error != got error:\n%s", diff)
 			}
 		})
@@ -978,7 +978,7 @@ func TestConnectConfig(t *testing.T) {
 								Namespace: cluster.GetNamespace(),
 								Name:      cluster.GetName(),
 							}
-							if diff := deep.Equal(want, got); diff != nil {
+							if diff := cmp.Diff(want, got); diff != "" {
 								return errors.Errorf("MockGet(Secret): want != got: %s", diff)
 							}
 							*actual = *cluster
@@ -988,7 +988,7 @@ func TestConnectConfig(t *testing.T) {
 								Namespace: cluster.GetNamespace(),
 								Name:      secret.GetName(),
 							}
-							if diff := deep.Equal(want, got); diff != nil {
+							if diff := cmp.Diff(want, got); diff != "" {
 								return errors.Errorf("MockGet(Secret): want != got: %s", diff)
 							}
 
@@ -1075,11 +1075,11 @@ func TestConnectConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotConfig, gotErr := tc.connecter.config(ctx, tc.ar)
 
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("tc.connecter.config(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.wantConfig, gotConfig); diff != nil {
+			if diff := cmp.Diff(tc.wantConfig, gotConfig); diff != "" {
 				t.Errorf("tc.connecter.config(...): want != got:\n%s", diff)
 			}
 		})
@@ -1126,11 +1126,11 @@ func TestConnect(t *testing.T) {
 
 			gotSD, gotErr := tc.connecter.connect(ctx, tc.ar)
 
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("tc.connecter.connect(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.wantSD, gotSD); diff != nil {
+			if diff := cmp.Diff(tc.wantSD, gotSD); diff != "" {
 				t.Errorf("tc.connecter.connect(...): want != got:\n%s", diff)
 			}
 		})
@@ -1240,7 +1240,7 @@ func TestReconcile(t *testing.T) {
 							),
 						)
 
-						if diff := deep.Equal(want, got); diff != nil {
+						if diff := cmp.Diff(want, got); diff != "" {
 							return errors.Errorf("MockUpdate: want != got: %s", diff)
 						}
 
@@ -1308,11 +1308,11 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotResult, gotErr := tc.rec.Reconcile(tc.req)
 
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.wantResult, gotResult); diff != nil {
+			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want != got:\n%s", diff)
 			}
 		})
@@ -1371,11 +1371,11 @@ func TestGetConnectionSecrets(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotSecrets := tc.rec.getConnectionSecrets(ctx, tc.ar)
 
-			if diff := deep.Equal(tc.wantSecrets, gotSecrets); diff != nil {
+			if diff := cmp.Diff(tc.wantSecrets, gotSecrets); diff != "" {
 				t.Errorf("tc.rec.getConnectionSecrets(...): want != got:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.wantAR, tc.ar); diff != nil {
+			if diff := cmp.Diff(tc.wantAR, tc.ar); diff != "" {
 				t.Errorf("AR: want != got:\n%s", diff)
 			}
 		})

--- a/pkg/controller/workload/kubernetes/resource/resource_test.go
+++ b/pkg/controller/workload/kubernetes/resource/resource_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -701,7 +702,7 @@ func TestSyncUnstructured(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotStatus, gotErr := tc.unstructured.sync(ctx, tc.template)
 
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("tc.unstructured.sync(...): want error != got error:\n%s", diff)
 			}
 
@@ -800,7 +801,7 @@ func TestDeleteUnstructured(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotErr := tc.unstructured.delete(ctx, tc.template)
 
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("tc.unstructured.delete(...): want error != got error:\n%s", diff)
 			}
 		})
@@ -878,7 +879,7 @@ func TestSyncSecret(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotErr := tc.secret.sync(ctx, tc.template)
 
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("tc.unstructured.sync(...): want error != got error:\n%s", diff)
 			}
 		})
@@ -945,7 +946,7 @@ func TestDeleteSecret(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotErr := tc.secret.delete(ctx, tc.template)
 
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("tc.secret.delete(...): want error != got error:\n%s", diff)
 			}
 		})
@@ -1075,7 +1076,7 @@ func TestConnectConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotConfig, gotErr := tc.connecter.config(ctx, tc.ar)
 
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("tc.connecter.config(...): want error != got error:\n%s", diff)
 			}
 
@@ -1103,10 +1104,10 @@ func TestConnect(t *testing.T) {
 			ar: kubeAR(withCluster(cluster.ObjectReference())),
 
 			// This empty struct is 'identical' to the actual, populated struct
-			// returned by tc.connecter.connect() because deep.Equal does not
-			// compare unexported fields by default. We don't inspect these
-			// unexported fields because doing so would mostly be testing
-			// controller-runtime's client.New() code, not ours.
+			// returned by tc.connecter.connect() because we do not compare
+			// unexported fields. We don't inspect these unexported fields
+			// because doing so would mostly be testing controller-runtime's
+			// client.New() code, not ours.
 			wantSD:  &remoteCluster{},
 			wantErr: nil,
 		},
@@ -1126,11 +1127,11 @@ func TestConnect(t *testing.T) {
 
 			gotSD, gotErr := tc.connecter.connect(ctx, tc.ar)
 
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("tc.connecter.connect(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := cmp.Diff(tc.wantSD, gotSD); diff != "" {
+			if diff := cmp.Diff(tc.wantSD, gotSD, cmpopts.IgnoreUnexported(remoteCluster{})); diff != "" {
 				t.Errorf("tc.connecter.connect(...): want != got:\n%s", diff)
 			}
 		})
@@ -1308,7 +1309,7 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotResult, gotErr := tc.rec.Reconcile(tc.req)
 
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
 			}
 

--- a/pkg/controller/workload/kubernetes/scheduler/scheduler_test.go
+++ b/pkg/controller/workload/kubernetes/scheduler/scheduler_test.go
@@ -440,7 +440,7 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotResult, gotErr := tc.rec.Reconcile(tc.req)
 
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
 			}
 

--- a/pkg/controller/workload/kubernetes/scheduler/scheduler_test.go
+++ b/pkg/controller/workload/kubernetes/scheduler/scheduler_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -319,11 +319,11 @@ func TestSchedule(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotResult := tc.scheduler.schedule(ctx, tc.app)
 
-			if diff := deep.Equal(tc.wantResult, gotResult); diff != nil {
+			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
 				t.Errorf("tc.scheduler.Schedule(...): want != got:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.wantApp, tc.app); diff != nil {
+			if diff := cmp.Diff(tc.wantApp, tc.app); diff != "" {
 				t.Errorf("app: want != got:\n%s", diff)
 			}
 		})
@@ -440,11 +440,11 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotResult, gotErr := tc.rec.Reconcile(tc.req)
 
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
 			}
 
-			if diff := deep.Equal(tc.wantResult, gotResult); diff != nil {
+			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want != got:\n%s", diff)
 			}
 		})

--- a/pkg/test/cmp.go
+++ b/pkg/test/cmp.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2019 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"reflect"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// TODO(negz): Replace this if a similar option is added to cmpopts per
+// https://github.com/google/go-cmp/issues/89
+
+// EquateErrors returns true if the supplied errors are of the same type and
+// produce identical strings. This mirrors the error comparison behaviour of
+// https://github.com/go-test/deep, which most Crossplane tests targeted before
+// we switched to go-cmp.
+func EquateErrors() cmp.Option {
+	return cmp.Comparer(func(a, b error) bool {
+		if a == nil || b == nil {
+			return a == nil && b == nil
+		}
+
+		av := reflect.ValueOf(a)
+		bv := reflect.ValueOf(b)
+		if av.Type() != bv.Type() {
+			return false
+		}
+
+		return a.Error() == b.Error()
+	})
+}

--- a/pkg/util/crud_test.go
+++ b/pkg/util/crud_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -173,7 +173,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotErr := CreateOrUpdate(ctx, tc.kube, tc.obj, tc.f)
 
-			if diff := deep.Equal(tc.wantErr, gotErr); diff != nil {
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
 			}
 		})

--- a/pkg/util/crud_test.go
+++ b/pkg/util/crud_test.go
@@ -173,7 +173,7 @@ func TestCreateOrUpdate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotErr := CreateOrUpdate(ctx, tc.kube, tc.obj, tc.f)
 
-			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, test.EquateErrors()); diff != "" {
 				t.Errorf("tc.rec.Reconcile(...): want error != got error:\n%s", diff)
 			}
 		})

--- a/pkg/util/references_test.go
+++ b/pkg/util/references_test.go
@@ -19,8 +19,7 @@ package util
 import (
 	"testing"
 
-	"github.com/go-test/deep"
-
+	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -73,7 +72,7 @@ func TestAddOwnerReference(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			AddOwnerReference(tt.args.om, tt.args.or)
-			if diff := deep.Equal(tt.args.om, tt.want); diff != nil {
+			if diff := cmp.Diff(tt.args.om, tt.want); diff != "" {
 				t.Errorf("AddOwnerReferenece() %s", diff)
 			}
 		})

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -19,7 +19,7 @@ package util
 import (
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 )
 
@@ -56,7 +56,7 @@ func TestParseMap(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ParseMap(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("parseMap() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -78,7 +78,7 @@ func TestParseBool(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ParseBool(tt.args)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("parseBool() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -155,7 +155,7 @@ func TestConditionalStringFormat(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ConditionalStringFormat(tt.args.format, tt.args.value)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("ConditionalStringFormat() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})
@@ -179,7 +179,7 @@ func TestSplit(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := Split(tt.args.s, tt.args.sep)
-			if diff := deep.Equal(got, tt.want); diff != nil {
+			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("Split() = %v, want %v\n%s", got, tt.want, diff)
 			}
 		})

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -23,7 +23,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -230,7 +230,7 @@ func TestApply(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := Apply(ctx, tt.args.kube, tt.args.o)
-			if diff := deep.Equal(err, tt.want); diff != nil {
+			if diff := cmp.Diff(err, tt.want); diff != "" {
 				t.Errorf("Apply() error = %v, want %v\n%s", err, tt.want, diff)
 			}
 		})

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -230,7 +230,7 @@ func TestApply(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := Apply(ctx, tt.args.kube, tt.args.o)
-			if diff := cmp.Diff(err, tt.want); diff != "" {
+			if diff := cmp.Diff(err, tt.want, test.EquateErrors()); diff != "" {
 				t.Errorf("Apply() error = %v, want %v\n%s", err, tt.want, diff)
 			}
 		})


### PR DESCRIPTION
This is primarily motivated by the fact that https://github.com/google/go-cmp provides more human readable output than https://github.com/go-test/deep when tests fail. In addition to nicer output, `cmp.Diff()` uses variadic rather than package level options, making it easier and less error prone to configure. `cmp.Diff()` is more opinionated than `deep.Equal()` - it's designed to panic rather than return potentially surprising results. See the commit messages in this PR for more details.