### PR TITLE
Replace deep.Equal() style test diffs with cmp.Diff style.

### DIFF
--- a/pkg/apis/core/v1alpha1/bindingphase_test.go
+++ b/pkg/apis/core/v1alpha1/bindingphase_test.go
@@ -52,7 +52,7 @@ func TestBindingStateMarshalJSON(t *testing.T) {
 				t.Errorf("BindingState.MarshalJSON(): %v", err)
 			}
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("BindingState.MarshalJSON(): want != got\n %+v", diff)
+				t.Errorf("BindingState.MarshalJSON(): -want, +got\n %+v", diff)
 			}
 		})
 	}
@@ -102,7 +102,7 @@ func TestBindingStateUnmarshalJSON(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("BindingState.UnmarshalJSON(): want != got\n %+v", diff)
+				t.Errorf("BindingState.UnmarshalJSON(): -want, +got\n %+v", diff)
 			}
 		})
 	}

--- a/pkg/clients/aws/elasticache/elasticache_test.go
+++ b/pkg/clients/aws/elasticache/elasticache_test.go
@@ -220,7 +220,7 @@ func TestNewCreateReplicationGroupInput(t *testing.T) {
 				t.Errorf("NewCreateReplicationGroupInput(...): invalid input: %v", err)
 			}
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("NewCreateReplicationGroupInput(...): want != got:\n%s", diff)
+				t.Errorf("NewCreateReplicationGroupInput(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -281,7 +281,7 @@ func TestNewModifyReplicationGroupInput(t *testing.T) {
 				t.Errorf("NewModifyReplicationGroupInput(...): invalid input: %v", err)
 			}
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("NewModifyReplicationGroupInput(...): want != got:\n%s", diff)
+				t.Errorf("NewModifyReplicationGroupInput(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -308,7 +308,7 @@ func TestNewDeleteReplicationGroupInput(t *testing.T) {
 				t.Errorf("NewDeleteReplicationGroupInput(...): invalid input: %v", err)
 			}
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("NewDeleteReplicationGroupInput(...): want != got:\n%s", diff)
+				t.Errorf("NewDeleteReplicationGroupInput(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -331,7 +331,7 @@ func TestNewDescribeReplicationGroupsInput(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewDescribeReplicationGroupsInput(tc.group)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("NewDescribeReplicationGroupsInput(...): want != got:\n%s", diff)
+				t.Errorf("NewDescribeReplicationGroupsInput(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -354,7 +354,7 @@ func TestNewDescribeCacheClustersInput(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewDescribeCacheClustersInput(tc.cluster)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("NewDescribeCacheClustersInput(...): want != got:\n%s", diff)
+				t.Errorf("NewDescribeCacheClustersInput(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -644,7 +644,7 @@ func TestConnectionEndpoint(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := ConnectionEndpoint(tc.rg)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("ConnectionEndpoint(...): want != got:\n%s", diff)
+				t.Errorf("ConnectionEndpoint(...): -want, +got:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/clients/azure/redis/redis_test.go
+++ b/pkg/clients/azure/redis/redis_test.go
@@ -109,7 +109,7 @@ func TestNewCreateParameters(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewCreateParameters(tc.r)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("NewCreateParameters(...): want != got\n%s", diff)
+				t.Errorf("NewCreateParameters(...): -want, +got\n%s", diff)
 			}
 		})
 	}
@@ -187,7 +187,7 @@ func TestNewUpdateParameters(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewUpdateParameters(tc.r)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("NewUpdateParameters(...): want != got\n%s", diff)
+				t.Errorf("NewUpdateParameters(...): -want, +got\n%s", diff)
 			}
 		})
 	}

--- a/pkg/clients/azure/resourcegroup/resourcegroup_test.go
+++ b/pkg/clients/azure/resourcegroup/resourcegroup_test.go
@@ -56,7 +56,7 @@ func TestNewParameters(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewParameters(tc.r)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("NewParameters(...): want != got\n%s", diff)
+				t.Errorf("NewParameters(...): -want, +got\n%s", diff)
 			}
 		})
 	}

