### PR TITLE
Add `json:",inline"` to All `ResourceSpec` field definition(s)

### DIFF
--- a/cluster/charts/crossplane/crds/aws/cache/v1alpha1/replicationgroup.yaml
+++ b/cluster/charts/crossplane/crds/aws/cache/v1alpha1/replicationgroup.yaml
@@ -86,6 +86,10 @@ spec:
                 your cluster in an Amazon VPC, you need to create a subnet group before
                 you start creating a cluster.
               type: string
+            claimRef:
+              type: object
+            classRef:
+              type: object
             engineVersion:
               description: EngineVersion specifies the version number of the cache
                 engine to be used for the clusters in this replication group. To view
@@ -165,6 +169,10 @@ spec:
                 as a range in the format ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC).
                 The minimum maintenance window is a 60 minute period.  Example: sun:23:00-mon:01:30'
               type: string
+            providerRef:
+              type: object
+            reclaimPolicy:
+              type: string
             replicasPerNodeGroup:
               description: ReplicasPerNodeGroup specifies the number of replica nodes
                 in each node group (shard). Valid values are 0 to 5.
@@ -214,7 +222,10 @@ spec:
                 cluster you must TransitEncryptionEnabled to true when you create
                 a cluster.
               type: boolean
+            writeConnectionSecretToRef:
+              type: object
           required:
+          - providerRef
           - cacheNodeType
           type: object
         status:

--- a/cluster/charts/crossplane/crds/aws/compute/v1alpha1/ekscluster.yaml
+++ b/cluster/charts/crossplane/crds/aws/compute/v1alpha1/ekscluster.yaml
@@ -53,6 +53,10 @@ spec:
           type: object
         spec:
           properties:
+            claimRef:
+              type: object
+            classRef:
+              type: object
             cliInput:
               description: CLIInput --cli-input-json  (string) Performs service operation
                 based on the JSON string provided. The JSON string follows the format
@@ -126,6 +130,10 @@ spec:
                 - groups
                 type: object
               type: array
+            providerRef:
+              type: object
+            reclaimPolicy:
+              type: string
             region:
               description: Region for EKS Cluster
               enum:
@@ -285,7 +293,10 @@ spec:
               - keyName
               - nodeInstanceType
               type: object
+            writeConnectionSecretToRef:
+              type: object
           required:
+          - providerRef
           - region
           - roleARN
           - vpcId

--- a/cluster/charts/crossplane/crds/aws/database/v1alpha1/rdsinstance.yaml
+++ b/cluster/charts/crossplane/crds/aws/database/v1alpha1/rdsinstance.yaml
@@ -44,13 +44,21 @@ spec:
           type: object
         spec:
           properties:
+            claimRef:
+              type: object
             class:
               type: string
+            classRef:
+              type: object
             engine:
               type: string
             engineVersion:
               type: string
             masterUsername:
+              type: string
+            providerRef:
+              type: object
+            reclaimPolicy:
               type: string
             securityGroups:
               description: "VPC Security groups that will allow the RDS instance to
@@ -72,7 +80,10 @@ spec:
                 If no DB subnet group is specified, then the new DB instance is not
                 created in a VPC.
               type: string
+            writeConnectionSecretToRef:
+              type: object
           required:
+          - providerRef
           - masterUsername
           - engine
           - class

--- a/cluster/charts/crossplane/crds/aws/storage/v1alpha1/s3bucket.yaml
+++ b/cluster/charts/crossplane/crds/aws/storage/v1alpha1/s3bucket.yaml
@@ -52,6 +52,10 @@ spec:
               - log-delivery-write
               - aws-exec-read
               type: string
+            claimRef:
+              type: object
+            classRef:
+              type: object
             localPermission:
               description: LocalPermission is the permissions granted on the bucket
                 for the provider specific bucket service account that is available
@@ -65,12 +69,19 @@ spec:
               description: NameFormat to format bucket name passing it a object UID
                 If not provided, defaults to "%s", i.e. UID value
               type: string
+            providerRef:
+              type: object
+            reclaimPolicy:
+              type: string
             region:
               description: Region is the aws region for the bucket
               type: string
             versioning:
               type: boolean
+            writeConnectionSecretToRef:
+              type: object
           required:
