### PR TITLE
add nolint for interfacer check on io.StringWriter, that type is only in go 1.12+

### DIFF
--- a/pkg/extensions/unpack.go
+++ b/pkg/extensions/unpack.go
@@ -220,7 +220,10 @@ func findResourcesFiles(fs afero.Fs, resourcesDir string) ([]string, error) {
 	return resourcesFiles, nil
 }
 
-func readResourceFile(fs afero.Fs, rf string, crdList *v1alpha1.CRDList, sw io.StringWriter) error {
+// Ignore interfacer linter check for this function signature, it wants to use io.StringWriter instead
+// of strings.Builder, but io.StringWriter is only available in go 1.12+ and we support older versions.
+// nolint:interfacer
+func readResourceFile(fs afero.Fs, rf string, crdList *v1alpha1.CRDList, sb *strings.Builder) error {
 	b, err := afero.ReadFile(fs, rf)
 	if err != nil {
 		// we weren't able to read the current resource file, surface this error
@@ -247,7 +250,7 @@ func readResourceFile(fs afero.Fs, rf string, crdList *v1alpha1.CRDList, sw io.S
 	crdList.Owned = append(crdList.Owned, crdTypeMeta)
 
 	// add the raw resource file content to the string builder
-	if _, err := sw.WriteString(yamlSeparator + string(b)); err != nil {
+	if _, err := sb.WriteString(yamlSeparator + string(b)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #468 

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [x] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [x] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [x] RBAC permissions in `clusterrole.yaml` have been updated to include new types, if necessary
- [x] All related commits have been squashed to improve readability.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
