### PR TITLE
Update HELM chart template(s) to be compatible with Helm v3 version.

### DIFF
--- a/cluster/charts/crossplane/templates/NOTES.txt
+++ b/cluster/charts/crossplane/templates/NOTES.txt
@@ -3,8 +3,6 @@ Release: {{.Release.Name}}
 Chart Name: {{.Chart.Name}}
 Chart Description: {{.Chart.Description}}
 Chart Version: {{.Chart.Version}}
-Chart API Version: {{.Chart.ApiVersion}}
 Chart Application Version: {{.Chart.AppVersion}}
 
 Kube Version: {{.Capabilities.KubeVersion}}
-Tiller Version: {{.Capabilities.TillerVersion}}


### PR DESCRIPTION
Helm v3 removed some of the propertiels which will fail `helm lint`:
```
Error: 1 chart(s) linted, 1 chart(s) failed
        %!s(<nil>)
        [INFO] Chart.yaml: icon is recommended
        [ERROR] templates/: render error at (crossplane/templates/NOTES.txt:6:27): can't evaluate field ApiVersion in type interface {}  
```

![image](https://user-images.githubusercontent.com/324803/58513190-c215fb80-8153-11e9-8ee8-bfbd4f3aecc1.png)

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [ ] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [ ] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [ ] RBAC permissions in `clusterrole.yaml` have been updated to include new types, if necessary
- [ ] All related commits have been squashed to improve readability.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)