+          - providerRef
           - region
           - localPermission
           type: object

--- a/cluster/charts/crossplane/crds/azure/cache/v1alpha1/redis.yaml
+++ b/cluster/charts/crossplane/crds/azure/cache/v1alpha1/redis.yaml
@@ -41,12 +41,20 @@ spec:
           type: object
         spec:
           properties:
+            claimRef:
+              type: object
+            classRef:
+              type: object
             enableNonSslPort:
               description: EnableNonSSLPort specifies whether the non-ssl Redis server
                 port (6379) is enabled.
               type: boolean
             location:
               description: Location in which to create this resource.
+              type: string
+            providerRef:
+              type: object
+            reclaimPolicy:
               type: string
             redisConfiguration:
               description: RedisConfiguration specifies Redis Settings.
@@ -99,7 +107,10 @@ spec:
               description: 'SubnetID specifies the full resource ID of a subnet in
                 a virtual network to deploy the Redis cache in. Example format: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/Microsoft.{Network|ClassicNetwork}/VirtualNetworks/vnet1/subnets/subnet1'
               type: string
+            writeConnectionSecretToRef:
+              type: object
           required:
+          - providerRef
           - resourceGroupName
           - location
           - sku

--- a/cluster/charts/crossplane/crds/azure/compute/v1alpha1/akscluster.yaml
+++ b/cluster/charts/crossplane/crds/azure/compute/v1alpha1/akscluster.yaml
@@ -53,6 +53,10 @@ spec:
           type: object
         spec:
           properties:
+            claimRef:
+              type: object
+            classRef:
+              type: object
             disableRBAC:
               description: DisableRBAC determines whether RBAC will be disabled or
                 enabled in the cluster.
@@ -79,6 +83,10 @@ spec:
                 Standard_B2s, Standard_F2s_v2, etc. This value cannot be changed after
                 cluster creation.
               type: string
+            providerRef:
+              type: object
+            reclaimPolicy:
+              type: string
             resourceGroupName:
               description: ResourceGroupName is the name of the resource group that
                 the cluster will be created in
@@ -87,12 +95,15 @@ spec:
               description: Version is the Kubernetes version that will be deployed
                 to the cluster
               type: string
+            writeConnectionSecretToRef:
+              type: object
             writeServicePrincipalTo:
               description: WriteServicePrincipalSecretTo the specified Secret. The
                 service principal is automatically generated and used by the AKS cluster
                 to interact with other Azure resources.
               type: object
           required:
+          - providerRef
           - resourceGroupName
           - location
           - version

--- a/cluster/charts/crossplane/crds/azure/database/v1alpha1/mysqlserver.yaml
+++ b/cluster/charts/crossplane/crds/azure/database/v1alpha1/mysqlserver.yaml
@@ -46,6 +46,10 @@ spec:
           properties:
             adminLoginName:
               type: string
+            claimRef:
+              type: object
+            classRef:
+              type: object
             location:
               type: string
             pricingTier:
@@ -62,6 +66,10 @@ spec:
               - vcores
               - family
               type: object
+            providerRef:
+              type: object
+            reclaimPolicy:
+              type: string
             resourceGroupName:
               type: string
             sslEnforced:
@@ -81,7 +89,10 @@ spec:
               type: object
             version:
               type: string
+            writeConnectionSecretToRef:
+              type: object
           required:
+          - providerRef
           - resourceGroupName
           - location
           - pricingTier

--- a/cluster/charts/crossplane/crds/azure/database/v1alpha1/postgresqlserver.yaml
+++ b/cluster/charts/crossplane/crds/azure/database/v1alpha1/postgresqlserver.yaml
@@ -46,6 +46,10 @@ spec:
           properties:
             adminLoginName:
               type: string
+            claimRef:
+              type: object
+            classRef:
+              type: object
             location:
               type: string
             pricingTier:
@@ -62,6 +66,10 @@ spec:
               - vcores
               - family
               type: object
+            providerRef:
+              type: object
+            reclaimPolicy:
+              type: string
             resourceGroupName:
               type: string
             sslEnforced:
@@ -81,7 +89,10 @@ spec:
               type: object
             version:
               type: string
+            writeConnectionSecretToRef:
+              type: object
           required:
+          - providerRef
           - resourceGroupName
           - location
           - pricingTier

