### PR TITLE
Handle deletion of clusters running a complex workload

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,7 @@ pipeline {
                 always {
                     archiveArtifacts "_output/tests/**/*"
                     junit "_output/tests/**/unit-tests.xml"
-                    cobertura coberturaReportFile: '_output/tests/**/coverage.xml',
+                    cobertura coberturaReportFile: '_output/tests/**/cobertura-coverage.xml',
                             classCoverageTargets: '50, 0, 0',
                             conditionalCoverageTargets: '70, 0, 0',
                             lineCoverageTargets: '40, 0, 0',


### PR DESCRIPTION
If the cluster is gone there's not much we can do to delete the resources we previously deployed to it, so we just remove our finalizer and let the KAR be deleted.

Fixes #459