### PR TITLE
Allow GKE resource classes to specify node, cluster, and service CIDRs

### DIFF
--- a/cluster/charts/crossplane/crds/gcp/compute/v1alpha1/gkecluster.yaml
+++ b/cluster/charts/crossplane/crds/gcp/compute/v1alpha1/gkecluster.yaml
@@ -58,125 +58,91 @@ spec:
                 type: string
               type: array
             async:
-              description: --adons
               type: boolean
             claimRef:
-              description: Kubernetes object references
               type: object
             classRef:
               type: object
             clusterSecondaryRangeName:
-              description: --cluster-ipv4-cidr
               type: string
             clusterVersion:
-              description: --cluster-secondary-range-name
               type: string
             connectionSecretRef:
               type: object
             createSubnetwork:
-              description: --cluster-version
               type: boolean
             diskSize:
-              description: --create-subnetwork
               type: string
             enableAutorepair:
-              description: --disk-size
               type: boolean
             enableAutoscaling:
-              description: Cluster Autoscaling
               type: boolean
             enableAutoupgrade:
-              description: --enable-autorepair
               type: boolean
             enableBasicAuth:
-              description: --password
               type: boolean
             enableCloudEndpoints:
-              description: --service-account
               type: boolean
             enableCloudLogging:
-              description: --enable-autoupgrade
               type: boolean
             enableCloudMonitoring:
-              description: --no-enable-cloud-logging]
               type: boolean
             enableIPAlias:
-              description: --no-enable-cloud-monitoring
               type: boolean
             enableKubernetesAlpha:
-              description: --enable-ip-alias
               type: boolean
             enableLegacyAuthorization:
-              description: --enable-kubernetes-alpha
               type: boolean
             enableNetworkPolicy:
-              description: --enable-legacy-authorization
               type: boolean
             imageType:
-              description: --enable-network-policy
               type: string
             labels:
-              description: --no-issue-client-certificate
               type: object
             localSSDCount:
-              description: --labels
               format: int64
               type: integer
             machineType:
-              description: --local-ssd-count
               type: string
             maintenanceWindow:
-              description: --machine-types
               type: string
             maxNodes:
-              description: --enable-autoscaling
               format: int64
               type: integer
             maxNodesPerPool:
-              description: '--maintenance-window, example: ''12:43'''
               format: int64
               type: integer
             minCPUPlatform:
-              description: --max-nodes-per-pool
               type: string
             minNodes:
-              description: --max-nodes
               format: int64
               type: integer
             network:
-              description: --min-cpu-platform
               type: string
             noIssueClientCertificates:
-              description: --image-type
               type: boolean
             nodeLabels:
               items:
                 type: string
               type: array
             nodeLocations:
-              description: --node-labels [NODE_LABEL,…]
               items:
                 type: string
               type: array
             nodeTaints:
-              description: --node-locations=ZONE,[ZONE,…]
               items:
                 type: string
               type: array
             nodeVersion:
-              description: --node-taints=[NODE_TAINT,…]
               items:
                 type: string
               type: array
             numNodes:
-              description: --node-version=NODE_VERSION
               format: int64
               type: integer
             password:
-              description: Basic Auth
               type: string
             preemtible:
-              description: --num-nodes=NUM_NODES; default=3
               type: boolean
             providerRef:
               type: object
@@ -185,29 +151,22 @@ spec:
                 after the deletion of this type
               type: string
             scopes:
-              description: --enable-cloud-endpoints
               items:
                 type: string
               type: array
             serviceAccount:
-              description: Node Identity
               type: string
             serviceSecondaryRangeName:
-              description: --services-ipv4-cidr=CIDR
               type: string
             subnetwork:
-              description: --services-secondary-range-name=NAME
               type: string
             tags:
-              description: --subnetwork=SUBNETWORK
               items:
                 type: string
               type: array
             username:
-              description: --enable-basic-auth
               type: string
             zone:
-              description: --tags=TAG,[TAG,…]
               type: string
           type: object
         status:

