### PR TITLE
Remove locationConstraint when provisioning S3Bucket in us-east-1

### DIFF
--- a/pkg/clients/aws/s3/s3.go
+++ b/pkg/clients/aws/s3/s3.go
@@ -181,10 +181,18 @@ func isErrorNotFound(err error) bool {
 
 // CreateBucketInput returns a CreateBucketInput from the supplied S3BucketSpec.
 func CreateBucketInput(spec *v1alpha1.S3BucketSpec) *s3.CreateBucketInput {
+	const (
+		// https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+		regionWithNoConstraint = "us-east-1"
+	)
 	bucketInput := &s3.CreateBucketInput{
-		CreateBucketConfiguration: &s3.CreateBucketConfiguration{LocationConstraint: s3.BucketLocationConstraint(spec.Region)},
-		Bucket:                    &spec.Name,
+		Bucket: &spec.Name,
 	}
+
+	if spec.Region != regionWithNoConstraint {
+		bucketInput.CreateBucketConfiguration = &s3.CreateBucketConfiguration{LocationConstraint: s3.BucketLocationConstraint(spec.Region)}
+	}
+
 	if spec.CannedACL != nil {
 		bucketInput.ACL = *spec.CannedACL
 	}


### PR DESCRIPTION
Per the api definition we shouldn't set this constraint in us-east-1.
Verified I can provision in us-east-1 with this change.

Resolves #316 

Signed-off-by: Luke Weber <luke.weber@gmail.com>

<!-- Please take a look at our [Contributing](../blob/master/CONTRIBUTING.md)
documentation before submitting a Pull Request!
Thank you for contributing to Crossplane! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [x] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [x] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [x] RBAC permissions in `clusterrole.yaml` have been updated to include new types, if necessary
- [x] All related commits have been squashed to improve readability.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