--- a/pkg/clients/gcp/cloudmemorystore/cloudmemorystore_test.go
+++ b/pkg/clients/gcp/cloudmemorystore/cloudmemorystore_test.go
@@ -93,7 +93,7 @@ func TestInstanceID(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewInstanceID(tc.project, tc.i)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("NewInstanceID(...): want != got:\n%s", diff)
+				t.Errorf("NewInstanceID(...): -want, +got:\n%s", diff)
 			}
 
 			gotName := got.Name()
@@ -175,7 +175,7 @@ func TestNewCreateInstanceRequest(t *testing.T) {
 			id := NewInstanceID(tc.project, tc.i)
 			got := NewCreateInstanceRequest(id, tc.i)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("NewCreateInstanceRequest(...): want != got:\n%v", diff)
+				t.Errorf("NewCreateInstanceRequest(...): -want, +got:\n%v", diff)
 			}
 		})
 	}
@@ -235,7 +235,7 @@ func TestNewUpdateInstanceRequest(t *testing.T) {
 			id := NewInstanceID(tc.project, tc.i)
 			got := NewUpdateInstanceRequest(id, tc.i)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("NewUpdateInstanceRequest(...): want != got:\n%v", diff)
+				t.Errorf("NewUpdateInstanceRequest(...): -want, +got:\n%v", diff)
 			}
 		})
 	}
@@ -331,7 +331,7 @@ func TestNewDeleteInstanceRequest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewDeleteInstanceRequest(tc.id)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("NewDeleteInstanceRequest(...): want != got:\n%v", diff)
+				t.Errorf("NewDeleteInstanceRequest(...): -want, +got:\n%v", diff)
 			}
 		})
 	}
@@ -356,7 +356,7 @@ func TestNewGetInstanceRequest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := NewGetInstanceRequest(tc.id)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("NewGetInstanceRequest(...): want != got:\n%v", diff)
+				t.Errorf("NewGetInstanceRequest(...): -want, +got:\n%v", diff)
 			}
 		})
 	}

--- a/pkg/controller/aws/cache/replicationgroup_test.go
+++ b/pkg/controller/aws/cache/replicationgroup_test.go
@@ -222,7 +222,7 @@ func TestCreate(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, tc.r); diff != "" {
-				t.Errorf("r: want != got:\n%s", diff)
+				t.Errorf("r: -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -641,7 +641,7 @@ func TestSync(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, tc.r); diff != "" {
-				t.Errorf("r: want != got:\n%s", diff)
+				t.Errorf("r: -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -716,7 +716,7 @@ func TestDelete(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, tc.r); diff != "" {
-				t.Errorf("r: want != got:\n%s", diff)
+				t.Errorf("r: -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -804,7 +804,7 @@ func TestConnect(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(elastiCache{})); diff != "" {
-				t.Errorf("tc.conn.Connect(...): want != got:\n%s", diff)
+				t.Errorf("tc.conn.Connect(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -964,7 +964,7 @@ func TestReconcile(t *testing.T) {
 						))
 						got := obj.(*v1alpha1.ReplicationGroup)
 						if diff := cmp.Diff(want, got); diff != "" {
-							t.Errorf("kube.Update(...): want != got:\n%s", diff)
+							t.Errorf("kube.Update(...): -want, +got:\n%s", diff)
 						}
 						return nil
 					},
@@ -1002,7 +1002,7 @@ func TestReconcile(t *testing.T) {
 							))
 						got := obj.(*v1alpha1.ReplicationGroup)
 						if diff := cmp.Diff(want, got); diff != "" {
-							t.Errorf("kube.Update(...): want != got:\n%s", diff)
+							t.Errorf("kube.Update(...): -want, +got:\n%s", diff)
 						}
 						return nil
 					},