--- a/cluster/charts/crossplane/crds/azure/storage/v1alpha1/account.yaml
+++ b/cluster/charts/crossplane/crds/azure/storage/v1alpha1/account.yaml
@@ -46,6 +46,14 @@ spec:
           type: object
         spec:
           properties:
+            claimRef:
+              type: object
+            classRef:
+              type: object
+            providerRef:
+              type: object
+            reclaimPolicy:
+              type: string
             resourceGroupName:
               description: ResourceGroupName azure group name
               type: string
@@ -291,7 +299,10 @@ spec:
                     a length no greater than 256 characters.
                   type: object
               type: object
+            writeConnectionSecretToRef:
+              type: object
           required:
+          - providerRef
           - resourceGroupName
           - storageAccountName
           - storageAccountSpec

--- a/cluster/charts/crossplane/crds/azure/v1alpha1/resourcegroup.yaml
+++ b/cluster/charts/crossplane/crds/azure/v1alpha1/resourcegroup.yaml
@@ -28,12 +28,24 @@ spec:
           type: object
         spec:
           properties:
+            claimRef:
+              type: object
+            classRef:
+              type: object
             location:
               description: See official list of valid regions - https://azure.microsoft.com/en-us/global-infrastructure/regions/
               type: string
             name:
               description: Name of the resource group
               type: string
+            providerRef:
+              type: object
+            reclaimPolicy:
+              type: string
+            writeConnectionSecretToRef:
+              type: object
+          required:
+          - providerRef
           type: object
         status:
           properties:

--- a/cluster/charts/crossplane/crds/gcp/cache/v1alpha1/cloudmemorystoreinstance.yaml
+++ b/cluster/charts/crossplane/crds/gcp/cache/v1alpha1/cloudmemorystoreinstance.yaml
@@ -52,6 +52,10 @@ spec:
                 Compute Engine network to which the instance is connected. If left
                 unspecified, the default network will be used.
               type: string
+            claimRef:
+              type: object
+            classRef:
+              type: object
             locationId:
               description: LocationID specifies the zone where the instance will be
                 provisioned. If not provided, the service will choose a zone for the
@@ -62,6 +66,10 @@ spec:
               description: MemorySizeGB specifies the Redis memory size in GiB.
               format: int64
               type: integer
+            providerRef:
+              type: object
+            reclaimPolicy:
+              type: string
             redisConfigs:
               description: 'RedisConfigs specifies Redis configuration parameters,
                 according to http://redis.io/topics/config. Currently, the only supported
@@ -94,7 +102,10 @@ spec:
               - BASIC
               - STANDARD_HA
               type: string
+            writeConnectionSecretToRef:
+              type: object
           required:
+          - providerRef
           - region
           - tier
           - memorySizeGb

--- a/cluster/charts/crossplane/crds/gcp/compute/v1alpha1/gkecluster.yaml
+++ b/cluster/charts/crossplane/crds/gcp/compute/v1alpha1/gkecluster.yaml
@@ -59,6 +59,10 @@ spec:
               type: array
             async:
               type: boolean
+            claimRef:
+              type: object
+            classRef:
+              type: object
             clusterSecondaryRangeName:
               type: string
             clusterVersion:
@@ -138,6 +142,10 @@ spec:
               type: string
             preemtible:
               type: boolean
+            providerRef:
+              type: object
+            reclaimPolicy:
+              type: string
             scopes:
               items:
                 type: string
@@ -154,8 +162,12 @@ spec:
               type: array
             username:
               type: string
+            writeConnectionSecretToRef:
+              type: object
             zone:
               type: string
+          required:
+          - providerRef
           type: object
         status:
           properties:

--- a/cluster/charts/crossplane/crds/gcp/database/v1alpha1/cloudsqlinstance.yaml
+++ b/cluster/charts/crossplane/crds/gcp/database/v1alpha1/cloudsqlinstance.yaml
@@ -44,9 +44,17 @@ spec:
           type: object
         spec:
           properties:
+            claimRef:
+              type: object
+            classRef:
+              type: object
             databaseVersion:
               description: The database engine (MySQL or PostgreSQL) and its specific
                 version to use, e.g., MYSQL_5_7 or POSTGRES_9_6.