--- a/cluster/charts/crossplane/crds/gcp/compute/v1alpha1/gkecluster.yaml
+++ b/cluster/charts/crossplane/crds/gcp/compute/v1alpha1/gkecluster.yaml
@@ -150,7 +150,6 @@ spec:
               description: --image-type
               type: boolean
             nodeLabels:
-              description: --network
               items:
                 type: string
               type: array

--- a/pkg/apis/gcp/compute/v1alpha1/types.go
+++ b/pkg/apis/gcp/compute/v1alpha1/types.go
@@ -40,56 +40,55 @@ const (
 
 // GKEClusterSpec specifies the configuration of a GKE cluster.
 type GKEClusterSpec struct {
-	Addons                    []string          `json:"addons,omitempty"`                    //--adons
-	Async                     bool              `json:"async,omitempty"`                     //--async
-	ClusterIPV4CIDR           string            `json:"clusterIPV4CIDR,omitempty"`           //--cluster-ipv4-cidr
-	ClusterSecondaryRangeName string            `json:"clusterSecondaryRangeName,omitempty"` //--cluster-secondary-range-name
-	ClusterVersion            string            `json:"clusterVersion,omitempty"`            //--cluster-version
-	CreateSubnetwork          bool              `json:"createSubnetwork,omitempty"`          //--create-subnetwork
-	DiskSize                  string            `json:"diskSize,omitempty"`                  //--disk-size
-	EnableAutorepair          bool              `json:"enableAutorepair,omitempty"`          //--enable-autorepair
-	EnableAutoupgrade         bool              `json:"enableAutoupgrade,omitempty"`         //--enable-autoupgrade
-	EnableCloudLogging        bool              `json:"enableCloudLogging,omitempty"`        //--no-enable-cloud-logging]
-	EnableCloudMonitoring     bool              `json:"enableCloudMonitoring,omitempty"`     //--no-enable-cloud-monitoring
-	EnableIPAlias             bool              `json:"enableIPAlias,omitempty"`             //--enable-ip-alias
-	EnableKubernetesAlpha     bool              `json:"enableKubernetesAlpha,omitempty"`     //--enable-kubernetes-alpha
-	EnableLegacyAuthorization bool              `json:"enableLegacyAuthorization,omitempty"` //--enable-legacy-authorization
-	EnableNetworkPolicy       bool              `json:"enableNetworkPolicy,omitempty"`       //--enable-network-policy
-	ImageType                 string            `json:"imageType,omitempty"`                 //--image-type
-	NoIssueClientCertificates bool              `json:"noIssueClientCertificates,omitempty"` //--no-issue-client-certificate
-	Labels                    map[string]string `json:"labels,omitempty"`                    //--labels
-	LocalSSDCount             int64             `json:"localSSDCount,omitempty"`             //--local-ssd-count
-	MachineType               string            `json:"machineType,omitempty"`               //--machine-types
-	MaintenanceWindow         string            `json:"maintenanceWindow,omitempty"`         //--maintenance-window, example: '12:43'
-	MaxNodesPerPool           int64             `json:"maxNodesPerPool,omitempty"`           //--max-nodes-per-pool
-	MinCPUPlatform            string            `json:"minCPUPlatform,omitempty"`            //--min-cpu-platform
-	Network                   string            `json:"network,omitempty"`                   //--network
+	Addons                    []string          `json:"addons,omitempty"`
+	Async                     bool              `json:"async,omitempty"`
+	ClusterIPV4CIDR           string            `json:"clusterIPV4CIDR,omitempty"`
+	ClusterSecondaryRangeName string            `json:"clusterSecondaryRangeName,omitempty"`
+	ClusterVersion            string            `json:"clusterVersion,omitempty"`
+	CreateSubnetwork          bool              `json:"createSubnetwork,omitempty"`
+	DiskSize                  string            `json:"diskSize,omitempty"`
+	EnableAutorepair          bool              `json:"enableAutorepair,omitempty"`
+	EnableAutoupgrade         bool              `json:"enableAutoupgrade,omitempty"`
+	EnableCloudLogging        bool              `json:"enableCloudLogging,omitempty"`
+	EnableCloudMonitoring     bool              `json:"enableCloudMonitoring,omitempty"`
+	EnableIPAlias             bool              `json:"enableIPAlias,omitempty"`
+	EnableKubernetesAlpha     bool              `json:"enableKubernetesAlpha,omitempty"`
+	EnableLegacyAuthorization bool              `json:"enableLegacyAuthorization,omitempty"`
+	EnableNetworkPolicy       bool              `json:"enableNetworkPolicy,omitempty"`
+	ImageType                 string            `json:"imageType,omitempty"`
+	NoIssueClientCertificates bool              `json:"noIssueClientCertificates,omitempty"`
+	Labels                    map[string]string `json:"labels,omitempty"`
+	LocalSSDCount             int64             `json:"localSSDCount,omitempty"`
+	MachineType               string            `json:"machineType,omitempty"`
+	MaintenanceWindow         string            `json:"maintenanceWindow,omitempty"`
+	MaxNodesPerPool           int64             `json:"maxNodesPerPool,omitempty"`
+	MinCPUPlatform            string            `json:"minCPUPlatform,omitempty"`
+	Network                   string            `json:"network,omitempty"`
 	NodeIPV4CIDR              string            `json:"nodeIPV4CIDR,omitempty"`
-	NodeLabels                []string          `json:"nodeLabels,omitempty"`                //--node-labels [NODE_LABEL,…]
-	NodeLocations             []string          `json:"nodeLocations,omitempty"`             //--node-locations=ZONE,[ZONE,…]
-	NodeTaints                []string          `json:"nodeTaints,omitempty"`                //--node-taints=[NODE_TAINT,…]
-	NodeVersion               []string          `json:"nodeVersion,omitempty"`               //--node-version=NODE_VERSION
-	NumNodes                  int64             `json:"numNodes,omitempty"`                  //--num-nodes=NUM_NODES; default=3
-	Preemtible                bool              `json:"preemtible,omitempty"`                //--preemptible
-	ServiceIPV4CIDR           string            `json:"serviceIPV4CIDR,omitempty"`           //--services-ipv4-cidr=CIDR
-	ServiceSecondaryRangeName string            `json:"serviceSecondaryRangeName,omitempty"` //--services-secondary-range-name=NAME
-	Subnetwork                string            `json:"subnetwork,omitempty"`                //--subnetwork=SUBNETWORK
-	Tags                      []string          `json:"tags,omitempty"`                      //--tags=TAG,[TAG,…]
-	Zone                      string            `json:"zone,omitempty"`                      //--zone
-	// Cluster Autoscaling
-	EnableAutoscaling bool  `json:"enableAutoscaling,omitempty"` //--enable-autoscaling
-	MaxNodes          int64 `json:"maxNodes,omitempty"`          //--max-nodes
-	MinNodes          int64 `json:"minNodes,omitempty"`          //--min-nodes
-	// Basic Auth
-	Password        string `json:"password,omitempty"`        //--password
-	EnableBasicAuth bool   `json:"enableBasicAuth,omitempty"` //--enable-basic-auth
-	Username        string `json:"username,omitempty"`        //--username (-u) default:"admin"
-	// Node Identity
-	ServiceAccount       string   `json:"serviceAccount,omitempty,omitempty"` //--service-account
-	EnableCloudEndpoints bool     `json:"enableCloudEndpoints,omitempty"`     //--enable-cloud-endpoints
-	Scopes               []string `json:"scopes,omitempty"`                   //--scopes=[SCOPE,…]; default="gke-default"
+	NodeLabels                []string          `json:"nodeLabels,omitempty"`
+	NodeLocations             []string          `json:"nodeLocations,omitempty"`
+	NodeTaints                []string          `json:"nodeTaints,omitempty"`
+	NodeVersion               []string          `json:"nodeVersion,omitempty"`
+	NumNodes                  int64             `json:"numNodes,omitempty"`
+	Preemtible                bool              `json:"preemtible,omitempty"`
+	ServiceIPV4CIDR           string            `json:"serviceIPV4CIDR,omitempty"`
+	ServiceSecondaryRangeName string            `json:"serviceSecondaryRangeName,omitempty"`
+	Subnetwork                string            `json:"subnetwork,omitempty"`
+	Tags                      []string          `json:"tags,omitempty"`
+	Zone                      string            `json:"zone,omitempty"`
 
-	// Kubernetes object references
+	EnableAutoscaling bool  `json:"enableAutoscaling,omitempty"`
+	MaxNodes          int64 `json:"maxNodes,omitempty"`
+	MinNodes          int64 `json:"minNodes,omitempty"`
+
+	Password        string `json:"password,omitempty"`
+	EnableBasicAuth bool   `json:"enableBasicAuth,omitempty"`
+	Username        string `json:"username,omitempty"`
+
+	ServiceAccount       string   `json:"serviceAccount,omitempty,omitempty"`
+	EnableCloudEndpoints bool     `json:"enableCloudEndpoints,omitempty"`
+	Scopes               []string `json:"scopes,omitempty"`
+
 	ClaimRef            *corev1.ObjectReference      `json:"claimRef,omitempty"`
 	ClassRef            *corev1.ObjectReference      `json:"classRef,omitempty"`
 	ConnectionSecretRef *corev1.LocalObjectReference `json:"connectionSecretRef,omitempty"`

--- a/pkg/apis/gcp/compute/v1alpha1/types.go
+++ b/pkg/apis/gcp/compute/v1alpha1/types.go
@@ -64,6 +64,7 @@ type GKEClusterSpec struct {
 	MaxNodesPerPool           int64             `json:"maxNodesPerPool,omitempty"`           //--max-nodes-per-pool
 	MinCPUPlatform            string            `json:"minCPUPlatform,omitempty"`            //--min-cpu-platform
 	Network                   string            `json:"network,omitempty"`                   //--network
+	NodeIPV4CIDR              string            `json:"nodeIPV4CIDR,omitempty"`
 	NodeLabels                []string          `json:"nodeLabels,omitempty"`                //--node-labels [NODE_LABEL,…]
 	NodeLocations             []string          `json:"nodeLocations,omitempty"`             //--node-locations=ZONE,[ZONE,…]
 	NodeTaints                []string          `json:"nodeTaints,omitempty"`                //--node-taints=[NODE_TAINT,…]
@@ -139,24 +140,20 @@ type GKEClusterList struct {
 
 // ParseClusterSpec from properties map
 func ParseClusterSpec(properties map[string]string) *GKEClusterSpec {
-	spec := &GKEClusterSpec{
-		ReclaimPolicy: DefaultReclaimPolicy,
+	return &GKEClusterSpec{
+		ReclaimPolicy:    DefaultReclaimPolicy,
+		ClusterVersion:   properties["clusterVersion"],
+		Labels:           util.ParseMap(properties["labels"]),
+		MachineType:      properties["machineType"],
+		NumNodes:         parseNodesNumber(properties["numNodes"]),
+		Scopes:           util.Split(properties["scopes"], ","),
+		Zone:             properties["zone"],
+		EnableIPAlias:    util.ParseBool(properties["enableIPAlias"]),
+		CreateSubnetwork: util.ParseBool(properties["createSubnetwork"]),
+		ClusterIPV4CIDR:  properties["clusterIPV4CIDR"],
+		ServiceIPV4CIDR:  properties["serviceIPV4CIDR"],
+		NodeIPV4CIDR:     properties["nodeIPV4CIDR"],
 	}
-
-	if len(properties) == 0 {
-		return spec
-	}
-
-	spec.ClusterVersion = properties["clusterVersion"]
-	spec.EnableIPAlias = util.ParseBool(properties["enableIPAlias"])
-	spec.Labels = util.ParseMap(properties["labels"])
-	spec.MachineType = properties["machineType"]
-	spec.NumNodes = parseNodesNumber(properties["numNodes"])
-	spec.Scopes = util.Split(properties["scopes"], ",")
-	spec.Zone = properties["zone"]
-	spec.CreateSubnetwork = util.ParseBool(properties["createSubnetwork"])
-
-	return spec
 }
 
 // parseNodesNumber from the input string value

--- a/pkg/apis/gcp/compute/v1alpha1/types_test.go
+++ b/pkg/apis/gcp/compute/v1alpha1/types_test.go
@@ -87,12 +87,24 @@ func TestParseClusterSpec(t *testing.T) {
 		{
 			name: "NilProperties",
 			args: nil,
-			want: &GKEClusterSpec{ReclaimPolicy: DefaultReclaimPolicy},
+			want: &GKEClusterSpec{
+				ReclaimPolicy: DefaultReclaimPolicy,
+				EnableIPAlias: false,
+				Labels:        map[string]string{},
+				NumNodes:      1,
+				Scopes:        []string{},
+			},
 		},
 		{
 			name: "EmptyProperties",
 			args: map[string]string{},
-			want: &GKEClusterSpec{ReclaimPolicy: DefaultReclaimPolicy},
+			want: &GKEClusterSpec{
+				ReclaimPolicy: DefaultReclaimPolicy,
+				EnableIPAlias: false,
+				Labels:        map[string]string{},
+				NumNodes:      1,
+				Scopes:        []string{},
+			},
 		},
 		{
 			name: "ValidValues",
@@ -156,8 +168,8 @@ func TestParseClusterSpec(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ParseClusterSpec(tt.args)
-			if diff := cmp.Diff(got, tt.want); diff != "" {
-				t.Errorf("ParseClusterSpec() = %v, want %v\n%s", got, tt.want, diff)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("ParseClusterSpec(): -want, +got\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/compute/kubernetes/gcp_handler_test.go
+++ b/pkg/controller/compute/kubernetes/gcp_handler_test.go
@@ -127,6 +127,9 @@ func TestGKEClusterHandler_Provision(t *testing.T) {
 						OwnerReferences: []v1.OwnerReference{claim.OwnerReference()},
 					},
 					Spec: v1alpha1.GKEClusterSpec{
+						NumNodes: 1,
+						Labels:   map[string]string{},
+						Scopes:   []string{},
 						ClassRef: class.ObjectReference(),
 						ClaimRef: claim.ObjectReference(),
 					},
@@ -158,8 +161,8 @@ func TestGKEClusterHandler_Provision(t *testing.T) {
 				t.Errorf("GKEClusterHandler.Provision() error = %v, want.err %v\n%s", err, tt.want.err, diff)
 				return
 			}
-			if diff := cmp.Diff(got, tt.want.res); diff != "" {
-				t.Errorf("GKEClusterHandler.Provision() = \n%v, want.res \n%v\n%s", got, tt.want.res, diff)
+			if diff := cmp.Diff(tt.want.res, got); diff != "" {
+				t.Errorf("GKEClusterHandler.Provision() -want, +got:\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
**Description of your changes:**
This allows us to ask for node, pod (aka cluster), and service subnets of specific sizes. For example:

```yaml
apiVersion: core.crossplane.io/v1alpha1
kind: ResourceClass
metadata:
  name: standard-cluster
  namespace: crossplane-system
parameters:
  labels: "provisioner:crossplane,owner:negz"
  machineType: n1-standard-1
  numNodes: "2"
  zone: us-central1-b

  # Subnet related fields.
  enableIPAlias: "true"
  createSubnetwork: "true"
  clusterIPV4CIDR: "/21"  # This is the smallest CIDR we're allowed to request.
  serviceIPV4CIDR: "/24"
  nodeIPV4CIDR: "/28"
provisioner: gkecluster.compute.gcp.crossplane.io/v1alpha1
providerRef:
  name: gcp-provider
reclaimPolicy: Delete
---
apiVersion: compute.crossplane.io/v1alpha1
kind: KubernetesCluster
metadata:
  name: gke-test
spec:
  classReference:
    name: standard-cluster
    namespace: crossplane-system
```

It's also possible to assign specific CIDRs for each purpose, but the chosen CIDRs must be valid and not conflict within the cluster's VPC.

Note that this PR includes some slight refactoring, the most notable part of which is that we'll no longer automatically enable IP Alias ranges when subnet creation is enabled; if a user asks for a subnet to be created but does not ask for IP Alias ranges the cluster will be created with neither. This matches the behaviour of the GKE API In the same situation.