@@ -1041,7 +1041,7 @@ func TestReconcile(t *testing.T) {
 							))
 						got := obj.(*v1alpha1.ReplicationGroup)
 						if diff := cmp.Diff(want, got); diff != "" {
-							t.Errorf("kube.Update(...): want != got:\n%s", diff)
+							t.Errorf("kube.Update(...): -want, +got:\n%s", diff)
 						}
 						return nil
 					},
@@ -1062,7 +1062,7 @@ func TestReconcile(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, gotResult); diff != "" {
-				t.Errorf("tc.rec.Reconcile(...): want != got:\n%s", diff)
+				t.Errorf("tc.rec.Reconcile(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -1122,7 +1122,7 @@ func TestConnectionSecretWithPassword(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := connectionSecretWithPassword(tc.r, tc.password)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("connectionSecretWithPassword(...): want != got:\n%s", diff)
+				t.Errorf("connectionSecretWithPassword(...): -want, +got:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/azure/cache/redis_test.go
+++ b/pkg/controller/azure/cache/redis_test.go
@@ -223,7 +223,7 @@ func TestCreate(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, tc.r); diff != "" {
-				t.Errorf("r: want != got:\n%s", diff)
+				t.Errorf("r: -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -472,7 +472,7 @@ func TestSync(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, tc.r); diff != "" {
-				t.Errorf("r: want != got:\n%s", diff)
+				t.Errorf("r: -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -547,7 +547,7 @@ func TestDelete(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, tc.r); diff != "" {
-				t.Errorf("r: want != got:\n%s", diff)
+				t.Errorf("r: -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -601,7 +601,7 @@ func TestKey(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, tc.r); diff != "" {
-				t.Errorf("r: want != got:\n%s", diff)
+				t.Errorf("r: -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -689,7 +689,7 @@ func TestConnect(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(azureRedisCache{})); diff != "" {
-				t.Errorf("tc.conn.Connect(...): want != got:\n%s", diff)
+				t.Errorf("tc.conn.Connect(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -847,7 +847,7 @@ func TestReconcile(t *testing.T) {
 						))
 						got := obj.(*v1alpha1.Redis)
 						if diff := cmp.Diff(want, got); diff != "" {
-							t.Errorf("kube.Update(...): want != got:\n%s", diff)
+							t.Errorf("kube.Update(...): -want, +got:\n%s", diff)
 						}
 						return nil
 					},
@@ -886,7 +886,7 @@ func TestReconcile(t *testing.T) {
 							))
 						got := obj.(*v1alpha1.Redis)
 						if diff := cmp.Diff(want, got); diff != "" {
-							t.Errorf("kube.Update(...): want != got:\n%s", diff)
+							t.Errorf("kube.Update(...): -want, +got:\n%s", diff)
 						}
 						return nil
 					},
@@ -925,7 +925,7 @@ func TestReconcile(t *testing.T) {
 							))
 						got := obj.(*v1alpha1.Redis)
 						if diff := cmp.Diff(want, got); diff != "" {
-							t.Errorf("kube.Update(...): want != got:\n%s", diff)
+							t.Errorf("kube.Update(...): -want, +got:\n%s", diff)
 						}
 						return nil
 					},
@@ -968,7 +968,7 @@ func TestReconcile(t *testing.T) {
 									},
 								))
 							if diff := cmp.Diff(want, got); diff != "" {
-								t.Errorf("kube.Update(...): want != got:\n%s", diff)
+								t.Errorf("kube.Update(...): -want, +got:\n%s", diff)
 							}
 						}
 						return nil
