### PR TITLE
azure: resource groups naming errors handled by creation

### DIFF
--- a/pkg/clients/azure/resourcegroup/resourcegroup.go
+++ b/pkg/clients/azure/resourcegroup/resourcegroup.go
@@ -18,7 +18,6 @@ package resourcegroup
 
 import (
 	"encoding/json"
-	"regexp"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources/resourcesapi"
@@ -27,14 +26,6 @@ import (
 
 	"github.com/crossplaneio/crossplane/pkg/apis/azure/v1alpha1"
 	"github.com/crossplaneio/crossplane/pkg/clients/azure"
-)
-
-// Resource group naming errors
-const (
-	NameTooShort  = "name of resource group must be at least one character"
-	NameTooLong   = "name of resource group may not be longer than 90 characters"
-	NameEndPeriod = "name of resource group may not end in a period"
-	NameRegex     = "name of resource group is not well-formed per https://docs.microsoft.com/en-us/rest/api/resources/resourcegroups/createorupdate"
 )
 
 // A GroupsClient handles CRUD operations for Azure Resource Group resources.
@@ -75,21 +66,4 @@ func NewParameters(r *v1alpha1.ResourceGroup) resources.Group {
 		Name:     azure.ToStringPtr(r.Spec.Name),
 		Location: azure.ToStringPtr(r.Spec.Location),
 	}
-}
-
-// CheckResourceGroupName checks to make sure Resource Group name adheres to
-func CheckResourceGroupName(name string) error {
-	if len(name) == 0 {
-		return errors.New(NameTooShort)
-	}
-	if len(name) > 90 {
-		return errors.New(NameTooLong)
-	}
-	if name[len(name)-1:] == "." {
-		return errors.New(NameEndPeriod)
-	}
-	if matched, _ := regexp.MatchString(`^[-\w\._\(\)]+$`, name); !matched {
-		return errors.New(NameRegex)
-	}
-	return nil
 }

--- a/pkg/clients/azure/resourcegroup/resourcegroup_test.go
+++ b/pkg/clients/azure/resourcegroup/resourcegroup_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
 	"github.com/google/go-cmp/cmp"
-	"github.com/onsi/gomega"
 
 	"github.com/crossplaneio/crossplane/pkg/apis/azure/v1alpha1"
 	"github.com/crossplaneio/crossplane/pkg/clients/azure"
@@ -58,59 +57,6 @@ func TestNewParameters(t *testing.T) {
 			got := NewParameters(tc.r)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("NewParameters(...): want != got\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestResourceGroupName(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
-
-	cases := []struct {
-		name        string
-		input       string
-		expectedErr string
-	}{
-		// name is OK, should not be modified
-		{
-			name:        "Ok",
-			input:       "foo",
-			expectedErr: "",
-		},
-		// name ends with a period, should not be allowed
-		{
-			name:        "EndWithPeriod",
-			input:       "foo.",
-			expectedErr: NameEndPeriod,
-		},
-		// longer than 90 characters, should not be allowed
-		{
-			name:        "TooLong",
-			input:       "resource-group-name-S2Ixh9w8DmsW0oMwVv4oXbC9Lv3Sn2ARwjp86fwSpb3GOmdFqVZy4la7qwO1OrGbn9uDOEzU2oL01oG4",
-			expectedErr: NameTooLong,
-		},
-		// shorter than 1 character, should not be allowed
-		{
-			name:        "TooShort",
-			input:       "",
-			expectedErr: NameTooShort,
-		},
-		// contains an illegal character, should not be allowed
-		{
-			name:        "PoorlyFormed",
-			input:       "fo^o",
-			expectedErr: NameRegex,
-		},
-	}
-
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			err := CheckResourceGroupName(tt.input)
-			if tt.expectedErr != "" {
-				g.Expect(err).To(gomega.HaveOccurred())
-				g.Expect(err.Error()).To(gomega.Equal(tt.expectedErr))
-			} else {
-				g.Expect(err).NotTo(gomega.HaveOccurred())
 			}
 		})
 	}

--- a/pkg/controller/azure/provider/resourcegroup.go
+++ b/pkg/controller/azure/provider/resourcegroup.go
@@ -90,11 +90,6 @@ type azureResourceGroup struct {
 }
 
 func (a *azureResourceGroup) Create(ctx context.Context, r *v1alpha1.ResourceGroup) bool {
-	if err := resourcegroup.CheckResourceGroupName(r.Spec.Name); err != nil {
-		r.Status.SetFailed(reasonCreatingResource, err.Error())
-		return true
-	}
-
 	if _, err := a.client.CreateOrUpdate(ctx, r.Spec.Name, resourcegroup.NewParameters(r)); err != nil {
 		r.Status.SetFailed(reasonCreatingResource, err.Error())
 		return true

--- a/pkg/controller/azure/provider/resourcegroup_test.go
+++ b/pkg/controller/azure/provider/resourcegroup_test.go
@@ -177,14 +177,18 @@ func TestCreate(t *testing.T) {
 		},
 		{
 			name: "FailedCreateDueToName",
-			csd:  &azureResourceGroup{client: &fakerg.MockClient{}},
-			r:    resource(withSpecName("foo.")),
+			csd: &azureResourceGroup{client: &fakerg.MockClient{
+				MockCreateOrUpdate: func(_ context.Context, _ string, _ resources.Group) (resources.Group, error) {
+					return resources.Group{}, errorBoom
+				},
+			}},
+			r: resource(withSpecName("foo.")),
 			want: resource(withConditions(
 				corev1alpha1.Condition{
 					Type:    corev1alpha1.Failed,
 					Status:  corev1.ConditionTrue,
 					Reason:  reasonCreatingResource,
-					Message: resourcegroup.NameEndPeriod,
+					Message: errorBoom.Error(),
 				},
 			), withSpecName("foo.")),
 			wantRequeue: true,


### PR DESCRIPTION
This commit represents the elimination of manual tests for resource group name and instead utilizes errors on resource group creation.

Signed-off-by: HashedDan <georgedanielmangum@gmail.com>

Many thanks to @jorgecotillo for insight / recommendations!

<!-- Please take a look at our [Contributing](../blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to Crossplane! -->

**Description of your changes:** Manual checking of resource group names was subject to fall behind Azure naming requirements, so it has been eliminated, and errors are checked for when the attempt to create or update the resource group takes place. Original idea (#415) was to validate using ARM templates, but this was deemed be inefficient and cumbersome.

**Which issue is resolved by this Pull Request:**
Resolves #415 

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [x] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [x] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [x] RBAC permissions in `clusterrole.yaml` have been updated to include new types, if necessary
- [x] All related commits have been squashed to improve readability.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
