### PR TITLE
Change aws example to kubernetesapp

### DIFF
--- a/cluster/charts/crossplane/crds/aws/v1alpha1/provider.yaml
+++ b/cluster/charts/crossplane/crds/aws/v1alpha1/provider.yaml
@@ -6,6 +6,17 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: providers.aws.crossplane.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.region
+    name: REGION
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: AGE
+    type: date
+  - JSONPath: .spec.credentialsSecretRef.name
+    name: CREDENTIAL
+    priority: 1
+    type: string
   group: aws.crossplane.io
   names:
     kind: Provider

--- a/cluster/charts/crossplane/crds/aws/v1alpha1/provider.yaml
+++ b/cluster/charts/crossplane/crds/aws/v1alpha1/provider.yaml
@@ -14,7 +14,7 @@ spec:
     name: AGE
     type: date
   - JSONPath: .spec.credentialsSecretRef.name
-    name: CREDENTIAL
+    name: SECRET-NAME
     priority: 1
     type: string
   group: aws.crossplane.io

--- a/cluster/charts/crossplane/crds/azure/v1alpha1/provider.yaml
+++ b/cluster/charts/crossplane/crds/azure/v1alpha1/provider.yaml
@@ -6,6 +6,11 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: providers.azure.crossplane.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.credentialsSecretRef.name
+    name: CREDENTIAL
+    priority: 1
+    type: string
   group: azure.crossplane.io
   names:
     kind: Provider

--- a/cluster/charts/crossplane/crds/azure/v1alpha1/provider.yaml
+++ b/cluster/charts/crossplane/crds/azure/v1alpha1/provider.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   additionalPrinterColumns:
   - JSONPath: .spec.credentialsSecretRef.name
-    name: CREDENTIAL
+    name: SECRET-NAME
     priority: 1
     type: string
   group: azure.crossplane.io

--- a/cluster/charts/crossplane/crds/gcp/v1alpha1/provider.yaml
+++ b/cluster/charts/crossplane/crds/gcp/v1alpha1/provider.yaml
@@ -13,6 +13,10 @@ spec:
   - JSONPath: .metadata.creationTimestamp
     name: AGE
     type: date
+  - JSONPath: .spec.credentialsSecretRef.name
+    name: CREDENTIAL
+    priority: 1
+    type: string
   group: gcp.crossplane.io
   names:
     kind: Provider

--- a/cluster/charts/crossplane/crds/gcp/v1alpha1/provider.yaml
+++ b/cluster/charts/crossplane/crds/gcp/v1alpha1/provider.yaml
@@ -14,7 +14,7 @@ spec:
     name: AGE
     type: date
   - JSONPath: .spec.credentialsSecretRef.name
-    name: CREDENTIAL
+    name: SECRET-NAME
     priority: 1
     type: string
   group: gcp.crossplane.io

--- a/cluster/examples/README.md
+++ b/cluster/examples/README.md
@@ -7,11 +7,11 @@ The cloud services column will link to an Example User Guide if one is available
 | Directory | Description | AWS | Azure | GCP
 | ---       | ---         | --- | ---   | ---
 | [cache](cache/)     | Provisions a Managed Redis service from any cloud. | Redis | Redis | CloudMemoryStore Redis |
