### PR TITLE
Default Resource Class Controller Design

### DIFF
--- a/design/one-pager-default-resource-class.md
+++ b/design/one-pager-default-resource-class.md
@@ -8,8 +8,8 @@ The Crossplane ecosystem exposes the concepts of [Resource Classes and Resource 
 ## Goals
 
 - Allow operators and administrators the opportunity to provide a well defined, sane default class of commonly used resources that developers commonly submit claims for within a team or organization
-- Minimize the burden of determining acceptable resource claims to submit for approval to an operations team. The ability to fall back on the underlying resource that has been deemed acceptable reduces uneccessary workflow stoppages and side channel communication
-- Provide an *optional* feature that does not necessarily have to be implented within a team or organization
+- Minimize the burden of determining acceptable resource claims to submit for approval to an operations team. The ability to fall back on the underlying resource that has been deemed acceptable reduces unnecessary workflow stoppages and side channel communication
+- Provide an *optional* feature that does not necessarily have to be implemented within a team or organization
 
 ## Non-Goals
 

--- a/design/one-pager-default-resource-class.md
+++ b/design/one-pager-default-resource-class.md
@@ -92,7 +92,7 @@ Internally, Crossplane will first check to see if a resource class is referenced
 
 ## Controllers
 
-Currently, each Crossplane resource kind (i.e. GKE Cluster, AWS S3 Bucket, etc.) has a controller that reconciles claims for that resource by binding them to the corresponding managed type. These controllers use [predicates](https://github.com/negz/crossplane/blob/resourceful/pkg/resource/predicates.go)(TEMPORARY LINK) to ensure that there is a provisioner defined for the class referenced by the claim. If the claim contains no reference to a class, the controller will not act on the claim.
+Currently, each Crossplane resource kind (i.e. GKE Cluster, AWS S3 Bucket, etc.) has a controller that reconciles claims for that resource by binding them to the corresponding managed type. These controllers use [predicates](https://github.com/crossplaneio/crossplane/blob/master/pkg/resource/predicates.go) to ensure that there is a provisioner defined for the class referenced by the claim. If the claim contains no reference to a class, the controller will not act on the claim.
 
 Default resource classes require a single additional controller that watches for claims of any resource kind that have no class reference defined. The controller will check for this using predicates in the same fashion as the claim controllers. Upon discovery of a claim without a class reference, the controller searches for a class with an `defaultForClaimKinds` field that contains the `Kind` specified in the claim.
 

--- a/design/one-pager-default-resource-class.md
+++ b/design/one-pager-default-resource-class.md
@@ -55,7 +55,7 @@ While this provides a nice separation of concerns for the developer and the oper
 
 ## Proposed Workflow
 
-While it will remain possible to explicitly reference an underlying resource class, developers will now have the option to omit the class reference and rely on falling back to whatever operators have deemed an appropriate default. The default resource class will be distinguished via the `default` and `abstractResource` fields:
+While it will remain possible to explicitly reference an underlying resource class, developers will now have the option to omit the class reference and rely on falling back to whatever operators have deemed an appropriate default. The default resource class will be distinguished via the `defaultForClaimKinds` field:
 
 ```yaml
 apiVersion: core.crossplane.io/v1alpha1
@@ -68,8 +68,8 @@ parameters:
   masterUsername: masteruser
   securityGroups: "sg-ab1cdefg,sg-05adsfkaj1ksdjak"
   size: "20"
-default: true
-abstractResource: postgresqlinstance.storage.crossplane.io
+defaultForClaimKinds:
+- postgresqlinstance.storage.crossplane.io
 provisioner: rdsinstance.database.aws.crossplane.io/v1alpha1
 providerRef:
   name: aws-provider
@@ -94,13 +94,58 @@ Internally, Crossplane will first check to see if a resource class is referenced
 
 Currently, each Crossplane resource kind (i.e. GKE Cluster, AWS S3 Bucket, etc.) has a controller that reconciles claims for that resource by binding them to the corresponding managed type. These controllers use [predicates](https://github.com/negz/crossplane/blob/resourceful/pkg/resource/predicates.go)(TEMPORARY LINK) to ensure that there is a provisioner defined for the class referenced by the claim. If the claim contains no reference to a class, the controller will not act on the claim.
 
-Default resource classes require an additional controller for each resource kind that watches for claims of that resource that have no class reference defined. The controller will check for this using predicates in the same fashion as the claim controller. Upon discovery of a claim without a class reference, the controller searches for a class with an `abstractResource` field that matches the claim kind, and a `default` field set to `true`.
+Default resource classes require a single additional controller that watches for claims of any resource kind that have no class reference defined. The controller will check for this using predicates in the same fashion as the claim controllers. Upon discovery of a claim without a class reference, the controller searches for a class with an `defaultForClaimKinds` field that contains the `Kind` specified in the claim.
 
-Finally, the controller will set the `ClassRef` of the claim to the discovered default class. The claim will now pass the predicates of the resource claim controller, and will be bound using the default class implementation.
+Finally, the controller will set the `ClassRef` of the claim to the discovered default class. The claim will now pass the predicates of the resource claim controller for the specified resource kind, and will be bound using the default class implementation.
 
 ## Future Considerations
 
 As Crossplane evolves, it is possible that the implementation of this functionality is manifested slightly differently. One area that might affect implementation is the introduction of [strongly typed resource classes](https://github.com/crossplaneio/crossplane/issues/90). However, the workflow for developers and operators would remain largely the same in regards to usage of default resource classes.
+
+Additionally, some resources in Crossplane that are not portable (i.e. do not have comparable resources across providers) may eventually be implemented as their own concrete resource types. This may introduce the desire to have multiple resource claim kinds for which a resource class serves as default. For example, a claim may specify its `Kind` as either a `NoSQLInstance` or a more specific `DynamoDBInstance` and operators may want to specify the same default resource class for both of these claim kinds. The proposed implementation in this document would make this functionality possible because `defaultForClaimKinds` allows for multiple values.
+
+In this scenario, a default resource class may look like this:
+
+```yaml
+apiVersion: core.crossplane.io/v1alpha1
+kind: ResourceClass
+metadata:
+  name: cloud-nosql
+  namespace: crossplane-system
+parameters:
+  ...
+defaultForClaimKinds:
+- nosqlinstance.storage.crossplane.io
+- dynamodbinstance.storage.crossplane.io
+provisioner: dynamodbinstance.database.aws.crossplane.io/v1alpha1
+providerRef:
+  name: aws-provider
+reclaimPolicy: Delete
+```
+
+And a resource claim that defaulted to the resource class above could look like this in the general case:
+
+```yaml
+apiVersion: storage.crossplane.io/v1alpha1
+kind: NoSQLInstance
+metadata:
+  name: dynamo-claim
+  namespace: demo
+spec:
+  ...
+```
+
+Or in the more specific case:
+
+```yaml
+apiVersion: storage.crossplane.io/v1alpha1
+kind: DynamoDBInstance
+metadata:
+  name: dynamo-claim
+  namespace: demo
+spec:
+  ...
+```
 
 ## Questions and Open Issues
 


### PR DESCRIPTION
This update to the default resource class one-pager describes the design of the controller and how it will go about binding claims with no class specified to the default class for the claim's abstract type.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

### Description of your changes
Previously, this document described how a default resource class would be set, and recommended the use of annotations. Because annotations are not used to [select objects](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/), defaulting will be specified by additional fields on the resource class, namely `abstractResource` and `default`.

Things to consider when reviewing this design:
- The proposed design is contingent on the acceptance of the resource claim controller (#545) work that @negz has done.
- Because `ClassRef` is currently only part of a `ResourceClaim` `Spec`, we would need to update the `Spec` as opposed to the `Status`. I am not sure that this is a good practice, so it may be a better option to change the core `ResourceClaimStatus` to include a `ClassRef` that is automatically set to the `ClassRef` defined in the `Spec` unless there is not one defined (as would be the case if the default resource class was desired). This logic would need to be included in the claim controller.
- Because there would be a default resource class controller for each resource type, the `abstractResource` field could be more user friendly by just specifying the `Kind` instead of the `GroupVersionKind` (i.e. `PostgreSQLInstance` vs `postgresqlinstance.storage.crossplane.io`). However, since we are already using the "long name" for the `provisioner` I would recommend sticking with `GroupVersionKind` which is the design specified in this PR.
- This design does not specify how multiple default resource classes for the the same `abstractResource` would be handled. My first inclination would be to only allow one default per `abstractResource`, but there could potentially be an opportunity to use a different default based on the information specified in the claim. This would get into more of a scheduler functionality, which has some intriguing prospects (i.e. introduction of priority functions into Crossplane), but not sure we want to address that at this time.

Welcome any and all feedback!

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml