### PR TITLE
fix GCP CloudSQLInstance root password update which requires Host

### DIFF
--- a/pkg/clients/gcp/cloudsql.go
+++ b/pkg/clients/gcp/cloudsql.go
@@ -81,7 +81,7 @@ func (c *CloudSQLClient) ListUsers(project string, instance string) (*sqladmin.U
 
 // UpdateUser updates the given user for the given CloudSQL instance
 func (c *CloudSQLClient) UpdateUser(project string, instance string, name string, user *sqladmin.User) (*sqladmin.Operation, error) {
-	return c.Users.Update(project, instance, name, user).Do()
+	return c.Users.Update(project, instance, name, user).Host(user.Host).Do()
 }
 
 // GetOperation retrieves the latest status for the given operation

--- a/pkg/controller/gcp/database/cloudsql_instance.go
+++ b/pkg/controller/gcp/database/cloudsql_instance.go
@@ -329,7 +329,7 @@ func (r *Reconciler) initDefaultUser(cloudSQLClient gcpclients.CloudSQLAPI,
 		// we already have a password for the default user, we are done
 		return nil
 	}
-	log.Error(err, "user is not initialized yet", "username", defaultUserName)
+	log.V(logging.Debug).Info("user is not initialized yet", "username", defaultUserName)
 
 	users, err := cloudSQLClient.ListUsers(provider.Spec.ProjectID, instance.Status.InstanceName)
 	if err != nil {


### PR DESCRIPTION
**Description of your changes:**

The GCP CloudSQL API requires Host to be specified in User Updates.  

Per @WTFKr0's suggestion in https://github.com/crossplaneio/crossplane/issues/508#issuecomment-499117488, set the Host in the UserUpdateCall when changing the root password. 

https://github.com/googleapis/google-api-go-client/blob/a077b3e91a274d413f19288b1cd3a03435d6785b/sqladmin/v1beta4/sqladmin-gen.go#L9469-L9484

**Which issue is resolved by this Pull Request:**
Resolves #508

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make generate`) has been run to update object specifications, if necessary.
- [ ] CRD manifests generation (`make manifests`) has been run to update CRD manifests yaml file specifications, if necessary.
- [ ] Update dependencies (`make vendor`) has been run to update `Gopkg.lock` file, if necessary
- [ ] RBAC permissions in `clusterrole.yaml` have been updated to include new types, if necessary
- [ ] All related commits have been squashed to improve readability.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
