### PR TITLE
Use basic auth for GKE

### DIFF
--- a/pkg/clients/gcp/gke/gke.go
+++ b/pkg/clients/gcp/gke/gke.go
@@ -30,6 +30,10 @@ import (
 const (
 	// DefaultScope used by the GKE API.
 	DefaultScope = container.CloudPlatformScope
+
+	// TODO(negz): Is this username special? I can't see any ClusterRoleBindings
+	// that bind it to a role.
+	adminUser = "admin"
 )
 
 // Client interface to perform cluster operations
@@ -83,9 +87,15 @@ func (c *ClusterClient) CreateCluster(name string, spec computev1alpha1.GKEClust
 		},
 		ResourceLabels: spec.Labels,
 		Zone:           zone,
+
+		// As of Kubernetes 1.12 GKE must be asked to generate a client cert
+		// that will be available via the GKE MasterAuth API. The certificate is
+		// generated with CN=client - a user with no RBAC permissions. Instead
+		// we user basic auth, which is still granted full admin privileges.
 		MasterAuth: &container.MasterAuth{
+			Username: adminUser,
 			ClientCertificateConfig: &container.ClientCertificateConfig{
-				IssueClientCertificate: true,
+				IssueClientCertificate: false,
 			},
 		},
 	}


### PR DESCRIPTION


**Description of your changes:**
This seems to be the only way we can get GKE to create and expose the creds for a user that has cluster-admin(ish?) RBAC permissions.

**Which issue is resolved by this Pull Request:**
Resolves #472 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [ ] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [ ] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [ ] RBAC permissions in `clusterrole.yaml` have been updated to include new types, if necessary
- [ ] All related commits have been squashed to improve readability.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