-| [compute](compute/)   | Creates a WordPress Workload that runs in a Crossplane created Kubernetes cluster using a Crossplane created managed MySQL service. ([Using Compute Workloads](https://github.com/crossplaneio/crossplane/blob/master/design/complex-workloads.md#complex-workloads-in-crossplane), [Legacy](https://github.com/crossplaneio/crossplane/issues/456)) | [EKS + RDS](../../docs/workloads/aws/wordpress-aws.md) | [AKS + Azure SQL](../../docs/workloads/azure/wordpress-azure.md) | GKE + Cloud SQL |
+| [compute](compute/)   | Creates a WordPress Workload that runs in a Crossplane created Kubernetes cluster using a Crossplane created managed MySQL service. ([Using Compute Workloads](https://github.com/crossplaneio/crossplane/blob/master/design/complex-workloads.md#complex-workloads-in-crossplane), [Legacy](https://github.com/crossplaneio/crossplane/issues/456)) | EKS + RDS | [AKS + Azure SQL](../../docs/workloads/azure/wordpress-azure.md) | GKE + Cloud SQL |
 | [database](database/)  | Deploys a PostgreSQL database in any cloud. | RDS | Azure SQL | Cloud SQL |
 | [extensions](extensions/) | Deploys the [sample-extension](https://github.com/crossplaneio/sample-extension) | n/a | n/a | n/a |
 | [gitlab](gitlab/)    | Deploy GitLab in all three clouds. See the per-Cloud documentation links. | [AWS](../../docs/gitlab/gitlab-aws.md) | | [GCP](../../docs/gitlab/gitlab-gcp.md) |
 | [kubernetes](kubernetes/) | Deploy a Kubernetes Cluster in any clouds. | EKS | AKS | GKE |
 | [storage](storage/)   | Provisions a object storage bucket from any cloud. | S3 | Storage | GCS |
 | [wordpress](wordpress/) | Provisions a MySQL service from any cloud and uses it in a WordPress deployment. | RDS | Azure SQL | Cloud SQL |
-| [workloads](workloads/) | Creates a WordPress Workload that runs in a Crossplane created Kubernetes cluster using a Crossplane created managed MySQL service. ([Using Complex Workloads](../../design/complex-workloads.md#complex-workloads-in-crossplane)) |  |  | [GKE + Cloud SQL](../../docs/workloads/gcp/wordpress-gcp.md) |
+| [workloads](workloads/) | Creates a WordPress Workload that runs in a Crossplane created Kubernetes cluster using a Crossplane created managed MySQL service. ([Using Complex Workloads](../../design/complex-workloads.md#complex-workloads-in-crossplane)) | [EKS + RDS](../../docs/workloads/aws/wordpress-aws.md) |  | [GKE + Cloud SQL](../../docs/workloads/gcp/wordpress-gcp.md) |

--- a/cluster/examples/aws-credentials.sh
+++ b/cluster/examples/aws-credentials.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# This is a helper script that uses ~/.aws/credentials and the aws CLI to create an
+# environment of EKS, RDS, VPC, Security and Subnet Groups for use in Crossplane AWS examples
+#
+# aws is required and must be configured with privileges to perform these tasks
+#
+set -e -o pipefail
+RAND=$RANDOM
+
+if ! command -v aws > /dev/null; then
+	echo "Please install aws: https://aws.amazon.com/cli/)"
+	exit 1
+fi
+
+if ! command -v jq > /dev/null; then
+	echo "Please install jq: https://stedolan.github.io/jq/download/)"
+	exit 1
+fi
+
+# must be one of us-west-2,us-east-1,eu-west-1 at time of writing for EKS
+export REGION=eu-west-1
+export KEYFILE=~/.aws/credentials
+export EKS_WORKER_KEY_NAME=crossplane-example-$RAND
+export RDS_SUBNET_GROUP_NAME=crossplane-example-db-subnet-group-$RAND
+
+# These variables are not used in yaml, just for the cli provisioning
+export EKS_ROLE_NAME=crossplane-example-role-$RAND
+export EKS_STACK_NAME=crossplane-example-stack-$RAND
+
+
+# delete everything that was created by this script give the random project id
+crossplane_delete_aws() {
+    RAND=$1
+    EKS_WORKER_KEY_NAME=crossplane-example-$RAND
+    RDS_SUBNET_GROUP_NAME=crossplane-example-db-subnet-group-$RAND
+    EKS_ROLE_NAME=crossplane-example-role-$RAND
+    EKS_STACK_NAME=crossplane-example-stack-$RAND
+    RDS_SECURITY_GROUP_NAME=crossplane-example-$RAND
+    RDS_SECURITY_GROUP_ID=$(aws ec2 describe-security-groups --region=$REGION --filter Name=group-name,Values=$RDS_SECURITY_GROUP_NAME --output=text --query="SecurityGroups[0].GroupId")
+
+    aws ec2 delete-key-pair --region $REGION --key-name $EKS_WORKER_KEY_NAME
+    aws iam detach-role-policy --region $REGION --role-name $EKS_ROLE_NAME --policy-arn arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+    aws iam detach-role-policy --region $REGION --role-name $EKS_ROLE_NAME --policy-arn arn:aws:iam::aws:policy/AmazonEKSServicePolicy
+    aws iam delete-role --region $REGION --role-name $EKS_ROLE_NAME
+    aws cloudformation delete-stack --region $REGION --stack-name $EKS_STACK_NAME
+    aws rds delete-db-subnet-group --region=$REGION --db-subnet-group-name=$RDS_SUBNET_GROUP_NAME
+    aws ec2 revoke-security-group-ingress --region $REGION --group-id $RDS_SECURITY_GROUP_ID --port 3306 --protocol tcp
+    aws ec2 delete-security-group --region $REGION --group-id $RDS_SECURITY_GROUP_ID
+}
+
+if [[ "$1" == "delete" ]]; then
+  if [[ -n "$2" ]]; then
+    crossplane_delete_aws $2
+    exit $?
+  else
+    echo "$0 delete [example-id]"
+  fi
+  exit 1
+fi
+
+
+# Generate a KeyPair 
+aws ec2 create-key-pair --key-name $EKS_WORKER_KEY_NAME --region=$REGION > /dev/null
+
+# Generate a Role that can Do everying necessary to provider EKS clusters
+aws iam create-role --role-name $EKS_ROLE_NAME --region $REGION --assume-role-policy-document file://<(echo '{"Version": "2012-10-17","Statement": {"Effect": "Allow", "Principal": {"Service": "eks.amazonaws.com"},"Action": "sts:AssumeRole"}}')  > /dev/null
+
+aws iam attach-role-policy --role-name $EKS_ROLE_NAME --policy-arn arn:aws:iam::aws:policy/AmazonEKSClusterPolicy > /dev/null
+aws iam attach-role-policy --role-name $EKS_ROLE_NAME --policy-arn arn:aws:iam::aws:policy/AmazonEKSServicePolicy > /dev/null
+
+export EKS_ROLE_ARN=$(aws iam get-role --role-name $EKS_ROLE_NAME | jq -r .Role.Arn)
+
+# Generate and run a CloudFormation Stack and get the VPC, Subnet, and Security Group associated with it
+aws cloudformation create-stack \
+    --template-url=https://amazon-eks.s3-us-west-2.amazonaws.com/cloudformation/2018-11-07/amazon-eks-vpc-sample.yaml \
+    --region $REGION \
+    --stack-name $EKS_STACK_NAME \
+    --parameters ParameterKey=VpcBlock,ParameterValue=192.168.0.0/16 ParameterKey=Subnet01Block,ParameterValue=192.168.64.0/18 ParameterKey=Subnet02Block,ParameterValue=192.168.128.0/18 ParameterKey=Subnet03Block,ParameterValue=192.168.192.0/18  > /dev/null
+
+echo -n "Waiting for 'CREATE_COMPLETE' from Cloudformation Stack $EKS_STACK_NAME"
+until [[ "CREATE_COMPLETE" == "$(aws cloudformation describe-stacks --stack-name $EKS_STACK_NAME --region $REGION | jq -r '.Stacks[0].StackStatus')" ]]; do
+  echo -n "."
+  sleep 2
+done;
+echo
+
+export EKS_VPC=$(aws cloudformation describe-stacks --stack-name $EKS_STACK_NAME --region $REGION | jq -r '.Stacks[0].Outputs[]|select(.OutputKey=="VpcId").OutputValue')
+export EKS_SUBNETS=$(aws cloudformation describe-stacks --stack-name $EKS_STACK_NAME --region $REGION | jq -r '.Stacks[0].Outputs[]|select(.OutputKey=="SubnetIds").OutputValue')
+export EKS_SECURITY_GROUP=$(aws cloudformation describe-stacks --stack-name $EKS_STACK_NAME --region $REGION | jq -r '.Stacks[0].Outputs[]|select(.OutputKey=="SecurityGroups").OutputValue')
+
+T="${EKS_SUBNETS//,/ }"
+aws rds create-db-subnet-group --region=$REGION --db-subnet-group-name=$RDS_SUBNET_GROUP_NAME --db-subnet-group-description="crossplane-example-$RAND EKS VPC $EKS_VPC to RDS" --subnet-ids $T > /dev/null
+
+# Generate the Security Group and add MySQL ingress to it
+
+aws ec2 create-security-group --vpc-id=$EKS_VPC --region=$REGION --group-name="crossplane-example-$RAND" --description="open mysql access for crossplane-example-$RAND" > /dev/null
+export RDS_SECURITY_GROUP=$(aws ec2 describe-security-groups --filter Name=group-name,Values=crossplane-example-$RAND --region=$REGION --output=text --query="SecurityGroups[0].GroupId")
+
+aws ec2 authorize-security-group-ingress --protocol=tcp --port=3306 --region=$REGION --cidr=0.0.0.0/0 --group-id=$RDS_SECURITY_GROUP  > /dev/null
+
+
+cat <<EOS
+#
+# Run the following for the variables that are used throughout the AWS example projects
+#
+export BASE64ENCODED_AWS_PROVIDER_CREDS=\$(base64 -w0 < $KEYFILE)
+export EKS_WORKER_KEY_NAME=$EKS_WORKER_KEY_NAME
+export EKS_ROLE_ARN=$EKS_ROLE_ARN
+export REGION=$REGION
+export EKS_VPC=$EKS_VPC
+export EKS_SUBNETS=$EKS_SUBNETS
+export EKS_SECURITY_GROUP=$EKS_SECURITY_GROUP
+export RDS_SUBNET_GROUP_NAME=$RDS_SUBNET_GROUP_NAME
+export RDS_SECURITY_GROUP=$RDS_SECURITY_GROUP
+
+#
+# Use this environment in an AWS Crossplane provider:
+#
+sed -e "s|BASE64ENCODED_AWS_PROVIDER_CREDS|\$(base64 -w0 < $KEYFILE)|g" \\
+    -e "s|EKS_WORKER_KEY_NAME|\$EKS_WORKER_KEY_NAME|g" \\
+    -e "s|EKS_ROLE_ARN|\$EKS_ROLE_ARN|g" \\
+    -e "s|REGION|\$REGION|g" \\
+    -e "s|EKS_VPC|\$EKS_VPC|g" \\
+    -e "s|EKS_SUBNETS|\$EKS_SUBNETS|g" \\
+    -e "s|EKS_SECURITY_GROUP|\$EKS_SECURITY_GROUP|g" \\
+    -e "s|RDS_SUBNET_GROUP_NAME|\$RDS_SUBNET_GROUP_NAME|g" \\
+    -e "s|RDS_SECURITY_GROUP|\$RDS_SECURITY_GROUP|g" \\
+    cluster/examples/workloads/kubernetes/wordpress-aws/provider.yaml | kubectl apply -f -
+
+# Clean up after this script by deleting everything it created:
+# $0 delete $RAND
+EOS
+echo

--- a/cluster/examples/aws-credentials.sh
+++ b/cluster/examples/aws-credentials.sh
@@ -104,7 +104,7 @@ cat <<EOS
 #
 # Run the following for the variables that are used throughout the AWS example projects
 #
-export BASE64ENCODED_AWS_PROVIDER_CREDS=\$(base64 -w0 < $KEYFILE)
+export BASE64ENCODED_AWS_PROVIDER_CREDS=\$(base64 $KEYFILE | tr -d "\n")
 export EKS_WORKER_KEY_NAME=$EKS_WORKER_KEY_NAME
 export EKS_ROLE_ARN=$EKS_ROLE_ARN
 export REGION=$REGION
@@ -117,7 +117,7 @@ export RDS_SECURITY_GROUP=$RDS_SECURITY_GROUP
 #
 # Use this environment in an AWS Crossplane provider:
 #
-sed -e "s|BASE64ENCODED_AWS_PROVIDER_CREDS|\$(base64 -w0 < $KEYFILE)|g" \\
+sed -e "s|BASE64ENCODED_AWS_PROVIDER_CREDS|\$(base64 $KEYFILE | tr -d "\n")|g" \\
     -e "s|EKS_WORKER_KEY_NAME|\$EKS_WORKER_KEY_NAME|g" \\
     -e "s|EKS_ROLE_ARN|\$EKS_ROLE_ARN|g" \\
     -e "s|REGION|\$REGION|g" \\

--- a/cluster/examples/workloads/kubernetes/wordpress-aws/app.yaml
+++ b/cluster/examples/workloads/kubernetes/wordpress-aws/app.yaml
@@ -2,10 +2,10 @@
 apiVersion: storage.crossplane.io/v1alpha1
 kind: MySQLInstance
 metadata:
-  name: sql
-  namespace: complex
+  name: demo-mysql
+  namespace: default
 spec:
-  classRef:
+  classReference:
     name: standard-mysql
     namespace: crossplane-system
   engineVersion: "5.7"

--- a/cluster/examples/workloads/kubernetes/wordpress-aws/app.yaml
+++ b/cluster/examples/workloads/kubernetes/wordpress-aws/app.yaml
@@ -2,8 +2,8 @@
 apiVersion: storage.crossplane.io/v1alpha1
 kind: MySQLInstance
 metadata:
-  name: demo-mysql
-  namespace: default
+  name: sql
+  namespace: complex
 spec:
   classReference:
     name: standard-mysql

--- a/cluster/examples/workloads/kubernetes/wordpress-aws/cluster.yaml
+++ b/cluster/examples/workloads/kubernetes/wordpress-aws/cluster.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: complex
+---
+apiVersion: compute.crossplane.io/v1alpha1
+kind: KubernetesCluster
+metadata:
+  name: wordpress-demo-cluster
+  namespace: complex
+  labels:
+    provider: aws
+    app: wordpress-demo
+spec:
+  classReference:
+    name: standard-cluster
+    namespace: crossplane-system
+---

--- a/cluster/examples/workloads/kubernetes/wordpress-aws/provider.yaml
+++ b/cluster/examples/workloads/kubernetes/wordpress-aws/provider.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: v1
+data:
+  credentials: BASE64ENCODED_AWS_PROVIDER_CREDS
+kind: Secret
+metadata:
+  name: aws-provider-creds
+  namespace: crossplane-system
+type: Opaque
+---
+apiVersion: aws.crossplane.io/v1alpha1
+kind: Provider
+metadata:
+  name: aws-provider
+  namespace: crossplane-system
+spec:
+  credentialsSecretRef:
+    key: credentials
+    name: aws-provider-creds
+  region: REGION
+---
+apiVersion: core.crossplane.io/v1alpha1
+kind: ResourceClass
+metadata:
+  name: standard-mysql
+  namespace: crossplane-system
+parameters:
+  class: db.t2.small
+  masterUsername: masteruser
+  securityGroups: RDS_SECURITY_GROUP #sg-1,sg-2
+  subnetGroupName: RDS_SUBNET_GROUP_NAME # eks-db-subnets
+  size: "20"
+provisioner: rdsinstance.database.aws.crossplane.io/v1alpha1
+providerRef:
+  name: aws-provider
+reclaimPolicy: Delete
+---
+apiVersion: core.crossplane.io/v1alpha1
+kind: ResourceClass
+metadata:
+  name: standard-cluster
+  namespace: crossplane-system
+parameters:
+  region: REGION
+  roleARN: EKS_ROLE_ARN # arn:aws:iam::<account-id>:role/<role-name>
+  vpcId: EKS_VPC #vpc-01
+  subnetIds: EKS_SUBNETS #subnet-01,subnet-02,subnet-03
+  securityGroupIds: EKS_SECURITY_GROUP #sg-01
+  workerKeyName: EKS_WORKER_KEY_NAME #named ec2 keypair
+  workerNodeInstanceType: m3.medium
+  workerNodeAutoScalingGroupMinSize: "1"
+  workerNodeAutoScalingGroupMaxSize: "1"
+  workerNodeGroupName: demo-nodes
+  workerClusterControlPlaneSecurityGroup: EKS_SECURITY_GROUP #sg-01
+provisioner: ekscluster.compute.aws.crossplane.io/v1alpha1
+providerRef:
+  name: aws-provider
+reclaimPolicy: Delete
+---

--- a/cluster/examples/workloads/kubernetes/wordpress-gcp/provider.yaml
+++ b/cluster/examples/workloads/kubernetes/wordpress-gcp/provider.yaml
@@ -22,13 +22,13 @@ spec:
 apiVersion: core.crossplane.io/v1alpha1
 kind: ResourceClass
 metadata:
-  name: standard-cluster
+  name: standard-mysql
   namespace: crossplane-system
 parameters:
-  machineType: n1-standard-1
-  numNodes: "1"
-  zone: us-central1-b
-provisioner: gkecluster.compute.gcp.crossplane.io/v1alpha1
+  tier: db-n1-standard-1
+  region: us-west2
+  storageType: PD_SSD
+provisioner: cloudsqlinstance.database.gcp.crossplane.io/v1alpha1
 providerRef:
   name: gcp-provider
   namespace: crossplane-system
@@ -37,13 +37,13 @@ reclaimPolicy: Delete
 apiVersion: core.crossplane.io/v1alpha1
 kind: ResourceClass
 metadata:
-  name: standard-mysql
+  name: standard-cluster
   namespace: crossplane-system
 parameters:
-  tier: db-n1-standard-1
-  region: us-west2
-  storageType: PD_SSD
-provisioner: cloudsqlinstance.database.gcp.crossplane.io/v1alpha1
+  machineType: n1-standard-1
+  numNodes: "1"
+  zone: us-central1-b
+provisioner: gkecluster.compute.gcp.crossplane.io/v1alpha1
 providerRef:
   name: gcp-provider
   namespace: crossplane-system

--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -4,6 +4,7 @@ toc: true
 weight: 330
 indent: true
 ---
+
 # Adding Your Cloud Providers
 
 In order for Crossplane to be able to manage resources across all your clouds, you will need to add your cloud provider credentials to Crossplane.
@@ -12,3 +13,30 @@ Use the links below for specific instructions to add each of the following cloud
 * [Google Cloud Platform (GCP)](cloud-providers/gcp/gcp-provider.md)
 * [Microsoft Azure](cloud-providers/azure/azure-provider.md)
 * [Amazon Web Services (AWS)](cloud-providers/aws/aws-provider.md)
+
+## Examining Cloud Provider Configuration
+
+When Crossplane is installed, you can list all of the available providers.
+
+```console
+$ kubectl api-resources  | grep providers.*crossplane | awk '{print $2}'
+aws.crossplane.io
+azure.crossplane.io
+gcp.crossplane.io
+```
+
+After credentials have put in place for some of the Cloud providers, you can list those configurations.
+
+```console
+$ kubectl -n crossplane-system get providers.gcp.crossplane.io
+NAME           PROJECT-ID                 AGE
+gcp-provider   crossplane-example-10412   22h
+
+$ kubectl -n crossplane-system get providers.aws.crossplane.io
+NAME           REGION      AGE
+aws-provider   eu-west-1   22h
+
+$ kubectl -n crossplane-system get providers.azure.crossplane.io
+NAME           AGE
+azure-provider 22h
+```

--- a/docs/cloud-providers/aws/aws-provider.md
+++ b/docs/cloud-providers/aws/aws-provider.md
@@ -8,6 +8,52 @@ In this guide, we will walk through the steps necessary to configure your AWS ac
 
 If you have already installed and configured the [`aws` command line tool](https://aws.amazon.com/cli/), you can simply find your AWS credentials file in `~/.aws/credentials`.
 
+#### Using `aws-credentials.sh`
+
+In the `cluster/examples` directory you will find a helper script, `aws-credentials.sh`.  This script will use the `aws` CLI to create the necessary AWS components for the Crossplane examples.  Running the final output of this command will configure your Crossplane AWS provider, RDS, and EKS resource classes.
+
+```console
+$ ./cluster/examples/aws-credentials.sh
+Waiting for 'CREATE_COMPLETE' from Cloudformation Stack crossplane-example-stack-25077.......................
+#
+# Run the following for the variables that are used throughout the AWS example projects
+#
+export BASE64ENCODED_AWS_PROVIDER_CREDS=$(base64 -w0 < ~/.aws/credentials)
+export EKS_WORKER_KEY_NAME=crossplane-example-25077
+export EKS_ROLE_ARN=arn:aws:iam::987654321234:role/crossplane-example-role-25077
+export REGION=eu-west-1
+export EKS_VPC=vpc-085444e4ce26b55e8
+export EKS_SUBNETS=subnet-08ad61800a39c537a,subnet-0d05d23815bed79be,subnet-07adcb08485e186fc
+export EKS_SECURITY_GROUP=sg-09aaba94fe7050cf8
+export RDS_SUBNET_GROUP_NAME=crossplane-example-db-subnet-group-25077
+export RDS_SECURITY_GROUP=sg-0b586dbd763fb35ad
+
+#
+# For example, to use this environment as an AWS Crossplane provider:
+#
+sed -e "s|BASE64ENCODED_AWS_PROVIDER_CREDS|$(base64 -w0 < /home/marques/.aws/credentials)|g" \
+    -e "s|EKS_WORKER_KEY_NAME|$EKS_WORKER_KEY_NAME|g" \
+    -e "s|EKS_ROLE_ARN|$EKS_ROLE_ARN|g" \
+    -e "s|REGION|$REGION|g" \
+    -e "s|EKS_VPC|$EKS_VPC|g" \
+    -e "s|EKS_SUBNETS|$EKS_SUBNETS|g" \
+    -e "s|EKS_SECURITY_GROUP|$EKS_SECURITY_GROUP|g" \
+    -e "s|RDS_SUBNET_GROUP_NAME|$RDS_SUBNET_GROUP_NAME|g" \
+    -e "s|RDS_SECURITY_GROUP|$RDS_SECURITY_GROUP|g" \
+    cluster/examples/workloads/kubernetes/wordpress-aws/provider.yaml | kubectl apply -f -
+
+# Clean up after this script by deleting everything it created:
+# ./cluster/examples/aws-credentials.sh delete 25077
+```
+
+After running `gcp-credentials.sh`, a series of `export` commands will be shown.  Copy and paste the `export` commands that are provided.  These variable names will be referenced throughout the Crossplane examples, generally with a `sed` command.
+
+You will also see a `sed` command.  This command will configure the AWS Crossplane provider using the environment that was created by the `aws-credentials.sh` script.
+
+When you are done with the examples and have deleted all of the AWS artifacts project artifacts you can use the delete command provided by the `aws-credentials.sh` script to remove the CloudFormation Stack, VPC, and other artifacts of the script.
+
+*Note* The AWS artifacts should be removed first using Kubernetes commands (`kubectl delete ...`) as each example will explain.
+
 ### Option 2: AWS Console in Web Browser
 
 If you do not have the `aws` tool installed, you can alternatively log into the [AWS console](https://aws.amazon.com/console/) and export the credentials.

--- a/docs/cloud-providers/aws/aws-provider.md
+++ b/docs/cloud-providers/aws/aws-provider.md
@@ -18,7 +18,7 @@ Waiting for 'CREATE_COMPLETE' from Cloudformation Stack crossplane-example-stack
 #
 # Run the following for the variables that are used throughout the AWS example projects
 #
-export BASE64ENCODED_AWS_PROVIDER_CREDS=$(base64 -w0 < ~/.aws/credentials)
+export BASE64ENCODED_AWS_PROVIDER_CREDS=$(base64 ~/.aws/credentials | tr -d "\n")
 export EKS_WORKER_KEY_NAME=crossplane-example-25077
 export EKS_ROLE_ARN=arn:aws:iam::987654321234:role/crossplane-example-role-25077
 export REGION=eu-west-1
@@ -31,7 +31,7 @@ export RDS_SECURITY_GROUP=sg-0b586dbd763fb35ad
 #
 # For example, to use this environment as an AWS Crossplane provider:
 #
-sed -e "s|BASE64ENCODED_AWS_PROVIDER_CREDS|$(base64 -w0 < /home/marques/.aws/credentials)|g" \
+sed -e "s|BASE64ENCODED_AWS_PROVIDER_CREDS|$(base64 ~/.aws/credentials | tr -d "\n")|g" \
     -e "s|EKS_WORKER_KEY_NAME|$EKS_WORKER_KEY_NAME|g" \
     -e "s|EKS_ROLE_ARN|$EKS_ROLE_ARN|g" \
     -e "s|REGION|$REGION|g" \

--- a/docs/workloads/aws/wordpress-aws.md
+++ b/docs/workloads/aws/wordpress-aws.md
@@ -148,7 +148,7 @@ Now deploy all the workload resources, including the RDS database and EKS cluste
 Create provider:
 
 ```console
-sed -e "s|BASE64ENCODED_AWS_PROVIDER_CREDS|`cat ~/.aws/credentials|base64|tr -d '\n'`|g;s|EKS_WORKER_KEY_NAME|$EKS_WORKER_KEY_NAME|g;s|EKS_ROLE_ARN|$EKS_ROLE_ARN|g;s|REGION|$REGION|g;s|EKS_VPC|$EKS_VPC|g;s|EKS_SUBNETS|$EKS_SUBNETS|g;s|EKS_SECURITY_GROUP|$EKS_SECURITY_GROUP|g;s|RDS_SUBNET_GROUP_NAME|$RDS_SUBNET_GROUP_NAME|g;s|RDS_SECURITY_GROUP|$RDS_SECURITY_GROUP|g" cluster/examples/workloads/kubernetes/wordpress-aws/provider.yaml | kubectl create -f -
+sed -e "s|BASE64ENCODED_AWS_PROVIDER_CREDS|`base64 ~/.aws/credentials|tr -d '\n'`|g;s|EKS_WORKER_KEY_NAME|$EKS_WORKER_KEY_NAME|g;s|EKS_ROLE_ARN|$EKS_ROLE_ARN|g;s|REGION|$REGION|g;s|EKS_VPC|$EKS_VPC|g;s|EKS_SUBNETS|$EKS_SUBNETS|g;s|EKS_SECURITY_GROUP|$EKS_SECURITY_GROUP|g;s|RDS_SUBNET_GROUP_NAME|$RDS_SUBNET_GROUP_NAME|g;s|RDS_SECURITY_GROUP|$RDS_SECURITY_GROUP|g" cluster/examples/workloads/kubernetes/wordpress-aws/provider.yaml | kubectl create -f -
 ```
 
 Create cluster:

--- a/docs/workloads/aws/wordpress-aws.md
+++ b/docs/workloads/aws/wordpress-aws.md
@@ -17,10 +17,10 @@ You should also have an AWS credentials file at `~/.aws/credentials` already on 
 
 This section covers tasks performed by the cluster or cloud administrator.  These include:
 
-- Importing AWS provider credentials
-- Defining resource classes for cluster and database resources
-- Creating all EKS pre-requisite artifacts
-- Creating a target EKS cluster (using dynamic provisioning with the cluster resource class)
+* Importing AWS provider credentials
+* Defining resource classes for cluster and database resources
+* Creating all EKS pre-requisite artifacts
+* Creating a target EKS cluster (using dynamic provisioning with the cluster resource class)
 
 > Note: All artifacts created by the administrator are stored/hosted in the `crossplane-system` namespace, which has
 restricted access, i.e. `Application Owner(s)` should not have access to them.
@@ -34,8 +34,10 @@ A number of artifacts and configurations need to be set up within the AWS consol
 We anticipate that AWS will make improvements on this user experience in the near future.
 
 #### Create a named keypair
+
 1. Use an existing ec2 key pair or create a new key pair by following [these steps](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html)
 1. Export the key pair name as the EKS_WORKER_KEY_NAME environment variable
+
     ```console
     export EKS_WORKER_KEY_NAME=replace-with-key-name
     ```
@@ -50,6 +52,7 @@ We anticipate that AWS will make improvements on this user experience in the nea
 1. Choose Next: Review.
 1. For the Role name, enter a unique name for your role, such as eksServiceRole, then choose Create role.
 1. Set the EKS_ROLE_ARN environment variable to the name of your role ARN
+
     ```console
     export EKS_ROLE_ARN=replace-with-full-role-arn
     ```
@@ -63,8 +66,9 @@ We anticipate that AWS will make improvements on this user experience in the nea
      > * US West (Oregon) (us-west-2)
      > * US East (N. Virginia) (us-east-1)
      > * EU (Ireland) (eu-west-1)
-    
+
 1. Set the REGION environment variable to your region
+
     ```console
     export REGION=replace-with-region
     ```
@@ -72,21 +76,26 @@ We anticipate that AWS will make improvements on this user experience in the nea
 1. Choose Create stack.
 1. For Choose a template, select Specify an Amazon S3 template URL.
 1. Paste the following URL into the text area and choose Next.
-    ```
+
+    ```text
     https://amazon-eks.s3-us-west-2.amazonaws.com/cloudformation/2018-11-07/amazon-eks-vpc-sample.yaml
     ```
+
 1. On the Specify Details page, fill out the parameters accordingly, and choose Next.
-    ```
+
+    ```console
     * Stack name: Choose a stack name for your AWS CloudFormation stack. For example, you can call it eks-vpc.
     * VpcBlock: Choose a CIDR range for your VPC. You may leave the default value.
     * Subnet01Block: Choose a CIDR range for subnet 1. You may leave the default value.
     * Subnet02Block: Choose a CIDR range for subnet 2. You may leave the default value.
     * Subnet03Block: Choose a CIDR range for subnet 3. You may leave the default value.
     ```
+
 1. (Optional) On the Options page, tag your stack resources and choose Next.
 1. On the Review page, choose Create.
 1. When your stack is created, select it in the console and choose Outputs.
 1. Using values from outputs, export the following environment variables.
+
     ```console
     export EKS_VPC=replace-with-eks-vpcId
     export EKS_SUBNETS=replace-with-eks-subnetIds01,replace-with-eks-subnetIds02,replace-with-eks-subnetIds03
@@ -94,6 +103,7 @@ We anticipate that AWS will make improvements on this user experience in the nea
     ```
 
 #### Create an RDS subnet group
+
 1. Navigate to the aws console in same region as the EKS clsuter
 1. Navigate to `RDS` service
 1. Navigate to `Subnet groups` in left hand pane
@@ -103,6 +113,7 @@ We anticipate that AWS will make improvements on this user experience in the nea
 1. Click `Add all subnets related to this VPC`
 1. Click Create
 1. Export the db subnet group name
+
     ```console
     export RDS_SUBNET_GROUP_NAME=replace-with-DBSubnetgroup-name
     ```
@@ -119,27 +130,29 @@ This is for **EXAMPLE PURPOSES ONLY** and is **NOT RECOMMENDED** for production 
 1. Give it a description
 1. Select the same VPC as the EKS cluster.
 1. On the Inbound Rules tab, choose Edit.
-    - For Type, choose `MYSQL/Aurora`
-    - For Port Range, type `3306`
-    - For Source, choose `Anywhere` from drop down or type: `0.0.0.0/0`
+    * For Type, choose `MYSQL/Aurora`
+    * For Port Range, type `3306`
+    * For Source, choose `Anywhere` from drop down or type: `0.0.0.0/0`
 1. Choose Add another rule if you need to add more IP addresses or different port ranges.
 1. Click: Create
 1. Export the security group id
+
     ```console
     export RDS_SECURITY_GROUP=replace-with-security-group-id
     ```
-
 
 ### Deploy all Workload Resources
 
 Now deploy all the workload resources, including the RDS database and EKS cluster with the following commands:
 
 Create provider:
+
 ```console
-sed -e "s|BASE64ENCODED_AWS_PROVIDER_CREDS|`cat ~/.aws/credentials|base64|tr -d '\n'`|g;s|EKS_WORKER_KEY_NAME|$EKS_WORKER_KEY_NAME|g;s|EKS_ROLE_ARN|$EKS_ROLE_ARN|g;s|REGION|$REGION|g;s|EKS_VPC|$EKS_VPC|g;s|EKS_SUBNETS|$EKS_SUBNETS|g;s|EKS_SECURITY_GROUP|$EKS_SECURITY_GROUP|g;s|RDS_SUBNET_GROUP_NAME|$RDS_SUBNET_GROUP_NAME|g;s|RDS_SECURITY_GROUP|$RDS_SECURITY_GROUP|g" cluster/examples/workloads/wordpress-aws/provider.yaml | kubectl create -f -
+sed -e "s|BASE64ENCODED_AWS_PROVIDER_CREDS|`cat ~/.aws/credentials|base64|tr -d '\n'`|g;s|EKS_WORKER_KEY_NAME|$EKS_WORKER_KEY_NAME|g;s|EKS_ROLE_ARN|$EKS_ROLE_ARN|g;s|REGION|$REGION|g;s|EKS_VPC|$EKS_VPC|g;s|EKS_SUBNETS|$EKS_SUBNETS|g;s|EKS_SECURITY_GROUP|$EKS_SECURITY_GROUP|g;s|RDS_SUBNET_GROUP_NAME|$RDS_SUBNET_GROUP_NAME|g;s|RDS_SECURITY_GROUP|$RDS_SECURITY_GROUP|g" cluster/examples/compute/wordpress-aws/provider.yaml | kubectl create -f -
 ```
 
 Create cluster:
+
 ```console
 kubectl create -f cluster/examples/workloads/wordpress-aws/cluster.yaml
 ```
@@ -148,61 +161,89 @@ It will take a while (~15 minutes) for the EKS cluster to be deployed and become
 You can keep an eye on its status with the following command:
 
 ```console
-kubectl -n crossplane-system get ekscluster -o custom-columns=NAME:.metadata.name,STATE:.status.state,CLUSTERNAME:.status.clusterName,ENDPOINT:.status.endpoint,LOCATION:.spec.location,CLUSTERCLASS:.spec.classRef.name,RECLAIMPOLICY:.spec.reclaimPolicy
+kubectl -n crossplane-system get ekscluster
 ```
 
 Once the cluster is done provisioning, you should see output similar to the following
 > Note:  the `STATE` field is `ACTIVE` and the `ENDPOINT` field has a value):
 
 ```console
-NAME                                       STATE      CLUSTERNAME   ENDPOINT                                                                   LOCATION   CLUSTERCLASS       RECLAIMPOLICY
-eks-8f1f32c7-f6b4-11e8-844c-025000000001   ACTIVE     <none>        https://B922855C944FC0567E9050FCD75B6AE5.yl4.us-west-2.eks.amazonaws.com   <none>     standard-cluster   Delete
+NAME                                       STATUS   STATE    CLUSTER-NAME   ENDPOINT                                                                   CLUSTER-CLASS      LOCATION   RECLAIM-POLICY   AGE
+eks-825c1234-9697-11e9-8b05-080027550c17   Bound    ACTIVE                  https://6A7981620931E720CE162F751C158A78.yl4.eu-west-1.eks.amazonaws.com   standard-cluster              Delete           51m
 ```
 
 ## Application Developer Tasks
 
 This section covers tasks performed by an application developer.  These include:
 
-- Defining a Workload in terms of Resources and Payload (Deployment/Service) which will be deployed into the target Kubernetes Cluster
-- Defining the resource's dependency requirements, in this case a `MySQL` database
+* Defining a Workload in terms of Resources and Payload (Deployment/Service) which will be deployed into the target Kubernetes Cluster
+* Defining the resource's dependency requirements, in this case a `MySQL` database
 
 Now that the EKS cluster is ready, let's begin deploying the workload as the application developer:
 
 ```console
-kubectl create -f cluster/examples/workloads/wordpress-aws/workload.yaml
+kubectl create -f cluster/examples/workloads/kubernetes/wordpress-aws/app.yaml
 ```
 
 This will also take awhile to complete, since the MySQL database needs to be deployed before the WordPress pod can consume it.
 You can follow along with the MySQL database deployment with the following:
 
 ```console
-kubectl -n crossplane-system get rdsinstance -o custom-columns=NAME:.metadata.name,STATUS:.status.state,CLASS:.spec.classRef.name,VERSION:.spec.version
+kubectl -n crossplane-system get rdsinstance
 ```
 
 Once the `STATUS` column is `available` as seen below, the WordPress pod should be able to connect to it:
 
 ```console
-NAME                                         STATUS      CLASS            VERSION
-mysql-2a0be04f-f748-11e8-844c-025000000001   available   standard-mysql   <none>
+NAME                                         STATUS   STATE      CLASS            VERSION   AGE
+mysql-dd26a14e-969e-11e9-8b05-080027550c17            creating   standard-mysql   5.7       1m
 ```
 
-Now we can watch the WordPress pod come online and a public IP address will get assigned to it:
+As an administrator, we can examine the cluster directly.
 
 ```console
-kubectl -n demo get workload -o custom-columns=NAME:.metadata.name,CLUSTER:.spec.targetCluster.name,NAMESPACE:.spec.targetNamespace,DEPLOYMENT:.spec.targetDeployment.metadata.name,SERVICE-EXTERNAL-IP:.status.service.loadBalancer.ingress[0].ip
+$ CLUSTER=eks-$(kubectl get kubernetesclusters.compute.crossplane.io -n complex -o=jsonpath='{.items[0].spec.resourceName.uid}')
+$ KUBECONFIG=/tmp/$CLUSTER aws eks update-kubeconfig --name=$CLUSTER --region=$REGION
+$ KUBECONFIG=/tmp/$CLUSTER kubectl get pods,services,deployments -A
+NAMESPACE     NAME                             READY   STATUS                       RESTARTS   AGE
+kube-system   pod/aws-node-d2sv2               1/1     Running                      0          58m
+kube-system   pod/coredns-7b5c8bfcfc-8cknr     1/1     Running                      0          85m
+kube-system   pod/coredns-7b5c8bfcfc-nsckc     1/1     Running                      0          85m
+kube-system   pod/kube-proxy-bxrkh             1/1     Running                      0          58m
+wordpress     pod/wordpress-8545774bcf-ppr4l   0/1     CreateContainerConfigError   0          44m
+
+NAMESPACE     NAME                 TYPE           CLUSTER-IP       EXTERNAL-IP                                                               PORT(S)         AGE
+default       service/kubernetes   ClusterIP      10.100.0.1       <none>                                                                    443/TCP         85m
+kube-system   service/kube-dns     ClusterIP      10.100.0.10      <none>                                                                    53/UDP,53/TCP   85m
+wordpress     service/wordpress    LoadBalancer   10.100.122.109   ae429ee31969e11e9b7eb06064878ead-1157393490.eu-west-1.elb.amazonaws.com   80:30297/TCP    44m
+
+NAMESPACE     NAME                              DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+kube-system   deployment.extensions/coredns     2         2         2            2           85m
+wordpress     deployment.extensions/wordpress   1         1         1            0           44m
+```
+
+Continuing as the application developer, we can watch the WordPress pod come online and a public IP address will get assigned to it:
+
+```console
+kubectl -n complex get kubernetesapplication,kubernetesapplicationresources
 ```
 
 When a public IP address has been assigned, you'll see output similar to the following:
 
 ```console
-NAME            CLUSTER        NAMESPACE   DEPLOYMENT   SERVICE-EXTERNAL-IP
-demo            demo-cluster   demo        wordpress    104.43.240.15
+NAME                                                          CLUSTER                  STATUS               DESIRED   SUBMITTED
+kubernetesapplication.workload.crossplane.io/wordpress-demo   wordpress-demo-cluster   PartiallySubmitted   3         1
+
+NAME                                                                             TEMPLATE-KIND   TEMPLATE-NAME   CLUSTER                  STATUS
+kubernetesapplicationresource.workload.crossplane.io/wordpress-demo-deployment   Deployment      wordpress       wordpress-demo-cluster   Failed
+kubernetesapplicationresource.workload.crossplane.io/wordpress-demo-namespace    Namespace       wordpress       wordpress-demo-cluster   Submitted
+kubernetesapplicationresource.workload.crossplane.io/wordpress-demo-service      Service         wordpress       wordpress-demo-cluster   Failed
 ```
 
 Once WordPress is running and has a public IP address through its service, we can get the URL with the following command:
 
 ```console
-echo "http://$(kubectl get workload test-workload -o jsonpath='{.status.service.loadBalancer.ingress[0].ip}')"
+echo "http://$(kubectl get kubernetesapplicationresource.workload.crossplane.io/wordpress-demo-service -n complex -o yaml  -o jsonpath='{.status.remote.loadBalancer.ingress[0].hostname}')"
 ```
 
 Paste that URL into your browser and you should see WordPress running and ready for you to walk through its setup experience. You may need to wait a few minutes for this to become accessible via the AWS load balancer.
@@ -210,17 +251,20 @@ Paste that URL into your browser and you should see WordPress running and ready 
 ## Connecting to your EKSCluster (optional)
 
 Requires:
- * awscli
- * aws-iam-authenticator
+
+* awscli
+* aws-iam-authenticator
 
 Please see [Install instructions](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html) section: `Install and Configure kubectl for Amazon EKS`
 
 When the EKSCluster is up and running, you can update your kubeconfig with:
+
 ```console
 aws eks update-kubeconfig --name <replace-me-eks-cluster-name>
 ```
 
 Node pool is created after the master is up, so expect a few more minutes to wait, but eventually you can see that nodes joined with:
+
 ```console
 kubectl config use-context <context-from-last-command>
 kubectl get nodes
@@ -231,19 +275,19 @@ kubectl get nodes
 First delete the workload, which will delete WordPress and the MySQL database:
 
 ```console
-kubectl delete -f cluster/examples/workloads/wordpress-aws/workload.yaml
+kubectl delete -f cluster/examples/workloads/kubernetes/wordpress-aws/app.yaml
 ```
 
 Then delete the EKS cluster:
 
 ```console
-kubectl delete -f cluster/examples/workloads/wordpress-aws/cluster.yaml
+kubectl delete -f cluster/examples/workloads/kubernetes/wordpress-aws/cluster.yaml
 ```
 
 Finally, delete the provider credentials:
 
 ```console
-kubectl delete -f cluster/examples/workloads/wordpress-aws/provider.yaml
+kubectl delete -f cluster/examples/workloads/kubernetes/wordpress-aws/provider.yaml
 ```
 
 > Note: There may still be an ELB that was not properly cleaned up, and you will need

--- a/docs/workloads/aws/wordpress-aws.md
+++ b/docs/workloads/aws/wordpress-aws.md
@@ -148,13 +148,13 @@ Now deploy all the workload resources, including the RDS database and EKS cluste
 Create provider:
 
 ```console
-sed -e "s|BASE64ENCODED_AWS_PROVIDER_CREDS|`cat ~/.aws/credentials|base64|tr -d '\n'`|g;s|EKS_WORKER_KEY_NAME|$EKS_WORKER_KEY_NAME|g;s|EKS_ROLE_ARN|$EKS_ROLE_ARN|g;s|REGION|$REGION|g;s|EKS_VPC|$EKS_VPC|g;s|EKS_SUBNETS|$EKS_SUBNETS|g;s|EKS_SECURITY_GROUP|$EKS_SECURITY_GROUP|g;s|RDS_SUBNET_GROUP_NAME|$RDS_SUBNET_GROUP_NAME|g;s|RDS_SECURITY_GROUP|$RDS_SECURITY_GROUP|g" cluster/examples/compute/wordpress-aws/provider.yaml | kubectl create -f -
+sed -e "s|BASE64ENCODED_AWS_PROVIDER_CREDS|`cat ~/.aws/credentials|base64|tr -d '\n'`|g;s|EKS_WORKER_KEY_NAME|$EKS_WORKER_KEY_NAME|g;s|EKS_ROLE_ARN|$EKS_ROLE_ARN|g;s|REGION|$REGION|g;s|EKS_VPC|$EKS_VPC|g;s|EKS_SUBNETS|$EKS_SUBNETS|g;s|EKS_SECURITY_GROUP|$EKS_SECURITY_GROUP|g;s|RDS_SUBNET_GROUP_NAME|$RDS_SUBNET_GROUP_NAME|g;s|RDS_SECURITY_GROUP|$RDS_SECURITY_GROUP|g" cluster/examples/workloads/kubernetes/wordpress-aws/provider.yaml | kubectl create -f -
 ```
 
 Create cluster:
 
 ```console
-kubectl create -f cluster/examples/workloads/wordpress-aws/cluster.yaml
+kubectl create -f cluster/examples/workloads/kubernetes/wordpress-aws/cluster.yaml
 ```
 
 It will take a while (~15 minutes) for the EKS cluster to be deployed and become available.

--- a/pkg/apis/aws/v1alpha1/types.go
+++ b/pkg/apis/aws/v1alpha1/types.go
@@ -37,6 +37,9 @@ type ProviderSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Provider is the Schema for the instances API
+// +kubebuilder:printcolumn:name="REGION",type="string",JSONPath=".spec.region"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="CREDENTIAL",type="string",JSONPath=".spec.credentialsSecretRef.name",priority="1"
 type Provider struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/aws/v1alpha1/types.go
+++ b/pkg/apis/aws/v1alpha1/types.go
@@ -39,7 +39,7 @@ type ProviderSpec struct {
 // Provider is the Schema for the instances API
 // +kubebuilder:printcolumn:name="REGION",type="string",JSONPath=".spec.region"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:printcolumn:name="CREDENTIAL",type="string",JSONPath=".spec.credentialsSecretRef.name",priority="1"
+// +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentialsSecretRef.name",priority="1"
 type Provider struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/azure/v1alpha1/types.go
+++ b/pkg/apis/azure/v1alpha1/types.go
@@ -36,7 +36,7 @@ type ProviderSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Provider is the Schema for the instances API
-// +kubebuilder:printcolumn:name="CREDENTIAL",type="string",JSONPath=".spec.credentialsSecretRef.name",priority="1"
+// +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentialsSecretRef.name",priority="1"
 type Provider struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/azure/v1alpha1/types.go
+++ b/pkg/apis/azure/v1alpha1/types.go
@@ -36,6 +36,7 @@ type ProviderSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Provider is the Schema for the instances API
+// +kubebuilder:printcolumn:name="CREDENTIAL",type="string",JSONPath=".spec.credentialsSecretRef.name",priority="1"
 type Provider struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/gcp/v1alpha1/types.go
+++ b/pkg/apis/gcp/v1alpha1/types.go
@@ -40,7 +40,7 @@ type ProviderSpec struct {
 // Provider is the Schema for the instances API
 // +kubebuilder:printcolumn:name="PROJECT-ID",type="string",JSONPath=".spec.projectID"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:printcolumn:name="CREDENTIAL",type="string",JSONPath=".spec.credentialsSecretRef.name",priority="1"
+// +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentialsSecretRef.name",priority="1"
 type Provider struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/gcp/v1alpha1/types.go
+++ b/pkg/apis/gcp/v1alpha1/types.go
@@ -40,6 +40,7 @@ type ProviderSpec struct {
 // Provider is the Schema for the instances API
 // +kubebuilder:printcolumn:name="PROJECT-ID",type="string",JSONPath=".spec.projectID"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="CREDENTIAL",type="string",JSONPath=".spec.credentialsSecretRef.name",priority="1"
 type Provider struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/clients/aws/cloudformation/cloudformation.go
+++ b/pkg/clients/aws/cloudformation/cloudformation.go
@@ -89,10 +89,18 @@ func IsErrorNotFound(err error) bool {
 
 // IsCompletedState validates that operation is complete for a create or update.
 func IsCompletedState(status cf.StackStatus) bool {
-	return status == cf.StackStatusCreateComplete || status == cf.StackStatusUpdateComplete
+	switch status {
+	case cf.StackStatusCreateComplete, cf.StackStatusUpdateComplete:
+		return true
+	}
+	return false
 }
 
 // IsFailedState reports if the operation has failed and can not continue.
 func IsFailedState(status cf.StackStatus) bool {
-	return status == cf.StackStatusCreateFailed || status == cf.StackStatusRollbackComplete || status == cf.StackStatusRollbackFailed || status == cf.StackStatusDeleteComplete || status == cf.StackStatusDeleteFailed
+	switch status {
+	case cf.StackStatusCreateFailed, cf.StackStatusRollbackComplete, cf.StackStatusRollbackFailed, cf.StackStatusDeleteComplete, cf.StackStatusDeleteFailed:
+		return true
+	}
+	return false
 }

--- a/pkg/clients/aws/cloudformation/cloudformation.go
+++ b/pkg/clients/aws/cloudformation/cloudformation.go
@@ -91,3 +91,8 @@ func IsErrorNotFound(err error) bool {
 func IsCompletedState(status cf.StackStatus) bool {
 	return status == cf.StackStatusCreateComplete || status == cf.StackStatusUpdateComplete
 }
+
+// IsFailedState reports if the operation has failed and can not continue.
+func IsFailedState(status cf.StackStatus) bool {
+	return status == cf.StackStatusCreateFailed || status == cf.StackStatusRollbackComplete || status == cf.StackStatusRollbackFailed || status == cf.StackStatusDeleteComplete || status == cf.StackStatusDeleteFailed
+}

--- a/pkg/clients/aws/cloudformation/cloudformation.go
+++ b/pkg/clients/aws/cloudformation/cloudformation.go
@@ -86,21 +86,3 @@ func IsErrorNotFound(err error) bool {
 	}
 	return false
 }
-
-// IsCompletedState validates that operation is complete for a create or update.
-func IsCompletedState(status cf.StackStatus) bool {
-	switch status {
-	case cf.StackStatusCreateComplete, cf.StackStatusUpdateComplete:
-		return true
-	}
-	return false
-}
-
-// IsFailedState reports if the operation has failed and can not continue.
-func IsFailedState(status cf.StackStatus) bool {
-	switch status {
-	case cf.StackStatusCreateFailed, cf.StackStatusRollbackComplete, cf.StackStatusRollbackFailed, cf.StackStatusDeleteComplete, cf.StackStatusDeleteFailed:
-		return true
-	}
-	return false
-}

--- a/pkg/controller/aws/compute/eks.go
+++ b/pkg/controller/aws/compute/eks.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	cf "github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -44,6 +45,7 @@ import (
 	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
 	awsClient "github.com/crossplaneio/crossplane/pkg/clients/aws"
 	cloudformationclient "github.com/crossplaneio/crossplane/pkg/clients/aws/cloudformation"
+
 	"github.com/crossplaneio/crossplane/pkg/clients/aws/eks"
 	"github.com/crossplaneio/crossplane/pkg/logging"
 	"github.com/crossplaneio/crossplane/pkg/meta"
@@ -66,6 +68,22 @@ var (
 	ctx           = context.Background()
 	result        = reconcile.Result{}
 	resultRequeue = reconcile.Result{Requeue: true}
+)
+
+// CloudFormation States that are non-transitory
+var (
+	completedCFState = map[cf.StackStatus]bool{
+		cf.StackStatusCreateComplete: true,
+		cf.StackStatusUpdateComplete: true,
+	}
+
+	failedCFState = map[cf.StackStatus]bool{
+		cf.StackStatusCreateFailed:     true,
+		cf.StackStatusRollbackComplete: true,
+		cf.StackStatusRollbackFailed:   true,
+		cf.StackStatusDeleteComplete:   true,
+		cf.StackStatusDeleteFailed:     true,
+	}
 )
 
 // Add creates a new Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
@@ -288,11 +306,11 @@ func (r *Reconciler) _sync(instance *awscomputev1alpha1.EKSCluster, client eks.C
 		return r.fail(instance, err)
 	}
 
-	if cloudformationclient.IsFailedState(clusterWorker.WorkersStatus) {
+	if failedCFState[clusterWorker.WorkersStatus] {
 		return r.fail(instance, errorSyncCluster, fmt.Sprintf("clusterworker stack failed with status %q and reason %q", clusterWorker.WorkersStatus, clusterWorker.WorkerReason))
 	}
 
-	if !cloudformationclient.IsCompletedState(clusterWorker.WorkersStatus) {
+	if !completedCFState[clusterWorker.WorkersStatus] {
 		instance.Status.SetConditions(corev1alpha1.ReconcileSuccess())
 		return resultRequeue, r.Update(ctx, instance)
 	}

--- a/pkg/controller/aws/compute/eks.go
+++ b/pkg/controller/aws/compute/eks.go
@@ -307,7 +307,7 @@ func (r *Reconciler) _sync(instance *awscomputev1alpha1.EKSCluster, client eks.C
 	}
 
 	if failedCFState[clusterWorker.WorkersStatus] {
-		return r.fail(instance, errorSyncCluster, fmt.Sprintf("clusterworker stack failed with status %q and reason %q", clusterWorker.WorkersStatus, clusterWorker.WorkerReason))
+		return r.fail(instance, fmt.Errorf("clusterworker stack failed with status %q and reason %q", clusterWorker.WorkersStatus, clusterWorker.WorkerReason))
 	}
 
 	if !completedCFState[clusterWorker.WorkersStatus] {

--- a/pkg/controller/aws/compute/eks.go
+++ b/pkg/controller/aws/compute/eks.go
@@ -288,6 +288,10 @@ func (r *Reconciler) _sync(instance *awscomputev1alpha1.EKSCluster, client eks.C
 		return r.fail(instance, err)
 	}
 
+	if cloudformationclient.IsFailedState(clusterWorker.WorkersStatus) {
+		return r.fail(instance, errorSyncCluster, fmt.Sprintf("clusterworker stack failed with status %q and reason %q", clusterWorker.WorkersStatus, clusterWorker.WorkerReason))
+	}
+
 	if !cloudformationclient.IsCompletedState(clusterWorker.WorkersStatus) {
 		instance.Status.SetConditions(corev1alpha1.ReconcileSuccess())
 		return resultRequeue, r.Update(ctx, instance)


### PR DESCRIPTION
The AWS compute workload example is updated to follow the Complex Workloads pattern (KubernetesApplications) as was done in #520.

Additionally:
* aws-credentials.sh script was added to configure the AWS environment used for the demos
* kubectl get provider* commands include more fields (in standard and wide listings)
* AWS CloudFormation stack failures are detected by AWS CF state

Closes #523 
Relates to #519 
 
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.