+              type: string
+            providerRef:
+              type: object
+            reclaimPolicy:
               type: string
             region:
               type: string
@@ -64,7 +72,10 @@ spec:
                 PostgreSQL, see the examples on https://cloud.google.com/sql/docs/postgres/create-instance?authuser=1#machine-types
                 and the naming rules on https://cloud.google.com/sql/docs/postgres/create-instance#create-2ndgen-curl.
               type: string
+            writeConnectionSecretToRef:
+              type: object
           required:
+          - providerRef
           - region
           - storageType
           - storageGB

--- a/cluster/charts/crossplane/crds/gcp/storage/v1alpha1/bucket.yaml
+++ b/cluster/charts/crossplane/crds/gcp/storage/v1alpha1/bucket.yaml
@@ -50,6 +50,10 @@ spec:
               description: BucketPolicyOnly configures access checks to use only bucket-level
                 IAM policies.
               type: object
+            claimRef:
+              type: object
+            classRef:
+              type: object
             cors:
               description: The bucket's Cross-Origin Resource Sharing (CORS) configuration.
               items:
@@ -198,6 +202,10 @@ spec:
                 is always empty for BucketAttrs returned from the service. See https://cloud.google.com/storage/docs/json_api/v1/buckets/insert
                 for valid values.
               type: string
+            providerRef:
+              type: object
+            reclaimPolicy:
+              type: string
             requesterPays:
               description: RequesterPays reports whether the bucket is a Requester
                 Pays bucket. Clients performing operations on Requester Pays buckets
@@ -262,6 +270,10 @@ spec:
                     result.
                   type: string
               type: object
+            writeConnectionSecretToRef:
+              type: object
+          required:
+          - providerRef
           type: object
         status:
           properties:

--- a/pkg/apis/aws/cache/v1alpha1/replication_group_types.go
+++ b/pkg/apis/aws/cache/v1alpha1/replication_group_types.go
@@ -71,7 +71,7 @@ var LatestSupportedPatchVersion = map[MinorVersion]PatchVersion{
 // Most fields map directly to an AWS ReplicationGroup resource.
 // https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateReplicationGroup.html#API_CreateReplicationGroup_RequestParameters
 type ReplicationGroupSpec struct {
-	corev1alpha1.ResourceSpec
+	corev1alpha1.ResourceSpec `json:",inline"`
 
 	// AtRestEncryptionEnabled enables encryption at rest when set to true.
 	//

--- a/pkg/apis/aws/cache/v1alpha1/replication_group_types_test.go
+++ b/pkg/apis/aws/cache/v1alpha1/replication_group_types_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
+	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,7 +52,14 @@ func TestMain(m *testing.M) {
 
 func TestStorageReplicationGroup(t *testing.T) {
 	key := types.NamespacedName{Name: name, Namespace: namespace}
-	created := &ReplicationGroup{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+	created := &ReplicationGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: ReplicationGroupSpec{
+			ResourceSpec: corev1alpha1.ResourceSpec{
+				ProviderReference: &core.ObjectReference{},
+			},
+		},
+	}
 	g := gomega.NewGomegaWithT(t)
 
 	// Test Create

--- a/pkg/apis/aws/compute/v1alpha1/types.go
+++ b/pkg/apis/aws/compute/v1alpha1/types.go
@@ -64,7 +64,7 @@ var (
 
 // EKSClusterSpec specifies the configuration for an EKS cluster.
 type EKSClusterSpec struct {
-	corev1alpha1.ResourceSpec
+	corev1alpha1.ResourceSpec `json:",inline"`
 
 	// Configuration of this Spec is dependent on the readme as described here
 	// https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html

--- a/pkg/apis/aws/compute/v1alpha1/types_test.go
+++ b/pkg/apis/aws/compute/v1alpha1/types_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -74,7 +75,8 @@ func TestEKSCluster(t *testing.T) {
 				ClusterControlPlaneSecurityGroup: "sg-cluster-sec-group",
 			},
 			ResourceSpec: corev1alpha1.ResourceSpec{
-				ReclaimPolicy: corev1alpha1.ReclaimRetain,
+				ProviderReference: &core.ObjectReference{},
+				ReclaimPolicy:     corev1alpha1.ReclaimRetain,
 			},
 		},
 	}

--- a/pkg/apis/aws/database/v1alpha1/rdsinstance_types.go
+++ b/pkg/apis/aws/database/v1alpha1/rdsinstance_types.go
@@ -34,7 +34,7 @@ const (
 
 // RDSInstanceSpec defines the desired state of RDSInstance
 type RDSInstanceSpec struct {
-	corev1alpha1.ResourceSpec
+	corev1alpha1.ResourceSpec `json:",inline"`
 
 	MasterUsername string `json:"masterUsername"`
 	Engine         string `json:"engine"`

--- a/pkg/apis/aws/database/v1alpha1/rdsinstance_types_test.go
+++ b/pkg/apis/aws/database/v1alpha1/rdsinstance_types_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	"golang.org/x/net/context"
+	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,7 +53,14 @@ func TestStorage(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	key := types.NamespacedName{Name: name, Namespace: namespace}
-	created := &RDSInstance{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+	created := &RDSInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: RDSInstanceSpec{
+			ResourceSpec: corev1alpha1.ResourceSpec{
+				ProviderReference: &core.ObjectReference{},
+			},
+		},
+	}
 
 	// Test Create
 	fetched := &RDSInstance{}

--- a/pkg/apis/aws/storage/v1alpha1/bucket_types.go
+++ b/pkg/apis/aws/storage/v1alpha1/bucket_types.go
@@ -33,7 +33,7 @@ import (
 
 // S3BucketSpec defines the desired state of S3Bucket
 type S3BucketSpec struct {
-	corev1alpha1.ResourceSpec
+	corev1alpha1.ResourceSpec `json:",inline"`
 
 	// NameFormat to format bucket name passing it a object UID
 	// If not provided, defaults to "%s", i.e. UID value

--- a/pkg/apis/aws/storage/v1alpha1/bucket_types_test.go
+++ b/pkg/apis/aws/storage/v1alpha1/bucket_types_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	"golang.org/x/net/context"
+	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -63,6 +64,9 @@ func TestStorageS3Bucket(t *testing.T) {
 			NameFormat:      "test-bucket-name-%s",
 			Region:          "us-west-1",
 			LocalPermission: &perm,
+			ResourceSpec: corev1alpha1.ResourceSpec{
+				ProviderReference: &core.ObjectReference{},
+			},
 		},
 	}
 	g := gomega.NewGomegaWithT(t)

--- a/pkg/apis/azure/cache/v1alpha1/redis_types.go
+++ b/pkg/apis/azure/cache/v1alpha1/redis_types.go
@@ -64,7 +64,7 @@ const (
 // Most fields map directly to an Azure Redis resource.
 // https://docs.microsoft.com/en-us/rest/api/redis/redis/get#redisresource
 type RedisSpec struct {
-	corev1alpha1.ResourceSpec
+	corev1alpha1.ResourceSpec `json:",inline"`
 
 	// ResourceGroupName in which to create this resource.
 	ResourceGroupName string `json:"resourceGroupName"`

--- a/pkg/apis/azure/cache/v1alpha1/redis_types_test.go
+++ b/pkg/apis/azure/cache/v1alpha1/redis_types_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
+	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,7 +54,12 @@ func TestStorageRedis(t *testing.T) {
 	key := types.NamespacedName{Name: name, Namespace: namespace}
 	created := &Redis{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Spec:       RedisSpec{SKU: SKUSpec{Name: SKUNameBasic, Family: SKUFamilyC, Capacity: 0}},
+		Spec: RedisSpec{
+			SKU: SKUSpec{Name: SKUNameBasic, Family: SKUFamilyC, Capacity: 0},
+			ResourceSpec: corev1alpha1.ResourceSpec{
+				ProviderReference: &core.ObjectReference{},
+			},
+		},
 	}
 	g := gomega.NewGomegaWithT(t)
 

--- a/pkg/apis/azure/compute/v1alpha1/types.go
+++ b/pkg/apis/azure/compute/v1alpha1/types.go
@@ -37,7 +37,7 @@ const (
 
 // AKSClusterSpec is the spec for AKS cluster resources
 type AKSClusterSpec struct {
-	corev1alpha1.ResourceSpec
+	corev1alpha1.ResourceSpec `json:",inline"`
 
 	// ResourceGroupName is the name of the resource group that the cluster will be created in
 	ResourceGroupName string `json:"resourceGroupName"` //--resource-group

--- a/pkg/apis/azure/compute/v1alpha1/types_test.go
+++ b/pkg/apis/azure/compute/v1alpha1/types_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/gomega"
+	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,6 +62,9 @@ func TestAKSCluster(t *testing.T) {
 			Location:          "West US",
 			DNSNamePrefix:     "conductor-aks",
 			DisableRBAC:       true,
+			ResourceSpec: corev1alpha1.ResourceSpec{
+				ProviderReference: &core.ObjectReference{},
+			},
 		},
 	}
 	g := NewGomegaWithT(t)

--- a/pkg/apis/azure/database/v1alpha1/sql_types.go
+++ b/pkg/apis/azure/database/v1alpha1/sql_types.go
@@ -226,7 +226,7 @@ type PostgresqlServerList struct {
 
 // SQLServerSpec defines the desired state of SQLServer
 type SQLServerSpec struct {
-	corev1alpha1.ResourceSpec
+	corev1alpha1.ResourceSpec `json:",inline"`
 
 	ResourceGroupName string             `json:"resourceGroupName"`
 	Location          string             `json:"location"`

--- a/pkg/apis/azure/database/v1alpha1/sql_types_test.go
+++ b/pkg/apis/azure/database/v1alpha1/sql_types_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
+	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -56,7 +57,14 @@ func TestMain(m *testing.M) {
 
 func TestStorageMysqlServer(t *testing.T) {
 	key := types.NamespacedName{Name: name, Namespace: namespace}
-	created := &MysqlServer{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+	created := &MysqlServer{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: SQLServerSpec{
+			ResourceSpec: corev1alpha1.ResourceSpec{
+				ProviderReference: &core.ObjectReference{},
+			},
+		},
+	}
 	g := gomega.NewGomegaWithT(t)
 
 	// Test Create
@@ -81,7 +89,14 @@ func TestStorageMysqlServer(t *testing.T) {
 
 func TestStoragePostgresqlServer(t *testing.T) {
 	key := types.NamespacedName{Name: name, Namespace: namespace}
-	created := &PostgresqlServer{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+	created := &PostgresqlServer{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: SQLServerSpec{
+			ResourceSpec: corev1alpha1.ResourceSpec{
+				ProviderReference: &core.ObjectReference{},
+			},
+		},
+	}
 	g := gomega.NewGomegaWithT(t)
 
 	// Test Create

--- a/pkg/apis/azure/storage/v1alpha1/types.go
+++ b/pkg/apis/azure/storage/v1alpha1/types.go
@@ -27,7 +27,7 @@ import (
 
 // AccountSpec is the schema for Account object
 type AccountSpec struct {
-	corev1alpha1.ResourceSpec
+	corev1alpha1.ResourceSpec `json:",inline"`
 
 	// ResourceGroupName azure group name
 	ResourceGroupName string `json:"resourceGroupName"`

--- a/pkg/apis/azure/storage/v1alpha1/types_test.go
+++ b/pkg/apis/azure/storage/v1alpha1/types_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
+	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,6 +61,9 @@ func TestAzureStorageAccount(t *testing.T) {
 			ResourceGroupName:  "test-group",
 			StorageAccountName: "test-name",
 			StorageAccountSpec: &StorageAccountSpec{},
+			ResourceSpec: v1alpha1.ResourceSpec{
+				ProviderReference: &core.ObjectReference{},
+			},
 		},
 	}
 	g := gomega.NewGomegaWithT(t)

--- a/pkg/apis/azure/v1alpha1/types.go
+++ b/pkg/apis/azure/v1alpha1/types.go
@@ -55,7 +55,7 @@ type ProviderList struct {
 // ResourceGroupSpec defines the desired state of Resource Group
 type ResourceGroupSpec struct {
 	// Important: Run "make generate" to regenerate code after modifying this file
-	corev1alpha1.ResourceSpec
+	corev1alpha1.ResourceSpec `json:",inline"`
 
 	// Name of the resource group
 	Name string `json:"name,omitempty"`

--- a/pkg/apis/gcp/cache/v1alpha1/cloudmemorystore_instance_types.go
+++ b/pkg/apis/gcp/cache/v1alpha1/cloudmemorystore_instance_types.go
@@ -48,7 +48,7 @@ var (
 // Most fields map directly to a GCP Instance resource.
 // https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Instance
 type CloudMemorystoreInstanceSpec struct {
-	corev1alpha1.ResourceSpec
+	corev1alpha1.ResourceSpec `json:",inline"`
 
 	// Region in which to create this CloudMemorystore cluster.
 	Region string `json:"region"`

--- a/pkg/apis/gcp/cache/v1alpha1/cloudmemorystore_instance_types_test.go
+++ b/pkg/apis/gcp/cache/v1alpha1/cloudmemorystore_instance_types_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
+	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,7 +54,12 @@ func TestStorageCloudMemorystoreInstance(t *testing.T) {
 	key := types.NamespacedName{Name: name, Namespace: namespace}
 	created := &CloudMemorystoreInstance{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Spec:       CloudMemorystoreInstanceSpec{Tier: TierBasic},
+		Spec: CloudMemorystoreInstanceSpec{
+			Tier: TierBasic,
+			ResourceSpec: corev1alpha1.ResourceSpec{
+				ProviderReference: &core.ObjectReference{},
+			},
+		},
 	}
 	g := gomega.NewGomegaWithT(t)
 

--- a/pkg/apis/gcp/compute/v1alpha1/types.go
+++ b/pkg/apis/gcp/compute/v1alpha1/types.go
@@ -40,7 +40,7 @@ const (
 
 // GKEClusterSpec specifies the configuration of a GKE cluster.
 type GKEClusterSpec struct {
-	corev1alpha1.ResourceSpec
+	corev1alpha1.ResourceSpec `json:",inline"`
 
 	Addons                    []string          `json:"addons,omitempty"`
 	Async                     bool              `json:"async,omitempty"`

--- a/pkg/apis/gcp/compute/v1alpha1/types_test.go
+++ b/pkg/apis/gcp/compute/v1alpha1/types_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
+	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,6 +59,9 @@ func TestGKECluster(t *testing.T) {
 			NumNodes:       int64(1),
 			Zone:           "us-central1-a",
 			MachineType:    "n1-standard-1",
+			ResourceSpec: v1alpha1.ResourceSpec{
+				ProviderReference: &core.ObjectReference{},
+			},
 		},
 	}
 	g := NewGomegaWithT(t)

--- a/pkg/apis/gcp/database/v1alpha1/cloudsql_instance_types.go
+++ b/pkg/apis/gcp/database/v1alpha1/cloudsql_instance_types.go
@@ -47,7 +47,7 @@ const (
 
 // CloudsqlInstanceSpec defines the desired state of CloudsqlInstance
 type CloudsqlInstanceSpec struct {
-	corev1alpha1.ResourceSpec
+	corev1alpha1.ResourceSpec `json:",inline"`
 
 	Region      string `json:"region"`
 	StorageType string `json:"storageType"`

--- a/pkg/apis/gcp/database/v1alpha1/cloudsql_instance_types_test.go
+++ b/pkg/apis/gcp/database/v1alpha1/cloudsql_instance_types_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
+	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,7 +52,14 @@ func TestMain(m *testing.M) {
 
 func TestStorageCloudsqlInstance(t *testing.T) {
 	key := types.NamespacedName{Name: name, Namespace: namespace}
-	created := &CloudsqlInstance{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+	created := &CloudsqlInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: CloudsqlInstanceSpec{
+			ResourceSpec: corev1alpha1.ResourceSpec{
+				ProviderReference: &core.ObjectReference{},
+			},
+		},
+	}
 	g := gomega.NewGomegaWithT(t)
 
 	// Test Create

--- a/pkg/apis/gcp/storage/v1alpha1/types.go
+++ b/pkg/apis/gcp/storage/v1alpha1/types.go
@@ -761,7 +761,7 @@ func NewBucketOutputAttrs(attrs *storage.BucketAttrs) BucketOutputAttrs {
 
 // BucketSpec defines the desired state of Bucket
 type BucketSpec struct {
-	corev1alpha1.ResourceSpec
+	corev1alpha1.ResourceSpec `json:",inline"`
 
 	BucketSpecAttrs `json:",inline"`
 

--- a/pkg/apis/gcp/storage/v1alpha1/types_test.go
+++ b/pkg/apis/gcp/storage/v1alpha1/types_test.go
@@ -62,6 +62,9 @@ func TestStorageGCPBucket(t *testing.T) {
 				Location:     "US",
 				StorageClass: "STANDARD",
 			},
+			ResourceSpec: corev1alpha1.ResourceSpec{
+				ProviderReference: &corev1.ObjectReference{},
+			},
 		},
 	}
 	g := gomega.NewGomegaWithT(t)


### PR DESCRIPTION
I was able to repro the issue. The "root" cause is (as it appears) missing `json` tag on `ResourceSpec` field.
```go
type CloudsqlInstanceSpec struct {
	corev1alpha1.ResourceSpec
```
vs.
```go
type CloudsqlInstanceSpec struct {
	corev1alpha1.ResourceSpec `json:",inline"`
```
If `json` tag is omitted the entire `ResourceSpec` appears to be treated as "optional" fields, hence by the extension all the `ResourceSpec` fields, include the required ones.

Using:
```yaml
apiVersion: database.gcp.crossplane.io/v1alpha1
kind: CloudsqlInstance
metadata:
  name: mysql-demo
  labels:
    foo: bar
spec:
  authorizedNetworks:
    - 0.0.0.0/0
  databaseVersion: MYSQL_5_7
  labels:
    owner: illya
  nameFormat: mysql-demo-%s
#  providerRef:
#    namespace: crossplane-system
#    name: demo-gcp
  region: us-west2
  storageType: PD_SSD
  storageGB: 10
  tier: db-n1-standard-1
  writeConnectionSecretToRef:
    name: mysql-demo
  reclaimPolicy: Delete
```

With `json` tag:
```
⋊> ~/g/s/g/c/crossplane on cloudsql-update ⨯ k apply -f config/gcp/cloudsql-resource.yaml                                                                                                                                                                        09:35:04
The CloudsqlInstance "mysql-demo" is invalid: []: Invalid value: map[string]interface {}{"apiVersion":"database.gcp.crossplane.io/v1alpha1", "kind":"CloudsqlInstance", "metadata":map[string]interface {}{"annotations":map[string]interface {}{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"database.gcp.crossplane.io/v1alpha1\",\"kind\":\"CloudsqlInstance\",\"metadata\":{\"annotations\":{},\"labels\":{\"foo\":\"bar\"},\"name\":\"mysql-demo\",\"namespace\":\"crossplane-system\"},\"spec\":{\"authorizedNetworks\":[\"0.0.0.0/0\"],\"databaseVersion\":\"MYSQL_5_7\",\"labels\":{\"owner\":\"illya\"},\"nameFormat\":\"mysql-demo-%s\",\"reclaimPolicy\":\"Delete\",\"region\":\"us-west2\",\"storageGB\":10,\"storageType\":\"PD_SSD\",\"tier\":\"db-n1-standard-1\",\"writeConnectionSecretToRef\":{\"name\":\"mysql-demo\"}}}\n"}, "creationTimestamp":"2019-07-01T16:35:08Z", "generation":1, "labels":map[string]interface {}{"foo":"bar"}, "name":"mysql-demo", "namespace":"crossplane-system", "uid":"40971e76-9a44-41b8-89d3-ba9ef11d4252"}, "spec":map[string]interface {}{"authorizedNetworks":[]interface {}{"0.0.0.0/0"}, "databaseVersion":"MYSQL_5_7", "labels":map[string]interface {}{"owner":"illya"}, "nameFormat":"mysql-demo-%s", "reclaimPolicy":"Delete", "region":"us-west2", "storageGB":10, "storageType":"PD_SSD", "tier":"db-n1-standard-1", "writeConnectionSecretToRef":map[string]interface {}{"name":"mysql-demo"}}}: validation failure list:
spec.providerRef in body is required
```

Without `json` tag:
```
⋊> ~/g/s/g/c/crossplane on cloudsql-update ◦ k apply -f config/gcp/cloudsql-resource.yaml                                                                                                                                                                        09:35:33
cloudsqlinstance.database.gcp.crossplane.io/mysql-demo created
```

Related to: #558

I have:
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml