### PR TITLE
Remove misleading unused comment directives

### DIFF
--- a/pkg/apis/aws/cache/v1alpha1/doc.go
+++ b/pkg/apis/aws/cache/v1alpha1/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=cache.aws.crossplane.io
 package v1alpha1

--- a/pkg/apis/aws/cache/v1alpha1/doc.go
+++ b/pkg/apis/aws/cache/v1alpha1/doc.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws/cache
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/aws/cache/v1alpha1/doc.go
+++ b/pkg/apis/aws/cache/v1alpha1/doc.go
@@ -16,6 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws/cache
 // +groupName=cache.aws.crossplane.io
 package v1alpha1

--- a/pkg/apis/aws/cache/v1alpha1/doc.go
+++ b/pkg/apis/aws/cache/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws/cache
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=cache.aws.crossplane.io
 package v1alpha1

--- a/pkg/apis/aws/cache/v1alpha1/register.go
+++ b/pkg/apis/aws/cache/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/aws/apis/aws/cache
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=cache.aws.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/aws/cache/v1alpha1/register.go
+++ b/pkg/apis/aws/cache/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=cache.aws.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/aws/cache/v1alpha1/register.go
+++ b/pkg/apis/aws/cache/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/aws/apis/aws/cache
 // +groupName=cache.aws.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/aws/cache/v1alpha1/register.go
+++ b/pkg/apis/aws/cache/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/aws/apis/aws/cache
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/aws/cache/v1alpha1/register.go
+++ b/pkg/apis/aws/cache/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/aws/cache/v1alpha1/register.go
+++ b/pkg/apis/aws/cache/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/aws/cache/v1alpha1/replication_group_types.go
+++ b/pkg/apis/aws/cache/v1alpha1/replication_group_types.go
@@ -285,7 +285,6 @@ type ReplicationGroupStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ReplicationGroup is the Schema for the instances API
-// +k8s:openapi-gen=true
 // +groupName=cache.aws
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classRef.name"

--- a/pkg/apis/aws/cache/v1alpha1/replication_group_types.go
+++ b/pkg/apis/aws/cache/v1alpha1/replication_group_types.go
@@ -285,7 +285,6 @@ type ReplicationGroupStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ReplicationGroup is the Schema for the instances API
-// +groupName=cache.aws
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classRef.name"
 // +kubebuilder:printcolumn:name="VERSION",type="string",JSONPath=".spec.engineVersion"

--- a/pkg/apis/aws/cache/v1alpha1/replication_group_types.go
+++ b/pkg/apis/aws/cache/v1alpha1/replication_group_types.go
@@ -281,7 +281,6 @@ type ReplicationGroupStatus struct {
 	// https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_ReplicationGroupPendingModifiedValues.html
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ReplicationGroup is the Schema for the instances API

--- a/pkg/apis/aws/compute/v1alpha1/doc.go
+++ b/pkg/apis/aws/compute/v1alpha1/doc.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the compute v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws/compute
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/aws/compute/v1alpha1/doc.go
+++ b/pkg/apis/aws/compute/v1alpha1/doc.go
@@ -16,6 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the compute v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws/compute
 // +groupName=compute.aws.crossplane.io
 package v1alpha1

--- a/pkg/apis/aws/compute/v1alpha1/doc.go
+++ b/pkg/apis/aws/compute/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the compute v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws/compute
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=compute.aws.crossplane.io
 package v1alpha1

--- a/pkg/apis/aws/compute/v1alpha1/doc.go
+++ b/pkg/apis/aws/compute/v1alpha1/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the compute v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=compute.aws.crossplane.io
 package v1alpha1

--- a/pkg/apis/aws/compute/v1alpha1/register.go
+++ b/pkg/apis/aws/compute/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the compute v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/aws/apis/aws/compute
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/aws/compute/v1alpha1/register.go
+++ b/pkg/apis/aws/compute/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the compute v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/aws/compute/v1alpha1/register.go
+++ b/pkg/apis/aws/compute/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the compute v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/aws/apis/aws/compute
 // +groupName=compute.aws.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/aws/compute/v1alpha1/register.go
+++ b/pkg/apis/aws/compute/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the compute v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/aws/apis/aws/compute
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=compute.aws.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/aws/compute/v1alpha1/register.go
+++ b/pkg/apis/aws/compute/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the compute v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=compute.aws.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/aws/compute/v1alpha1/register.go
+++ b/pkg/apis/aws/compute/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the compute v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/aws/compute/v1alpha1/types.go
+++ b/pkg/apis/aws/compute/v1alpha1/types.go
@@ -240,7 +240,6 @@ type EKSClusterStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // EKSCluster is the Schema for the resources API
-// +k8s:openapi-gen=true
 // +groupName=compute.aws
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.state"

--- a/pkg/apis/aws/compute/v1alpha1/types.go
+++ b/pkg/apis/aws/compute/v1alpha1/types.go
@@ -236,7 +236,6 @@ type EKSClusterStatus struct {
 	ConnectionSecretRef corev1.LocalObjectReference `json:"connectionSecretRef,omitempty"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // EKSCluster is the Schema for the resources API

--- a/pkg/apis/aws/compute/v1alpha1/types.go
+++ b/pkg/apis/aws/compute/v1alpha1/types.go
@@ -240,7 +240,6 @@ type EKSClusterStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // EKSCluster is the Schema for the resources API
-// +groupName=compute.aws
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="CLUSTER-NAME",type="string",JSONPath=".status.clusterName"

--- a/pkg/apis/aws/database/v1alpha1/doc.go
+++ b/pkg/apis/aws/database/v1alpha1/doc.go
@@ -16,6 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws/database
 // +groupName=database.aws.crossplane.io
 package v1alpha1

--- a/pkg/apis/aws/database/v1alpha1/doc.go
+++ b/pkg/apis/aws/database/v1alpha1/doc.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws/database
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/aws/database/v1alpha1/doc.go
+++ b/pkg/apis/aws/database/v1alpha1/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=database.aws.crossplane.io
 package v1alpha1

--- a/pkg/apis/aws/database/v1alpha1/doc.go
+++ b/pkg/apis/aws/database/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws/database
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=database.aws.crossplane.io
 package v1alpha1

--- a/pkg/apis/aws/database/v1alpha1/rdsinstance_types.go
+++ b/pkg/apis/aws/database/v1alpha1/rdsinstance_types.go
@@ -88,7 +88,6 @@ type RDSInstanceStatus struct {
 	Endpoint     string `json:"endpoint,omitempty"`     // rds instance endpoint
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // RDSInstance is the Schema for the instances API

--- a/pkg/apis/aws/database/v1alpha1/rdsinstance_types.go
+++ b/pkg/apis/aws/database/v1alpha1/rdsinstance_types.go
@@ -92,7 +92,6 @@ type RDSInstanceStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // RDSInstance is the Schema for the instances API
-// +k8s:openapi-gen=true
 // +groupName=database.aws
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.state"

--- a/pkg/apis/aws/database/v1alpha1/rdsinstance_types.go
+++ b/pkg/apis/aws/database/v1alpha1/rdsinstance_types.go
@@ -92,7 +92,6 @@ type RDSInstanceStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // RDSInstance is the Schema for the instances API
-// +groupName=database.aws
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classRef.name"

--- a/pkg/apis/aws/database/v1alpha1/register.go
+++ b/pkg/apis/aws/database/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/aws/database/v1alpha1/register.go
+++ b/pkg/apis/aws/database/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws/database
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=database.aws.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/aws/database/v1alpha1/register.go
+++ b/pkg/apis/aws/database/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/aws/database/v1alpha1/register.go
+++ b/pkg/apis/aws/database/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws/database
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/aws/database/v1alpha1/register.go
+++ b/pkg/apis/aws/database/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=database.aws.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/aws/database/v1alpha1/register.go
+++ b/pkg/apis/aws/database/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws/database
 // +groupName=database.aws.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/aws/storage/v1alpha1/bucket_types.go
+++ b/pkg/apis/aws/storage/v1alpha1/bucket_types.go
@@ -108,7 +108,6 @@ func NewS3BucketSpec(properties map[string]string) *S3BucketSpec {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // S3Bucket is the Schema for the S3Bucket API
-// +groupName=storage.aws
 // +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classRef.name"
 // +kubebuilder:printcolumn:name="PREDEFINED-ACL",type="string",JSONPath=".spec.cannedACL"
 // +kubebuilder:printcolumn:name="LOCAL-PERMISSION",type="string",JSONPath=".spec.localPermission"

--- a/pkg/apis/aws/storage/v1alpha1/bucket_types.go
+++ b/pkg/apis/aws/storage/v1alpha1/bucket_types.go
@@ -108,7 +108,6 @@ func NewS3BucketSpec(properties map[string]string) *S3BucketSpec {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // S3Bucket is the Schema for the S3Bucket API
-// +k8s:openapi-gen=true
 // +groupName=storage.aws
 // +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classRef.name"
 // +kubebuilder:printcolumn:name="PREDEFINED-ACL",type="string",JSONPath=".spec.cannedACL"

--- a/pkg/apis/aws/storage/v1alpha1/bucket_types.go
+++ b/pkg/apis/aws/storage/v1alpha1/bucket_types.go
@@ -104,7 +104,6 @@ func NewS3BucketSpec(properties map[string]string) *S3BucketSpec {
 	return spec
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // S3Bucket is the Schema for the S3Bucket API

--- a/pkg/apis/aws/storage/v1alpha1/doc.go
+++ b/pkg/apis/aws/storage/v1alpha1/doc.go
@@ -16,6 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws/storage
 // +groupName=storage.aws.crossplane.io
 package v1alpha1

--- a/pkg/apis/aws/storage/v1alpha1/doc.go
+++ b/pkg/apis/aws/storage/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws/storage
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=storage.aws.crossplane.io
 package v1alpha1

--- a/pkg/apis/aws/storage/v1alpha1/doc.go
+++ b/pkg/apis/aws/storage/v1alpha1/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=storage.aws.crossplane.io
 package v1alpha1

--- a/pkg/apis/aws/storage/v1alpha1/doc.go
+++ b/pkg/apis/aws/storage/v1alpha1/doc.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws/storage
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/aws/storage/v1alpha1/register.go
+++ b/pkg/apis/aws/storage/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws/storage
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=storage.aws.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/aws/storage/v1alpha1/register.go
+++ b/pkg/apis/aws/storage/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws/storage
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/aws/storage/v1alpha1/register.go
+++ b/pkg/apis/aws/storage/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws/storage
 // +groupName=storage.aws.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/aws/storage/v1alpha1/register.go
+++ b/pkg/apis/aws/storage/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=storage.aws.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/aws/storage/v1alpha1/register.go
+++ b/pkg/apis/aws/storage/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/aws/storage/v1alpha1/register.go
+++ b/pkg/apis/aws/storage/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/aws/v1alpha1/doc.go
+++ b/pkg/apis/aws/v1alpha1/doc.go
@@ -16,6 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the aws v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws
 // +groupName=aws.crossplane.io
 package v1alpha1

--- a/pkg/apis/aws/v1alpha1/doc.go
+++ b/pkg/apis/aws/v1alpha1/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the aws v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=aws.crossplane.io
 package v1alpha1

--- a/pkg/apis/aws/v1alpha1/doc.go
+++ b/pkg/apis/aws/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the aws v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=aws.crossplane.io
 package v1alpha1

--- a/pkg/apis/aws/v1alpha1/doc.go
+++ b/pkg/apis/aws/v1alpha1/doc.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the aws v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/aws
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/aws/v1alpha1/register.go
+++ b/pkg/apis/aws/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the aws v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/aws/v1alpha1/register.go
+++ b/pkg/apis/aws/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the aws v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/aws/apis/aws
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=aws.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/aws/v1alpha1/register.go
+++ b/pkg/apis/aws/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the aws v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/aws/apis/aws
 // +groupName=aws.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/aws/v1alpha1/register.go
+++ b/pkg/apis/aws/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the aws v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/aws/v1alpha1/register.go
+++ b/pkg/apis/aws/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the aws v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=aws.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/aws/v1alpha1/register.go
+++ b/pkg/apis/aws/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the aws v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/aws/apis/aws
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/aws/v1alpha1/types.go
+++ b/pkg/apis/aws/v1alpha1/types.go
@@ -38,7 +38,6 @@ type ProviderSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Provider is the Schema for the instances API
-// +groupName=aws
 type Provider struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/aws/v1alpha1/types.go
+++ b/pkg/apis/aws/v1alpha1/types.go
@@ -34,7 +34,6 @@ type ProviderSpec struct {
 	Secret corev1.SecretKeySelector `json:"credentialsSecretRef"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Provider is the Schema for the instances API

--- a/pkg/apis/aws/v1alpha1/types.go
+++ b/pkg/apis/aws/v1alpha1/types.go
@@ -38,7 +38,6 @@ type ProviderSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Provider is the Schema for the instances API
-// +k8s:openapi-gen=true
 // +groupName=aws
 type Provider struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/azure/cache/v1alpha1/doc.go
+++ b/pkg/apis/azure/cache/v1alpha1/doc.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/azure/cache
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/azure/cache/v1alpha1/doc.go
+++ b/pkg/apis/azure/cache/v1alpha1/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=cache.azure.crossplane.io
 package v1alpha1

--- a/pkg/apis/azure/cache/v1alpha1/doc.go
+++ b/pkg/apis/azure/cache/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/azure/cache
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=cache.azure.crossplane.io
 package v1alpha1

--- a/pkg/apis/azure/cache/v1alpha1/doc.go
+++ b/pkg/apis/azure/cache/v1alpha1/doc.go
@@ -16,6 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/azure/cache
 // +groupName=cache.azure.crossplane.io
 package v1alpha1

--- a/pkg/apis/azure/cache/v1alpha1/redis_types.go
+++ b/pkg/apis/azure/cache/v1alpha1/redis_types.go
@@ -158,7 +158,6 @@ type RedisStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Redis is the Schema for the instances API
-// +groupName=cache.azure
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classRef.name"
 // +kubebuilder:printcolumn:name="VERSION",type="string",JSONPath=".status.redisVersion"

--- a/pkg/apis/azure/cache/v1alpha1/redis_types.go
+++ b/pkg/apis/azure/cache/v1alpha1/redis_types.go
@@ -154,7 +154,6 @@ type RedisStatus struct {
 	ResourceName string `json:"resourceName,omitempty"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Redis is the Schema for the instances API

--- a/pkg/apis/azure/cache/v1alpha1/redis_types.go
+++ b/pkg/apis/azure/cache/v1alpha1/redis_types.go
@@ -158,7 +158,6 @@ type RedisStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Redis is the Schema for the instances API
-// +k8s:openapi-gen=true
 // +groupName=cache.azure
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classRef.name"

--- a/pkg/apis/azure/cache/v1alpha1/register.go
+++ b/pkg/apis/azure/cache/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=cache.azure.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/azure/cache/v1alpha1/register.go
+++ b/pkg/apis/azure/cache/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/azure/apis/azure/cache
 // +groupName=cache.azure.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/azure/cache/v1alpha1/register.go
+++ b/pkg/apis/azure/cache/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/azure/apis/azure/cache
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/azure/cache/v1alpha1/register.go
+++ b/pkg/apis/azure/cache/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/azure/cache/v1alpha1/register.go
+++ b/pkg/apis/azure/cache/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/azure/apis/azure/cache
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=cache.azure.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/azure/cache/v1alpha1/register.go
+++ b/pkg/apis/azure/cache/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/azure/compute/v1alpha1/doc.go
+++ b/pkg/apis/azure/compute/v1alpha1/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the container v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=compute.azure.crossplane.io
 package v1alpha1

--- a/pkg/apis/azure/compute/v1alpha1/doc.go
+++ b/pkg/apis/azure/compute/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the container v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/azure/compute
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=compute.azure.crossplane.io
 package v1alpha1

--- a/pkg/apis/azure/compute/v1alpha1/doc.go
+++ b/pkg/apis/azure/compute/v1alpha1/doc.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the container v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/azure/compute
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/azure/compute/v1alpha1/doc.go
+++ b/pkg/apis/azure/compute/v1alpha1/doc.go
@@ -16,6 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the container v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/azure/compute
 // +groupName=compute.azure.crossplane.io
 package v1alpha1

--- a/pkg/apis/azure/compute/v1alpha1/register.go
+++ b/pkg/apis/azure/compute/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the container v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/azure/compute/v1alpha1/register.go
+++ b/pkg/apis/azure/compute/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the container v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=compute.azure.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/azure/compute/v1alpha1/register.go
+++ b/pkg/apis/azure/compute/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the container v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/azure/compute/v1alpha1/register.go
+++ b/pkg/apis/azure/compute/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the container v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/azure/apis/azure/compute
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=compute.azure.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/azure/compute/v1alpha1/register.go
+++ b/pkg/apis/azure/compute/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the container v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/azure/apis/azure/compute
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/azure/compute/v1alpha1/register.go
+++ b/pkg/apis/azure/compute/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the container v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/azure/apis/azure/compute
 // +groupName=compute.azure.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/azure/compute/v1alpha1/types.go
+++ b/pkg/apis/azure/compute/v1alpha1/types.go
@@ -101,7 +101,6 @@ type AKSClusterStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // AKSCluster is the Schema for the instances API
-// +groupName=compute.azure
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="CLUSTER-NAME",type="string",JSONPath=".status.clusterName"

--- a/pkg/apis/azure/compute/v1alpha1/types.go
+++ b/pkg/apis/azure/compute/v1alpha1/types.go
@@ -101,7 +101,6 @@ type AKSClusterStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // AKSCluster is the Schema for the instances API
-// +k8s:openapi-gen=true
 // +groupName=compute.azure
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.state"

--- a/pkg/apis/azure/database/v1alpha1/doc.go
+++ b/pkg/apis/azure/database/v1alpha1/doc.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/azure/database
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/azure/database/v1alpha1/doc.go
+++ b/pkg/apis/azure/database/v1alpha1/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=database.azure.crossplane.io
 package v1alpha1

--- a/pkg/apis/azure/database/v1alpha1/doc.go
+++ b/pkg/apis/azure/database/v1alpha1/doc.go
@@ -16,6 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/azure/database
 // +groupName=database.azure.crossplane.io
 package v1alpha1

--- a/pkg/apis/azure/database/v1alpha1/doc.go
+++ b/pkg/apis/azure/database/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/azure/database
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=database.azure.crossplane.io
 package v1alpha1

--- a/pkg/apis/azure/database/v1alpha1/register.go
+++ b/pkg/apis/azure/database/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/azure/database/v1alpha1/register.go
+++ b/pkg/apis/azure/database/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/azure/apis/azure/database
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=database.azure.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/azure/database/v1alpha1/register.go
+++ b/pkg/apis/azure/database/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/azure/database/v1alpha1/register.go
+++ b/pkg/apis/azure/database/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/azure/apis/azure/database
 // +groupName=database.azure.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/azure/database/v1alpha1/register.go
+++ b/pkg/apis/azure/database/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=database.azure.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/azure/database/v1alpha1/register.go
+++ b/pkg/apis/azure/database/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/azure/apis/azure/database
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/azure/database/v1alpha1/sql_types.go
+++ b/pkg/apis/azure/database/v1alpha1/sql_types.go
@@ -44,7 +44,6 @@ type SQLServer interface {
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // MysqlServer is the Schema for the instances API
@@ -70,7 +69,6 @@ type MysqlServerList struct {
 	Items           []MysqlServer `json:"items"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PostgresqlServer is the Schema for the instances API

--- a/pkg/apis/azure/database/v1alpha1/sql_types.go
+++ b/pkg/apis/azure/database/v1alpha1/sql_types.go
@@ -48,7 +48,6 @@ type SQLServer interface {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // MysqlServer is the Schema for the instances API
-// +k8s:openapi-gen=true
 // +groupName=database.azure
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.state"
@@ -76,7 +75,6 @@ type MysqlServerList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PostgresqlServer is the Schema for the instances API
-// +k8s:openapi-gen=true
 // +groupName=database.azure
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.state"

--- a/pkg/apis/azure/database/v1alpha1/sql_types.go
+++ b/pkg/apis/azure/database/v1alpha1/sql_types.go
@@ -48,7 +48,6 @@ type SQLServer interface {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // MysqlServer is the Schema for the instances API
-// +groupName=database.azure
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classRef.name"
@@ -75,7 +74,6 @@ type MysqlServerList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PostgresqlServer is the Schema for the instances API
-// +groupName=database.azure
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classRef.name"

--- a/pkg/apis/azure/storage/v1alpha1/doc.go
+++ b/pkg/apis/azure/storage/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/azure/database
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=storage.azure.crossplane.io
 package v1alpha1

--- a/pkg/apis/azure/storage/v1alpha1/doc.go
+++ b/pkg/apis/azure/storage/v1alpha1/doc.go
@@ -16,6 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/azure/database
 // +groupName=storage.azure.crossplane.io
 package v1alpha1

--- a/pkg/apis/azure/storage/v1alpha1/doc.go
+++ b/pkg/apis/azure/storage/v1alpha1/doc.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/azure/database
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/azure/storage/v1alpha1/doc.go
+++ b/pkg/apis/azure/storage/v1alpha1/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=storage.azure.crossplane.io
 package v1alpha1

--- a/pkg/apis/azure/storage/v1alpha1/register.go
+++ b/pkg/apis/azure/storage/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/azure/storage
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=storage.azure.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/azure/storage/v1alpha1/register.go
+++ b/pkg/apis/azure/storage/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=storage.azure.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/azure/storage/v1alpha1/register.go
+++ b/pkg/apis/azure/storage/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/azure/storage/v1alpha1/register.go
+++ b/pkg/apis/azure/storage/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/azure/storage/v1alpha1/register.go
+++ b/pkg/apis/azure/storage/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/azure/storage
 // +groupName=storage.azure.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/azure/storage/v1alpha1/register.go
+++ b/pkg/apis/azure/storage/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/azure/storage
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/azure/storage/v1alpha1/types.go
+++ b/pkg/apis/azure/storage/v1alpha1/types.go
@@ -62,7 +62,6 @@ type AccountStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Account is the Schema for the Account API
-// +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="RESOURCE_GROUP",type="string",JSONPath=".spec.resourceGroupName"
 // +kubebuilder:printcolumn:name="ACCOUNT_NAME",type="string",JSONPath=".spec.storageAccountName"
@@ -169,7 +168,6 @@ type ContainerStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Container is the Schema for the Container
-// +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="STORAGE_ACCOUNT",type="string",JSONPath=".spec.accountRef.name"
 // +kubebuilder:printcolumn:name="PUBLIC_ACCESS_TYPE",type="string",JSONPath=".spec.publicAccessType"

--- a/pkg/apis/azure/storage/v1alpha1/types.go
+++ b/pkg/apis/azure/storage/v1alpha1/types.go
@@ -58,7 +58,6 @@ type AccountStatus struct {
 	ConnectionSecretRef corev1.LocalObjectReference `json:"connectionSecretRef,omitempty"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Account is the Schema for the Account API
@@ -164,7 +163,6 @@ type ContainerStatus struct {
 	Name                string                      `json:"name,omitempty"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Container is the Schema for the Container

--- a/pkg/apis/azure/v1alpha1/doc.go
+++ b/pkg/apis/azure/v1alpha1/doc.go
@@ -16,6 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the azure v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/azure
 // +groupName=azure.crossplane.io
 package v1alpha1

--- a/pkg/apis/azure/v1alpha1/doc.go
+++ b/pkg/apis/azure/v1alpha1/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the azure v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=azure.crossplane.io
 package v1alpha1

--- a/pkg/apis/azure/v1alpha1/doc.go
+++ b/pkg/apis/azure/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the azure v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/azure
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=azure.crossplane.io
 package v1alpha1

--- a/pkg/apis/azure/v1alpha1/doc.go
+++ b/pkg/apis/azure/v1alpha1/doc.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the azure v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/azure
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/azure/v1alpha1/register.go
+++ b/pkg/apis/azure/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the azure v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/azure/v1alpha1/register.go
+++ b/pkg/apis/azure/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the azure v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/azure/apis/azure
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=azure.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/azure/v1alpha1/register.go
+++ b/pkg/apis/azure/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the azure v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=azure.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/azure/v1alpha1/register.go
+++ b/pkg/apis/azure/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the azure v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/azure/apis/azure
 // +groupName=azure.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/azure/v1alpha1/register.go
+++ b/pkg/apis/azure/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the azure v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/azure/apis/azure
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/azure/v1alpha1/register.go
+++ b/pkg/apis/azure/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the azure v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/azure/v1alpha1/types.go
+++ b/pkg/apis/azure/v1alpha1/types.go
@@ -33,7 +33,6 @@ type ProviderSpec struct {
 	Secret corev1.SecretKeySelector `json:"credentialsSecretRef"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Provider is the Schema for the instances API
@@ -76,7 +75,6 @@ type ResourceGroupStatus struct {
 	corev1alpha1.DeprecatedConditionedStatus
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ResourceGroup is the Schema for the instances API

--- a/pkg/apis/azure/v1alpha1/types.go
+++ b/pkg/apis/azure/v1alpha1/types.go
@@ -37,7 +37,6 @@ type ProviderSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Provider is the Schema for the instances API
-// +k8s:openapi-gen=true
 // +groupName=azure
 type Provider struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -82,7 +81,6 @@ type ResourceGroupStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ResourceGroup is the Schema for the instances API
-// +k8s:openapi-gen=true
 // +groupName=azure
 type ResourceGroup struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/azure/v1alpha1/types.go
+++ b/pkg/apis/azure/v1alpha1/types.go
@@ -37,7 +37,6 @@ type ProviderSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Provider is the Schema for the instances API
-// +groupName=azure
 type Provider struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -81,7 +80,6 @@ type ResourceGroupStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ResourceGroup is the Schema for the instances API
-// +groupName=azure
 type ResourceGroup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/cache/v1alpha1/doc.go
+++ b/pkg/apis/cache/v1alpha1/doc.go
@@ -16,6 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/cache
 // +groupName=cache.crossplane.io
 package v1alpha1

--- a/pkg/apis/cache/v1alpha1/doc.go
+++ b/pkg/apis/cache/v1alpha1/doc.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/cache
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/cache/v1alpha1/doc.go
+++ b/pkg/apis/cache/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/cache
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=cache.crossplane.io
 package v1alpha1

--- a/pkg/apis/cache/v1alpha1/doc.go
+++ b/pkg/apis/cache/v1alpha1/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=cache.crossplane.io
 package v1alpha1

--- a/pkg/apis/cache/v1alpha1/rediscluster_types.go
+++ b/pkg/apis/cache/v1alpha1/rediscluster_types.go
@@ -34,7 +34,6 @@ type RedisClusterSpec struct {
 	EngineVersion string `json:"engineVersion"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // RedisCluster is the the CRD type for abstract Redis clusters. Crossplane

--- a/pkg/apis/cache/v1alpha1/rediscluster_types.go
+++ b/pkg/apis/cache/v1alpha1/rediscluster_types.go
@@ -39,7 +39,6 @@ type RedisClusterSpec struct {
 
 // RedisCluster is the the CRD type for abstract Redis clusters. Crossplane
 // considers a single Redis instance a 'cluster' of one instance.
-// +k8s:openapi-gen=true
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classReference.name"
 // +kubebuilder:printcolumn:name="VERSION",type="string",JSONPath=".spec.engineVersion"

--- a/pkg/apis/cache/v1alpha1/register.go
+++ b/pkg/apis/cache/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/cache
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=cache.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/cache/v1alpha1/register.go
+++ b/pkg/apis/cache/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/cache
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/cache/v1alpha1/register.go
+++ b/pkg/apis/cache/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/cache/v1alpha1/register.go
+++ b/pkg/apis/cache/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/cache
 // +groupName=cache.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/cache/v1alpha1/register.go
+++ b/pkg/apis/cache/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=cache.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/cache/v1alpha1/register.go
+++ b/pkg/apis/cache/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/compute/v1alpha1/doc.go
+++ b/pkg/apis/compute/v1alpha1/doc.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/compute
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/compute/v1alpha1/doc.go
+++ b/pkg/apis/compute/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/compute
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=compute.crossplane.io
 package v1alpha1

--- a/pkg/apis/compute/v1alpha1/doc.go
+++ b/pkg/apis/compute/v1alpha1/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=compute.crossplane.io
 package v1alpha1

--- a/pkg/apis/compute/v1alpha1/doc.go
+++ b/pkg/apis/compute/v1alpha1/doc.go
@@ -16,6 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/compute
 // +groupName=compute.crossplane.io
 package v1alpha1

--- a/pkg/apis/compute/v1alpha1/register.go
+++ b/pkg/apis/compute/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=compute.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/compute/v1alpha1/register.go
+++ b/pkg/apis/compute/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/compute/v1alpha1/register.go
+++ b/pkg/apis/compute/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/compute
 // +groupName=compute.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/compute/v1alpha1/register.go
+++ b/pkg/apis/compute/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/compute
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/compute/v1alpha1/register.go
+++ b/pkg/apis/compute/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/compute/v1alpha1/register.go
+++ b/pkg/apis/compute/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/compute
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=compute.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/compute/v1alpha1/types.go
+++ b/pkg/apis/compute/v1alpha1/types.go
@@ -38,7 +38,6 @@ type KubernetesClusterSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // KubernetesCluster is the Schema for the instances API
-// +k8s:openapi-gen=true
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="CLUSTER-CLASS",type="string",JSONPath=".spec.classReference.name"
 // +kubebuilder:printcolumn:name="CLUSTER-REF",type="string",JSONPath=".spec.resourceName.name"
@@ -127,7 +126,6 @@ type WorkloadStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Workload is the Schema for the instances API
-// +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="CLUSTER",type="string",JSONPath=".status.clusterRef.name"

--- a/pkg/apis/compute/v1alpha1/types.go
+++ b/pkg/apis/compute/v1alpha1/types.go
@@ -34,7 +34,6 @@ type KubernetesClusterSpec struct {
 	ClusterVersion string `json:"clusterVersion,omitempty"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // KubernetesCluster is the Schema for the instances API
@@ -122,7 +121,6 @@ type WorkloadStatus struct {
 	Service                 *corev1.ObjectReference `json:"serviceRef,omitempty"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Workload is the Schema for the instances API

--- a/pkg/apis/core/v1alpha1/doc.go
+++ b/pkg/apis/core/v1alpha1/doc.go
@@ -16,6 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/core
 // +groupName=core.crossplane.io
 package v1alpha1

--- a/pkg/apis/core/v1alpha1/doc.go
+++ b/pkg/apis/core/v1alpha1/doc.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/core
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/core/v1alpha1/doc.go
+++ b/pkg/apis/core/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/core
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=core.crossplane.io
 package v1alpha1

--- a/pkg/apis/core/v1alpha1/doc.go
+++ b/pkg/apis/core/v1alpha1/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=core.crossplane.io
 package v1alpha1

--- a/pkg/apis/core/v1alpha1/register.go
+++ b/pkg/apis/core/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=core.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/core/v1alpha1/register.go
+++ b/pkg/apis/core/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/core
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/core/v1alpha1/register.go
+++ b/pkg/apis/core/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/core/v1alpha1/register.go
+++ b/pkg/apis/core/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/core
 // +groupName=core.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/core/v1alpha1/register.go
+++ b/pkg/apis/core/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/core/v1alpha1/register.go
+++ b/pkg/apis/core/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/core
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=core.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/core/v1alpha1/resource.go
+++ b/pkg/apis/core/v1alpha1/resource.go
@@ -71,7 +71,6 @@ type ResourceClaim interface {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ResourceClass is the Schema for the instances API
-// +k8s:openapi-gen=true
 // +kubebuilder:printcolumn:name="PROVISIONER",type="string",JSONPath=".provisioner"
 // +kubebuilder:printcolumn:name="PROVIDER-REF",type="string",JSONPath=".providerRef.name"
 // +kubebuilder:printcolumn:name="RECLAIM-POLICY",type="string",JSONPath=".reclaimPolicy"

--- a/pkg/apis/core/v1alpha1/resource.go
+++ b/pkg/apis/core/v1alpha1/resource.go
@@ -67,7 +67,6 @@ type ResourceClaim interface {
 	SetResourceRef(*corev1.ObjectReference)
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ResourceClass is the Schema for the instances API

--- a/pkg/apis/extensions/v1alpha1/doc.go
+++ b/pkg/apis/extensions/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the crossplane extensions v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/extensions
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=extensions.crossplane.io
 package v1alpha1

--- a/pkg/apis/extensions/v1alpha1/doc.go
+++ b/pkg/apis/extensions/v1alpha1/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane extensions v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=extensions.crossplane.io
 package v1alpha1

--- a/pkg/apis/extensions/v1alpha1/doc.go
+++ b/pkg/apis/extensions/v1alpha1/doc.go
@@ -16,6 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane extensions v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/extensions
 // +groupName=extensions.crossplane.io
 package v1alpha1

--- a/pkg/apis/extensions/v1alpha1/doc.go
+++ b/pkg/apis/extensions/v1alpha1/doc.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the crossplane extensions v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/extensions
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/extensions/v1alpha1/register.go
+++ b/pkg/apis/extensions/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the crossplane extensions v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/extensions/v1alpha1/register.go
+++ b/pkg/apis/extensions/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the crossplane extensions v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/extensions
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/extensions/v1alpha1/register.go
+++ b/pkg/apis/extensions/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the crossplane extensions v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/extensions
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=extensions.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/extensions/v1alpha1/register.go
+++ b/pkg/apis/extensions/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane extensions v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=extensions.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/extensions/v1alpha1/register.go
+++ b/pkg/apis/extensions/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane extensions v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/extensions
 // +groupName=extensions.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/extensions/v1alpha1/register.go
+++ b/pkg/apis/extensions/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane extensions v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -28,7 +28,6 @@ import (
 // TODO: how do we pretty print conditioned status items? There may be multiple of them, and they
 // can have varying status (e.g., True, False, Unknown)
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ExtensionRequest is the CRD type for a request to add an extension to Crossplane.
@@ -79,7 +78,6 @@ type ExtensionRequestStatus struct {
 	ExtensionRecord *corev1.ObjectReference `json:"extensionRecord,omitempty"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Extension is the CRD type for a request to add an extension to Crossplane.

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -32,7 +32,6 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ExtensionRequest is the CRD type for a request to add an extension to Crossplane.
-// +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.Conditions[?(@.Status=="True")].Type"
 // +kubebuilder:printcolumn:name="SOURCE",type="string",JSONPath=".spec.source"
@@ -84,7 +83,6 @@ type ExtensionRequestStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Extension is the CRD type for a request to add an extension to Crossplane.
-// +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.Conditions[?(@.Status=="True")].Type"
 // +kubebuilder:printcolumn:name="VERSION",type="string",JSONPath=".spec.version"

--- a/pkg/apis/gcp/cache/v1alpha1/cloudmemorystore_instance_types.go
+++ b/pkg/apis/gcp/cache/v1alpha1/cloudmemorystore_instance_types.go
@@ -143,7 +143,6 @@ type CloudMemorystoreInstanceStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CloudMemorystoreInstance is the Schema for the instances API
-// +k8s:openapi-gen=true
 // +groupName=cache.gcp
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classRef.name"

--- a/pkg/apis/gcp/cache/v1alpha1/cloudmemorystore_instance_types.go
+++ b/pkg/apis/gcp/cache/v1alpha1/cloudmemorystore_instance_types.go
@@ -143,7 +143,6 @@ type CloudMemorystoreInstanceStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CloudMemorystoreInstance is the Schema for the instances API
-// +groupName=cache.gcp
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classRef.name"
 // +kubebuilder:printcolumn:name="VERSION",type="string",JSONPath=".spec.redisVersion"

--- a/pkg/apis/gcp/cache/v1alpha1/cloudmemorystore_instance_types.go
+++ b/pkg/apis/gcp/cache/v1alpha1/cloudmemorystore_instance_types.go
@@ -139,7 +139,6 @@ type CloudMemorystoreInstanceStatus struct {
 	InstanceName string `json:"instanceName,omitempty"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CloudMemorystoreInstance is the Schema for the instances API

--- a/pkg/apis/gcp/cache/v1alpha1/doc.go
+++ b/pkg/apis/gcp/cache/v1alpha1/doc.go
@@ -16,6 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/gcp/cache
 // +groupName=cache.gcp.crossplane.io
 package v1alpha1

--- a/pkg/apis/gcp/cache/v1alpha1/doc.go
+++ b/pkg/apis/gcp/cache/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/gcp/cache
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=cache.gcp.crossplane.io
 package v1alpha1

--- a/pkg/apis/gcp/cache/v1alpha1/doc.go
+++ b/pkg/apis/gcp/cache/v1alpha1/doc.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/gcp/cache
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/gcp/cache/v1alpha1/doc.go
+++ b/pkg/apis/gcp/cache/v1alpha1/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=cache.gcp.crossplane.io
 package v1alpha1

--- a/pkg/apis/gcp/cache/v1alpha1/register.go
+++ b/pkg/apis/gcp/cache/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/gcp/apis/gcp/cache
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/gcp/cache/v1alpha1/register.go
+++ b/pkg/apis/gcp/cache/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/gcp/apis/gcp/cache
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=cache.gcp.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/gcp/cache/v1alpha1/register.go
+++ b/pkg/apis/gcp/cache/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/gcp/apis/gcp/cache
 // +groupName=cache.gcp.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/gcp/cache/v1alpha1/register.go
+++ b/pkg/apis/gcp/cache/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=cache.gcp.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/gcp/cache/v1alpha1/register.go
+++ b/pkg/apis/gcp/cache/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/gcp/cache/v1alpha1/register.go
+++ b/pkg/apis/gcp/cache/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/gcp/compute/v1alpha1/doc.go
+++ b/pkg/apis/gcp/compute/v1alpha1/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the container v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=compute.gcp.crossplane.io
 package v1alpha1

--- a/pkg/apis/gcp/compute/v1alpha1/doc.go
+++ b/pkg/apis/gcp/compute/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the container v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/gcp/compute
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=compute.gcp.crossplane.io
 package v1alpha1

--- a/pkg/apis/gcp/compute/v1alpha1/doc.go
+++ b/pkg/apis/gcp/compute/v1alpha1/doc.go
@@ -16,6 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the container v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/gcp/compute
 // +groupName=compute.gcp.crossplane.io
 package v1alpha1

--- a/pkg/apis/gcp/compute/v1alpha1/doc.go
+++ b/pkg/apis/gcp/compute/v1alpha1/doc.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the container v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/gcp/compute
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/gcp/compute/v1alpha1/register.go
+++ b/pkg/apis/gcp/compute/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the container v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/gcp/compute/v1alpha1/register.go
+++ b/pkg/apis/gcp/compute/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the container v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/gcp/apis/gcp/compute
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=compute.gcp.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/gcp/compute/v1alpha1/register.go
+++ b/pkg/apis/gcp/compute/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the container v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/gcp/compute/v1alpha1/register.go
+++ b/pkg/apis/gcp/compute/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the container v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/gcp/apis/gcp/compute
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/gcp/compute/v1alpha1/register.go
+++ b/pkg/apis/gcp/compute/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the container v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/gcp/apis/gcp/compute
 // +groupName=compute.gcp.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/gcp/compute/v1alpha1/register.go
+++ b/pkg/apis/gcp/compute/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the container v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=compute.gcp.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/gcp/compute/v1alpha1/types.go
+++ b/pkg/apis/gcp/compute/v1alpha1/types.go
@@ -111,7 +111,6 @@ type GKEClusterStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // GKECluster is the Schema for the instances API
-// +groupName=compute.gcp
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="CLUSTER-NAME",type="string",JSONPath=".status.clusterName"

--- a/pkg/apis/gcp/compute/v1alpha1/types.go
+++ b/pkg/apis/gcp/compute/v1alpha1/types.go
@@ -111,7 +111,6 @@ type GKEClusterStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // GKECluster is the Schema for the instances API
-// +k8s:openapi-gen=true
 // +groupName=compute.gcp
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.state"

--- a/pkg/apis/gcp/database/v1alpha1/cloudsql_instance_types.go
+++ b/pkg/apis/gcp/database/v1alpha1/cloudsql_instance_types.go
@@ -89,7 +89,6 @@ type CloudsqlInstanceStatus struct {
 	InstanceName string `json:"instanceName,omitempty"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CloudsqlInstance is the Schema for the instances API

--- a/pkg/apis/gcp/database/v1alpha1/cloudsql_instance_types.go
+++ b/pkg/apis/gcp/database/v1alpha1/cloudsql_instance_types.go
@@ -93,7 +93,6 @@ type CloudsqlInstanceStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CloudsqlInstance is the Schema for the instances API
-// +k8s:openapi-gen=true
 // +groupName=database.gcp
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.state"

--- a/pkg/apis/gcp/database/v1alpha1/cloudsql_instance_types.go
+++ b/pkg/apis/gcp/database/v1alpha1/cloudsql_instance_types.go
@@ -93,7 +93,6 @@ type CloudsqlInstanceStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CloudsqlInstance is the Schema for the instances API
-// +groupName=database.gcp
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classRef.name"

--- a/pkg/apis/gcp/database/v1alpha1/doc.go
+++ b/pkg/apis/gcp/database/v1alpha1/doc.go
@@ -16,6 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/gcp/database
 // +groupName=database.gcp.crossplane.io
 package v1alpha1

--- a/pkg/apis/gcp/database/v1alpha1/doc.go
+++ b/pkg/apis/gcp/database/v1alpha1/doc.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/gcp/database
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/gcp/database/v1alpha1/doc.go
+++ b/pkg/apis/gcp/database/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/gcp/database
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=database.gcp.crossplane.io
 package v1alpha1

--- a/pkg/apis/gcp/database/v1alpha1/doc.go
+++ b/pkg/apis/gcp/database/v1alpha1/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=database.gcp.crossplane.io
 package v1alpha1

--- a/pkg/apis/gcp/database/v1alpha1/register.go
+++ b/pkg/apis/gcp/database/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/gcp/apis/gcp/database
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/gcp/database/v1alpha1/register.go
+++ b/pkg/apis/gcp/database/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/gcp/database/v1alpha1/register.go
+++ b/pkg/apis/gcp/database/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/gcp/apis/gcp/database
 // +groupName=database.gcp.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/gcp/database/v1alpha1/register.go
+++ b/pkg/apis/gcp/database/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/gcp/apis/gcp/database
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=database.gcp.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/gcp/database/v1alpha1/register.go
+++ b/pkg/apis/gcp/database/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/gcp/database/v1alpha1/register.go
+++ b/pkg/apis/gcp/database/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the database v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=database.gcp.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/gcp/storage/v1alpha1/doc.go
+++ b/pkg/apis/gcp/storage/v1alpha1/doc.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/gcp/storage
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/gcp/storage/v1alpha1/doc.go
+++ b/pkg/apis/gcp/storage/v1alpha1/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=storage.gcp.crossplane.io
 package v1alpha1

--- a/pkg/apis/gcp/storage/v1alpha1/doc.go
+++ b/pkg/apis/gcp/storage/v1alpha1/doc.go
@@ -16,6 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/gcp/storage
 // +groupName=storage.gcp.crossplane.io
 package v1alpha1

--- a/pkg/apis/gcp/storage/v1alpha1/doc.go
+++ b/pkg/apis/gcp/storage/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/gcp/storage
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=storage.gcp.crossplane.io
 package v1alpha1

--- a/pkg/apis/gcp/storage/v1alpha1/register.go
+++ b/pkg/apis/gcp/storage/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=storage.gcp.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/gcp/storage/v1alpha1/register.go
+++ b/pkg/apis/gcp/storage/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/gcp/storage/v1alpha1/register.go
+++ b/pkg/apis/gcp/storage/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/gcp/storage/v1alpha1/register.go
+++ b/pkg/apis/gcp/storage/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/gcp/storage
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=storage.gcp.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/gcp/storage/v1alpha1/register.go
+++ b/pkg/apis/gcp/storage/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/gcp/storage
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/gcp/storage/v1alpha1/register.go
+++ b/pkg/apis/gcp/storage/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the storage v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/gcp/storage
 // +groupName=storage.gcp.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/gcp/storage/v1alpha1/types.go
+++ b/pkg/apis/gcp/storage/v1alpha1/types.go
@@ -794,7 +794,6 @@ type BucketStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Bucket is the Schema for the instances API
-// +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="STORAGE_CLASS",type="string",JSONPath=".spec.storageClass"
 // +kubebuilder:printcolumn:name="LOCATION",type="string",JSONPath=".spec.location"

--- a/pkg/apis/gcp/storage/v1alpha1/types.go
+++ b/pkg/apis/gcp/storage/v1alpha1/types.go
@@ -790,7 +790,6 @@ type BucketStatus struct {
 	ConnectionSecretRef corev1.LocalObjectReference `json:"connectionSecretRef,omitempty"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Bucket is the Schema for the instances API

--- a/pkg/apis/gcp/v1alpha1/doc.go
+++ b/pkg/apis/gcp/v1alpha1/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the gcp v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=gcp.crossplane.io
 package v1alpha1

--- a/pkg/apis/gcp/v1alpha1/doc.go
+++ b/pkg/apis/gcp/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the gcp v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/gcp
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=gcp.crossplane.io
 package v1alpha1

--- a/pkg/apis/gcp/v1alpha1/doc.go
+++ b/pkg/apis/gcp/v1alpha1/doc.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the gcp v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/gcp
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/gcp/v1alpha1/doc.go
+++ b/pkg/apis/gcp/v1alpha1/doc.go
@@ -16,6 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the gcp v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/gcp
 // +groupName=gcp.crossplane.io
 package v1alpha1

--- a/pkg/apis/gcp/v1alpha1/register.go
+++ b/pkg/apis/gcp/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the gcp v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/gcp/apis/gcp
 // +groupName=gcp.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/gcp/v1alpha1/register.go
+++ b/pkg/apis/gcp/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the gcp v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/gcp/v1alpha1/register.go
+++ b/pkg/apis/gcp/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the gcp v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/gcp/apis/gcp
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/gcp/v1alpha1/register.go
+++ b/pkg/apis/gcp/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the gcp v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/gcp/v1alpha1/register.go
+++ b/pkg/apis/gcp/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the gcp v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=gcp.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/gcp/v1alpha1/register.go
+++ b/pkg/apis/gcp/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the gcp v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/gcp/apis/gcp
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=gcp.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/gcp/v1alpha1/types.go
+++ b/pkg/apis/gcp/v1alpha1/types.go
@@ -35,7 +35,6 @@ type ProviderSpec struct {
 	RequiredPermissions []string `json:"requiredPermissions,omitempty"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Provider is the Schema for the instances API

--- a/pkg/apis/gcp/v1alpha1/types.go
+++ b/pkg/apis/gcp/v1alpha1/types.go
@@ -39,7 +39,6 @@ type ProviderSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Provider is the Schema for the instances API
-// +groupName=gcp
 // +kubebuilder:printcolumn:name="PROJECT-ID",type="string",JSONPath=".spec.projectID"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 type Provider struct {

--- a/pkg/apis/gcp/v1alpha1/types.go
+++ b/pkg/apis/gcp/v1alpha1/types.go
@@ -39,7 +39,6 @@ type ProviderSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Provider is the Schema for the instances API
-// +k8s:openapi-gen=true
 // +groupName=gcp
 // +kubebuilder:printcolumn:name="PROJECT-ID",type="string",JSONPath=".spec.projectID"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"

--- a/pkg/apis/storage/v1alpha1/doc.go
+++ b/pkg/apis/storage/v1alpha1/doc.go
@@ -16,6 +16,5 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/storage
 // +groupName=storage.crossplane.io
 package v1alpha1

--- a/pkg/apis/storage/v1alpha1/doc.go
+++ b/pkg/apis/storage/v1alpha1/doc.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/storage
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/storage/v1alpha1/doc.go
+++ b/pkg/apis/storage/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/storage
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=storage.crossplane.io
 package v1alpha1

--- a/pkg/apis/storage/v1alpha1/doc.go
+++ b/pkg/apis/storage/v1alpha1/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=storage.crossplane.io
 package v1alpha1

--- a/pkg/apis/storage/v1alpha1/register.go
+++ b/pkg/apis/storage/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/storage/v1alpha1/register.go
+++ b/pkg/apis/storage/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=storage.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/storage/v1alpha1/register.go
+++ b/pkg/apis/storage/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/storage
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=storage.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/storage/v1alpha1/register.go
+++ b/pkg/apis/storage/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/storage
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/storage/v1alpha1/register.go
+++ b/pkg/apis/storage/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/storage
 // +groupName=storage.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/storage/v1alpha1/register.go
+++ b/pkg/apis/storage/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/storage/v1alpha1/types.go
+++ b/pkg/apis/storage/v1alpha1/types.go
@@ -189,7 +189,6 @@ type BucketSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Bucket is the Schema for the Bucket API
-// +groupName=storage
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classReference.name"
 // +kubebuilder:printcolumn:name="PREDEFINED-ACL",type="string",JSONPath=".spec.predefinedACL"

--- a/pkg/apis/storage/v1alpha1/types.go
+++ b/pkg/apis/storage/v1alpha1/types.go
@@ -34,7 +34,6 @@ type MySQLInstanceSpec struct {
 	EngineVersion string `json:"engineVersion"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // MySQLInstance is the CRD type for abstract MySQL database instances
@@ -91,7 +90,6 @@ type PostgreSQLInstanceSpec struct {
 	EngineVersion string `json:"engineVersion,omitempty"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PostgreSQLInstance is the CRD type for abstract PostgreSQL database instances
@@ -185,7 +183,6 @@ type BucketSpec struct {
 	ConnectionSecretNameOverride string `json:"connectionSecretNameOverride,omitempty"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Bucket is the Schema for the Bucket API

--- a/pkg/apis/storage/v1alpha1/types.go
+++ b/pkg/apis/storage/v1alpha1/types.go
@@ -38,7 +38,6 @@ type MySQLInstanceSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // MySQLInstance is the CRD type for abstract MySQL database instances
-// +k8s:openapi-gen=true
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classReference.name"
 // +kubebuilder:printcolumn:name="VERSION",type="string",JSONPath=".spec.engineVersion"
@@ -96,7 +95,6 @@ type PostgreSQLInstanceSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PostgreSQLInstance is the CRD type for abstract PostgreSQL database instances
-// +k8s:openapi-gen=true
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classReference.name"
 // +kubebuilder:printcolumn:name="VERSION",type="string",JSONPath=".spec.engineVersion"
@@ -191,7 +189,6 @@ type BucketSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Bucket is the Schema for the Bucket API
-// +k8s:openapi-gen=true
 // +groupName=storage
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="CLASS",type="string",JSONPath=".spec.classReference.name"

--- a/pkg/apis/workload/v1alpha1/doc.go
+++ b/pkg/apis/workload/v1alpha1/doc.go
@@ -18,6 +18,5 @@ limitations under the License.
 // v1alpha1 API group.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/workload
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=workload.crossplane.io
 package v1alpha1

--- a/pkg/apis/workload/v1alpha1/doc.go
+++ b/pkg/apis/workload/v1alpha1/doc.go
@@ -17,5 +17,4 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the crossplane workload
 // v1alpha1 API group.
 // +k8s:deepcopy-gen=package,register
-// +groupName=workload.crossplane.io
 package v1alpha1

--- a/pkg/apis/workload/v1alpha1/doc.go
+++ b/pkg/apis/workload/v1alpha1/doc.go
@@ -17,6 +17,5 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the crossplane workload
 // v1alpha1 API group.
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/workload
 // +groupName=workload.crossplane.io
 package v1alpha1

--- a/pkg/apis/workload/v1alpha1/doc.go
+++ b/pkg/apis/workload/v1alpha1/doc.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane workload
 // v1alpha1 API group.
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/workload
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/workload/v1alpha1/register.go
+++ b/pkg/apis/workload/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=compute.crossplane.io
 package v1alpha1
 
 import (

--- a/pkg/apis/workload/v1alpha1/register.go
+++ b/pkg/apis/workload/v1alpha1/register.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
-// Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
-// +k8s:deepcopy-gen=package,register
 package v1alpha1
 
 import (

--- a/pkg/apis/workload/v1alpha1/register.go
+++ b/pkg/apis/workload/v1alpha1/register.go
@@ -17,7 +17,6 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/compute
 // +groupName=compute.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/workload/v1alpha1/register.go
+++ b/pkg/apis/workload/v1alpha1/register.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/compute
 // +k8s:defaulter-gen=TypeMeta

--- a/pkg/apis/workload/v1alpha1/register.go
+++ b/pkg/apis/workload/v1alpha1/register.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: Boilerplate only.  Ignore this file.
 
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:openapi-gen=true

--- a/pkg/apis/workload/v1alpha1/register.go
+++ b/pkg/apis/workload/v1alpha1/register.go
@@ -18,7 +18,6 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the crossplane core v1alpha1 API group
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/crossplaneio/crossplane/pkg/apis/compute
-// +k8s:defaulter-gen=TypeMeta
 // +groupName=compute.crossplane.io
 package v1alpha1
 

--- a/pkg/apis/workload/v1alpha1/types.go
+++ b/pkg/apis/workload/v1alpha1/types.go
@@ -102,7 +102,6 @@ type KubernetesApplicationStatus struct {
 
 // A KubernetesApplication defines an application deployed by Crossplane to a
 // Kubernetes cluster that is managed by Crossplane.
-// +k8s:openapi-gen=true
 // +kubebuilder:printcolumn:name="CLUSTER",type="string",JSONPath=".status.clusterRef.name"
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="DESIRED",type="integer",JSONPath=".status.desiredResources"
@@ -199,7 +198,6 @@ type KubernetesApplicationResourceStatus struct {
 // A KubernetesApplicationResource is a resource of a Kubernetes application.
 // Each resource templates a single Kubernetes resource to be deployed to its
 // scheduled KubernetesCluster.
-// +k8s:openapi-gen=true
 // +kubebuilder:printcolumn:name="TEMPLATE-KIND",type="string",JSONPath=".spec.template.kind"
 // +kubebuilder:printcolumn:name="TEMPLATE-NAME",type="string",JSONPath=".spec.template.metadata.name"
 // +kubebuilder:printcolumn:name="CLUSTER",type="string",JSONPath=".status.clusterRef.name"

--- a/pkg/apis/workload/v1alpha1/types.go
+++ b/pkg/apis/workload/v1alpha1/types.go
@@ -97,7 +97,6 @@ type KubernetesApplicationStatus struct {
 	SubmittedResources int `json:"submittedResources,omitempty"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // A KubernetesApplication defines an application deployed by Crossplane to a
@@ -192,7 +191,6 @@ type KubernetesApplicationResourceStatus struct {
 	Remote *RemoteStatus `json:"remote,omitempty"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // A KubernetesApplicationResource is a resource of a Kubernetes application.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
This pull request removes various comment directives for kubernetes code generation tools that Crossplane does not use. I presume most of these were added by kubebuilder originally, then proliferated as we copied and pasted API scaffolding.

I've added a little context in each commit; the overall change was inspired by my having assumed on at least two occasions that these directives were controlling our code generation tools. This lead to a reasonable amount of wasted time as I tried to figure out why changing the directives was not having the effect on generated code or manifests I anticipated. It's my opinion that these directives are liable to confuse potential contributors as they did me. I propose we remove them; we can always re-add them if we want to use one of the tools they control. 

I've tested this commit by deleting all generated Go files and CRD manifests, running `make reviewable` to generate new copies, and validating there is no git diff.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation](/docs/), [examples](/cluster/examples/), or [release notes](/PendingReleaseNotes.md).
- [ ] Updated the RBAC permissions in `clusterrole.yaml` to include any new types.