@@ -990,7 +990,7 @@ func TestReconcile(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, gotResult); diff != "" {
-				t.Errorf("tc.rec.Reconcile(...): want != got:\n%s", diff)
+				t.Errorf("tc.rec.Reconcile(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -1030,7 +1030,7 @@ func TestConnectionSecret(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := connectionSecret(tc.r, tc.password)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("connectionSecret(...): want != got:\n%s", diff)
+				t.Errorf("connectionSecret(...): -want, +got:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/azure/resourcegroup/resourcegroup_test.go
+++ b/pkg/controller/azure/resourcegroup/resourcegroup_test.go
@@ -201,7 +201,7 @@ func TestCreate(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, tc.r); diff != "" {
-				t.Errorf("r: want != got:\n%s", diff)
+				t.Errorf("r: -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -321,7 +321,7 @@ func TestSync(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, tc.r); diff != "" {
-				t.Errorf("r: want != got:\n%s", diff)
+				t.Errorf("r: -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -396,7 +396,7 @@ func TestDelete(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, tc.r); diff != "" {
-				t.Errorf("r: want != got:\n%s", diff)
+				t.Errorf("r: -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -490,7 +490,7 @@ func TestConnect(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(azureResourceGroup{})); diff != "" {
-				t.Errorf("tc.conn.Connect(...): want != got:\n%s", diff)
+				t.Errorf("tc.conn.Connect(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -637,7 +637,7 @@ func TestReconcile(t *testing.T) {
 						))
 						got := obj.(*v1alpha1.ResourceGroup)
 						if diff := cmp.Diff(want, got); diff != "" {
-							t.Errorf("kube.Update(...): want != got:\n%s", diff)
+							t.Errorf("kube.Update(...): -want, +got:\n%s", diff)
 						}
 						return nil
 					},
@@ -658,7 +658,7 @@ func TestReconcile(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, gotResult); diff != "" {
-				t.Errorf("tc.rec.Reconcile(...): want != got:\n%s", diff)
+				t.Errorf("tc.rec.Reconcile(...): -want, +got:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/cache/redis/aws_handler_test.go
+++ b/pkg/controller/cache/redis/aws_handler_test.go
@@ -103,7 +103,7 @@ func TestResolveAWSClassValues(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, tc.class); diff != "" {
-				t.Errorf("want != got:\n%s", diff)
+				t.Errorf("-want, +got:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/cache/redis/azure_handler_test.go
+++ b/pkg/controller/cache/redis/azure_handler_test.go
@@ -60,7 +60,7 @@ func TestResolveAzureClassValues(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := resolveAzureClassValues(tc.claim)
 			if diff := cmp.Diff(tc.want, got, test.EquateErrors()); diff != "" {
-				t.Errorf("want != got:\n%s", diff)
+				t.Errorf("-want, +got:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/cache/redis/gcp_handler_test.go
+++ b/pkg/controller/cache/redis/gcp_handler_test.go
@@ -94,7 +94,7 @@ func TestResolveGCPClassInstanceValues(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, tc.class); diff != "" {
-				t.Errorf("want != got:\n %+v", diff)
+				t.Errorf("-want, +got:\n %+v", diff)
 			}
 		})
 	}

--- a/pkg/controller/gcp/cache/cloudmemorystore_instance_test.go
+++ b/pkg/controller/gcp/cache/cloudmemorystore_instance_test.go
@@ -207,7 +207,7 @@ func TestCreate(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, tc.i); diff != "" {
-				t.Errorf("i: want != got:\n%s", diff)
+				t.Errorf("i: -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -433,7 +433,7 @@ func TestSync(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, tc.i); diff != "" {
-				t.Errorf("i: want != got:\n%s", diff)
+				t.Errorf("i: -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -508,7 +508,7 @@ func TestDelete(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, tc.i); diff != "" {
-				t.Errorf("i: want != got:\n%s", diff)
+				t.Errorf("i: -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -602,7 +602,7 @@ func TestConnect(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(cloudMemorystore{})); diff != "" {
-				t.Errorf("tc.conn.Connect(...): want != got:\n%s", diff)
+				t.Errorf("tc.conn.Connect(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -752,7 +752,7 @@ func TestReconcile(t *testing.T) {
 						))
 						got := obj.(*v1alpha1.CloudMemorystoreInstance)
 						if diff := cmp.Diff(want, got); diff != "" {
-							t.Errorf("kube.Update(...): want != got:\n%s", diff)
+							t.Errorf("kube.Update(...): -want, +got:\n%s", diff)
 						}
 						return nil
 					},
@@ -791,7 +791,7 @@ func TestReconcile(t *testing.T) {
 							))
 						got := obj.(*v1alpha1.CloudMemorystoreInstance)
 						if diff := cmp.Diff(want, got); diff != "" {
-							t.Errorf("kube.Update(...): want != got:\n%s", diff)
+							t.Errorf("kube.Update(...): -want, +got:\n%s", diff)
 						}
 						return nil
 					},
@@ -830,7 +830,7 @@ func TestReconcile(t *testing.T) {
 							))
 						got := obj.(*v1alpha1.CloudMemorystoreInstance)
 						if diff := cmp.Diff(want, got); diff != "" {
-							t.Errorf("kube.Update(...): want != got:\n%s", diff)
+							t.Errorf("kube.Update(...): -want, +got:\n%s", diff)
 						}
 						return nil
 					},
@@ -873,7 +873,7 @@ func TestReconcile(t *testing.T) {
 									},
 								))
 							if diff := cmp.Diff(want, got); diff != "" {
-								t.Errorf("kube.Update(...): want != got:\n%s", diff)
+								t.Errorf("kube.Update(...): -want, +got:\n%s", diff)
 							}
 						}
 						return nil
@@ -895,7 +895,7 @@ func TestReconcile(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, gotResult); diff != "" {
-				t.Errorf("tc.rec.Reconcile(...): want != got:\n%s", diff)
+				t.Errorf("tc.rec.Reconcile(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -930,7 +930,7 @@ func TestConnectionSecret(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := connectionSecret(tc.i)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("connectionSecret(...): want != got:\n%s", diff)
+				t.Errorf("connectionSecret(...): -want, +got:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/workload/kubernetes/application/application_test.go
+++ b/pkg/controller/workload/kubernetes/application/application_test.go
@@ -368,11 +368,11 @@ func TestSync(t *testing.T) {
 			gotResult := tc.syncer.sync(ctx, tc.app)
 
 			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
-				t.Errorf("tc.sd.Sync(...): want != got:\n%s", diff)
+				t.Errorf("tc.sd.Sync(...): -want, +got:\n%s", diff)
 			}
 
 			if diff := cmp.Diff(tc.wantApp, tc.app); diff != "" {
-				t.Errorf("app: want != got:\n%s", diff)
+				t.Errorf("app: -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -452,7 +452,7 @@ func TestReconcile(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
-				t.Errorf("tc.rec.Reconcile(...): want != got:\n%s", diff)
+				t.Errorf("tc.rec.Reconcile(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -567,7 +567,7 @@ func TestGarbageCollect(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.wantApp, tc.app); diff != "" {
-				t.Errorf("app: want != got:\n%s", diff)
+				t.Errorf("app: -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -639,7 +639,7 @@ func TestSyncApplicationResource(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.wantSubmitted, gotSubmitted); diff != "" {
-				t.Errorf("tc.ar.Sync(...): want != got:\n%s", diff)
+				t.Errorf("tc.ar.Sync(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -665,7 +665,7 @@ func TestRenderTemplate(t *testing.T) {
 			got := renderTemplate(tc.app, tc.template)
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("renderTemplate(...): want != got:\n%s", diff)
+				t.Errorf("renderTemplate(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -751,7 +751,7 @@ func TestHasSameController(t *testing.T) {
 			got := hasSameController(tc.a, tc.b)
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("hasSameController(...): want != got:\n%s", diff)
+				t.Errorf("hasSameController(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -786,7 +786,7 @@ func TestGetControllerName(t *testing.T) {
 			got := getControllerName(tc.obj)
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("getControllerName(...): want != got:\n%s", diff)
+				t.Errorf("getControllerName(...): -want, +got:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/workload/kubernetes/resource/resource_test.go
+++ b/pkg/controller/workload/kubernetes/resource/resource_test.go
@@ -372,7 +372,7 @@ func TestSync(t *testing.T) {
 							RemoteControllerUID:       string(meta.GetUID()),
 						})
 						if diff := cmp.Diff(want, got); diff != "" {
-							return nil, errors.Errorf("mockSync: want != got: %s", diff)
+							return nil, errors.Errorf("mockSync: -want, +got: %s", diff)
 						}
 
 						return remoteStatus, nil
@@ -389,7 +389,7 @@ func TestSync(t *testing.T) {
 							RemoteControllerUID:       string(meta.GetUID()),
 						})
 						if diff := cmp.Diff(want, got); diff != "" {
-							return errors.Errorf("mockSync: want != got: %s", diff)
+							return errors.Errorf("mockSync: -want, +got: %s", diff)
 						}
 
 						return nil
@@ -502,11 +502,11 @@ func TestSync(t *testing.T) {
 			gotResult := tc.syncer.sync(ctx, tc.ar, tc.secrets)
 
 			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
-				t.Errorf("tc.syncer.sync(...): want != got:\n%s", diff)
+				t.Errorf("tc.syncer.sync(...): -want, +got:\n%s", diff)
 			}
 
 			if diff := cmp.Diff(tc.wantAR, tc.ar); diff != "" {
-				t.Errorf("app: want != got:\n%s", diff)
+				t.Errorf("app: -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -533,7 +533,7 @@ func TestDelete(t *testing.T) {
 							RemoteControllerUID:       string(meta.GetUID()),
 						})
 						if diff := cmp.Diff(want, got); diff != "" {
-							errors.Errorf("unstructured mockDelete: want != got: %s", diff)
+							errors.Errorf("unstructured mockDelete: -want, +got: %s", diff)
 						}
 
 						return nil
@@ -550,7 +550,7 @@ func TestDelete(t *testing.T) {
 							RemoteControllerUID:       string(meta.GetUID()),
 						})
 						if diff := cmp.Diff(want, got); diff != "" {
-							return errors.Errorf("secret mockDelete: want != got: %s", diff)
+							return errors.Errorf("secret mockDelete: -want, +got: %s", diff)
 						}
 
 						return nil
@@ -648,11 +648,11 @@ func TestDelete(t *testing.T) {
 			gotResult := tc.deleter.delete(ctx, tc.ar, tc.secrets)
 
 			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
-				t.Errorf("tc.deleter.delete(...): want != got:\n%s", diff)
+				t.Errorf("tc.deleter.delete(...): -want, +got:\n%s", diff)
 			}
 
 			if diff := cmp.Diff(tc.wantAR, tc.ar); diff != "" {
-				t.Errorf("AR: want != got:\n%s", diff)
+				t.Errorf("AR: -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -736,7 +736,7 @@ func TestSyncUnstructured(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.wantStatus, gotStatus); diff != "" {
-				t.Errorf("tc.unstructured.sync(...): want != got:\n%s", diff)
+				t.Errorf("tc.unstructured.sync(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -764,7 +764,7 @@ func TestGetRemoteStatus(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := getRemoteStatus(tc.remote)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("getRemoteStatus(...): want != got:\n%s", diff)
+				t.Errorf("getRemoteStatus(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -1009,7 +1009,7 @@ func TestConnectConfig(t *testing.T) {
 								Name:      cluster.GetName(),
 							}
 							if diff := cmp.Diff(want, got); diff != "" {
-								return errors.Errorf("MockGet(Secret): want != got: %s", diff)
+								return errors.Errorf("MockGet(Secret): -want, +got: %s", diff)
 							}
 							*actual = *cluster
 
@@ -1019,7 +1019,7 @@ func TestConnectConfig(t *testing.T) {
 								Name:      secret.GetName(),
 							}
 							if diff := cmp.Diff(want, got); diff != "" {
-								return errors.Errorf("MockGet(Secret): want != got: %s", diff)
+								return errors.Errorf("MockGet(Secret): -want, +got: %s", diff)
 							}
 
 							*actual = *secret
@@ -1110,7 +1110,7 @@ func TestConnectConfig(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.wantConfig, gotConfig); diff != "" {
-				t.Errorf("tc.connecter.config(...): want != got:\n%s", diff)
+				t.Errorf("tc.connecter.config(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -1161,7 +1161,7 @@ func TestConnect(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.wantSD, gotSD, cmpopts.IgnoreUnexported(remoteCluster{})); diff != "" {
-				t.Errorf("tc.connecter.connect(...): want != got:\n%s", diff)
+				t.Errorf("tc.connecter.connect(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -1271,7 +1271,7 @@ func TestReconcile(t *testing.T) {
 						)
 
 						if diff := cmp.Diff(want, got); diff != "" {
-							return errors.Errorf("MockUpdate: want != got: %s", diff)
+							return errors.Errorf("MockUpdate: -want, +got: %s", diff)
 						}
 
 						return nil
@@ -1297,7 +1297,7 @@ func TestReconcile(t *testing.T) {
 						want := kubeAR(withDeletionTimestamp(deleteTime))
 
 						if diff := cmp.Diff(want, got); diff != "" {
-							return errors.Errorf("MockUpdate: want != got: %s", diff)
+							return errors.Errorf("MockUpdate: -want, +got: %s", diff)
 						}
 
 						return nil
@@ -1368,7 +1368,7 @@ func TestReconcile(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
-				t.Errorf("tc.rec.Reconcile(...): want != got:\n%s", diff)
+				t.Errorf("tc.rec.Reconcile(...): -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -1427,11 +1427,11 @@ func TestGetConnectionSecrets(t *testing.T) {
 			gotSecrets := tc.rec.getConnectionSecrets(ctx, tc.ar)
 
 			if diff := cmp.Diff(tc.wantSecrets, gotSecrets); diff != "" {
-				t.Errorf("tc.rec.getConnectionSecrets(...): want != got:\n%s", diff)
+				t.Errorf("tc.rec.getConnectionSecrets(...): -want, +got:\n%s", diff)
 			}
 
 			if diff := cmp.Diff(tc.wantAR, tc.ar); diff != "" {
-				t.Errorf("AR: want != got:\n%s", diff)
+				t.Errorf("AR: -want, +got:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/workload/kubernetes/scheduler/scheduler_test.go
+++ b/pkg/controller/workload/kubernetes/scheduler/scheduler_test.go
@@ -320,11 +320,11 @@ func TestSchedule(t *testing.T) {
 			gotResult := tc.scheduler.schedule(ctx, tc.app)
 
 			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
-				t.Errorf("tc.scheduler.Schedule(...): want != got:\n%s", diff)
+				t.Errorf("tc.scheduler.Schedule(...): -want, +got:\n%s", diff)
 			}
 
 			if diff := cmp.Diff(tc.wantApp, tc.app); diff != "" {
-				t.Errorf("app: want != got:\n%s", diff)
+				t.Errorf("app: -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -445,7 +445,7 @@ func TestReconcile(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
-				t.Errorf("tc.rec.Reconcile(...): want != got:\n%s", diff)
+				t.Errorf("tc.rec.Reconcile(...): -want, +got:\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
deep.Equal produced a `a != b` style diff, while cmp.Diff produces a
more common -/+ diff, i.e:

```
- a
+ b
```

Relates to #452.