### PR TITLE
Default resource classes

### DIFF
--- a/design/one-pager-default-resource-class.md
+++ b/design/one-pager-default-resource-class.md
@@ -63,13 +63,13 @@ kind: ResourceClass
 metadata:
   name: cloud-postgresql
   namespace: crossplane-system
+  labels:
+    postgresqlinstance.storage.crossplane.io/default: "true"
 parameters:
   class: db.t2.small
   masterUsername: masteruser
   securityGroups: "sg-ab1cdefg,sg-05adsfkaj1ksdjak"
   size: "20"
-defaultForClaimKinds:
-- postgresqlinstance.database.crossplane.io
 provisioner: rdsinstance.database.aws.crossplane.io/v1alpha1
 providerRef:
   name: aws-provider

--- a/pkg/controller/defaultclass/bucket.go
+++ b/pkg/controller/defaultclass/bucket.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2019 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultclass
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	storagev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/storage/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/resource"
+)
+
+// AddBucket adds a default class controller that reconciles claims
+// of kind Bucket to a resource class that declares it as the Bucket
+// default
+func AddBucket(mgr manager.Manager) error {
+	r := resource.NewDefaultClassReconciler(mgr,
+		resource.ClaimKind(storagev1alpha1.BucketGroupVersionKind),
+	)
+
+	name := strings.ToLower(fmt.Sprintf("%s.%s", storagev1alpha1.BucketKind, controllerBaseName))
+	c, err := controller.New(name, mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return errors.Wrap(err, "cannot create default controller")
+	}
+
+	return errors.Wrapf(c.Watch(
+		&source.Kind{Type: &storagev1alpha1.Bucket{}},
+		&handler.EnqueueRequestForObject{},
+		resource.NewPredicates(resource.NoClassReference()),
+		resource.NewPredicates(resource.NoManagedResourceReference()),
+	), "cannot watch for %s", storagev1alpha1.BucketGroupVersionKind)
+}

--- a/pkg/controller/defaultclass/defaultclass.go
+++ b/pkg/controller/defaultclass/defaultclass.go
@@ -14,26 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package defaultclass
 
 import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
 
-	"github.com/crossplaneio/crossplane/pkg/controller/aws"
-	"github.com/crossplaneio/crossplane/pkg/controller/azure"
-	"github.com/crossplaneio/crossplane/pkg/controller/defaultclass"
-	"github.com/crossplaneio/crossplane/pkg/controller/gcp"
-	"github.com/crossplaneio/crossplane/pkg/controller/workload"
+const (
+	controllerBaseName = "defaultclass.crossplane.io"
 )
 
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
 	AddToManagerFuncs = append(AddToManagerFuncs,
-		aws.AddToManager,
-		azure.AddToManager,
-		gcp.AddToManager,
-		workload.AddToManager,
-		defaultclass.AddToManager,
+		AddBucket,
+		AddMySQLInstance,
+		AddPostgreSQLInstance,
+		AddRedisCluster,
+		AddKubernetesCluster,
 	)
 }
 

--- a/pkg/controller/defaultclass/kubernetescluster.go
+++ b/pkg/controller/defaultclass/kubernetescluster.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2019 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultclass
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	computev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/compute/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/resource"
+)
+
+// AddKubernetesCluster adds a default class controller that reconciles claims
+// of kind KubernetesCluster to a resource class that declares it as the KubernetesCluster
+// default
+func AddKubernetesCluster(mgr manager.Manager) error {
+	r := resource.NewDefaultClassReconciler(mgr,
+		resource.ClaimKind(computev1alpha1.KubernetesClusterGroupVersionKind),
+	)
+
+	name := strings.ToLower(fmt.Sprintf("%s.%s", computev1alpha1.KubernetesClusterKind, controllerBaseName))
+	c, err := controller.New(name, mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return errors.Wrap(err, "cannot create default controller")
+	}
+
+	return errors.Wrapf(c.Watch(
+		&source.Kind{Type: &computev1alpha1.KubernetesCluster{}},
+		&handler.EnqueueRequestForObject{},
+		resource.NewPredicates(resource.NoClassReference()),
+		resource.NewPredicates(resource.NoManagedResourceReference()),
+	), "cannot watch for %s", computev1alpha1.KubernetesClusterGroupVersionKind)
+}

--- a/pkg/controller/defaultclass/mysqlinstance.go
+++ b/pkg/controller/defaultclass/mysqlinstance.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2019 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultclass
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	databasev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/database/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/resource"
+)
+
+// AddMySQLInstance adds a default class controller that reconciles claims
+// of kind MySQLInstance to a resource class that declares it as the MySQLInstance
+// default
+func AddMySQLInstance(mgr manager.Manager) error {
+	r := resource.NewDefaultClassReconciler(mgr,
+		resource.ClaimKind(databasev1alpha1.MySQLInstanceGroupVersionKind),
+	)
+
+	name := strings.ToLower(fmt.Sprintf("%s.%s", databasev1alpha1.MySQLInstanceKind, controllerBaseName))
+	c, err := controller.New(name, mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return errors.Wrap(err, "cannot create default controller")
+	}
+
+	return errors.Wrapf(c.Watch(
+		&source.Kind{Type: &databasev1alpha1.MySQLInstance{}},
+		&handler.EnqueueRequestForObject{},
+		resource.NewPredicates(resource.NoClassReference()),
+		resource.NewPredicates(resource.NoManagedResourceReference()),
+	), "cannot watch for %s", databasev1alpha1.MySQLInstanceGroupVersionKind)
+}

--- a/pkg/controller/defaultclass/postgresqlinstance.go
+++ b/pkg/controller/defaultclass/postgresqlinstance.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2019 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultclass
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	databasev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/database/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/resource"
+)
+
+// AddPostgreSQLInstance adds a default class controller that reconciles claims
+// of kind PostgreSQLInstance to a resource class that declares it as the PostgreSQLInstance
+// default
+func AddPostgreSQLInstance(mgr manager.Manager) error {
+	r := resource.NewDefaultClassReconciler(mgr,
+		resource.ClaimKind(databasev1alpha1.PostgreSQLInstanceGroupVersionKind),
+	)
+
+	name := strings.ToLower(fmt.Sprintf("%s.%s", databasev1alpha1.PostgreSQLInstanceKind, controllerBaseName))
+	c, err := controller.New(name, mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return errors.Wrap(err, "cannot create default controller")
+	}
+
+	return errors.Wrapf(c.Watch(
+		&source.Kind{Type: &databasev1alpha1.PostgreSQLInstance{}},
+		&handler.EnqueueRequestForObject{},
+		resource.NewPredicates(resource.NoClassReference()),
+		resource.NewPredicates(resource.NoManagedResourceReference()),
+	), "cannot watch for %s", databasev1alpha1.PostgreSQLInstanceGroupVersionKind)
+}

--- a/pkg/controller/defaultclass/rediscluster.go
+++ b/pkg/controller/defaultclass/rediscluster.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2019 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultclass
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	cachev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/cache/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/resource"
+)
+
+// AddRedisCluster adds a default class controller that reconciles claims
+// of kind RedisCluster to a resource class that declares it as the RedisCluster
+// default
+func AddRedisCluster(mgr manager.Manager) error {
+	r := resource.NewDefaultClassReconciler(mgr,
+		resource.ClaimKind(cachev1alpha1.RedisClusterGroupVersionKind),
+	)
+
+	name := strings.ToLower(fmt.Sprintf("%s.%s", cachev1alpha1.RedisClusterKind, controllerBaseName))
+	c, err := controller.New(name, mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return errors.Wrap(err, "cannot create default controller")
+	}
+
+	return errors.Wrapf(c.Watch(
+		&source.Kind{Type: &cachev1alpha1.RedisCluster{}},
+		&handler.EnqueueRequestForObject{},
+		resource.NewPredicates(resource.NoClassReference()),
+		resource.NewPredicates(resource.NoManagedResourceReference()),
+	), "cannot watch for %s", cachev1alpha1.RedisClusterGroupVersionKind)
+}

--- a/pkg/resource/defaultclass.go
+++ b/pkg/resource/defaultclass.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2018 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/logging"
+	"github.com/crossplaneio/crossplane/pkg/meta"
+)
+
+const (
+	controllerNameDefaultClass = "defaultclass.crossplane.io"
+	defaultClassWait           = 1 * time.Minute
+)
+
+var logDefaultClass = logging.Logger.WithName("controller").WithValues("controller", controllerNameDefaultClass)
+
+// Error strings
+const (
+	errFailedList             = "unable to list default resource classes"
+	errNoDefaultClass         = "unable to locate a default resource class for claim kind"
+	errMultipleDefaultClasses = "multiple default classes defined for claim kind"
+)
+
+// DefaultClassReconciler reconciles resource claims to the
+// default resource class for their given kind. Predicates
+// ensure that only claims with no resource class reference
+// are reconciled.
+type DefaultClassReconciler struct {
+	client   client.Client
+	newClaim func() Claim
+	options  *client.ListOptions
+}
+
+// NewDefaultClassReconciler creates a new DefaultReconciler for the claim kind
+func NewDefaultClassReconciler(m manager.Manager, of ClaimKind) *DefaultClassReconciler {
+	nc := func() Claim { return MustCreateObject(schema.GroupVersionKind(of), m.GetScheme()).(Claim) }
+
+	// Panic early if we've been asked to reconcile a claim that has
+	// not been registered with our controller manager's scheme.
+	_ = nc()
+
+	gk := strings.ToLower(schema.GroupVersionKind(of).GroupKind().String())
+
+	// Create list options query that will be used to search
+	// for resource class that is default for claim kind.
+	options := &client.ListOptions{}
+	if err := options.SetLabelSelector(gk + "/default=" + "true"); err != nil {
+		// Panic if unable to set label selector or else panic will occur
+		// when returned reconciler is invoked.
+		panic(err)
+	}
+
+	return &DefaultClassReconciler{
+		client:   m.GetClient(),
+		newClaim: nc,
+		options:  options,
+	}
+}
+
+// Reconcile reconciles a claim to the default class reference for its kind
+func (r *DefaultClassReconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) {
+	logDefaultClass.V(logging.Debug).Info("Reconciling", "request", req)
+
+	ctx, cancel := context.WithTimeout(context.Background(), reconcileTimeout)
+	defer cancel()
+
+	claim := r.newClaim()
+	if err := r.client.Get(ctx, req.NamespacedName, claim); err != nil {
+		// There's no need to requeue if we no longer exist. Otherwise we'll be
+		// requeued implicitly because we return an error.
+		return reconcile.Result{}, errors.Wrap(IgnoreNotFound(err), errGetClaim)
+	}
+
+	// Get resource classes with claim kind as default
+	classes := &corev1alpha1.ResourceClassList{}
+	if err := r.client.List(ctx, r.options, classes); err != nil {
+		// If this is the first time we encounter no defaults we'll be
+		// requeued implicitly due to the status update. If not, we don't
+		// care to requeue because list parameters will not change.
+		claim.SetConditions(corev1alpha1.ReconcileError(errors.New(errFailedList)))
+		return reconcile.Result{}, errors.Wrap(IgnoreNotFound(r.client.Status().Update(ctx, claim)), errUpdateClaimStatus)
+	}
+
+	// Check to see if no defaults defined for claim kind.
+	if len(classes.Items) == 0 {
+		// If this is the first time we encounter no defaults we'll be
+		// requeued implicitly due to the status update. If not, we will requeue
+		// after a time to see if a default class has been created.
+		claim.SetConditions(corev1alpha1.ReconcileError(errors.New(errNoDefaultClass)))
+		return reconcile.Result{RequeueAfter: defaultClassWait}, errors.Wrap(IgnoreNotFound(r.client.Status().Update(ctx, claim)), errUpdateClaimStatus)
+	}
+
+	// Check to see if multiple defaults defined for claim kind.
+	if len(classes.Items) > 1 {
+		// If this is the first time we encounter multiple defaults we'll be
+		// requeued implicitly due to the status update. If not, we will requeue
+		// after a time to see if only one default class exists.
+		claim.SetConditions(corev1alpha1.ReconcileError(errors.New(errMultipleDefaultClasses)))
+		return reconcile.Result{RequeueAfter: defaultClassWait}, errors.Wrap(IgnoreNotFound(r.client.Status().Update(ctx, claim)), errUpdateClaimStatus)
+	}
+
+	// Set class reference on claim to default resource class
+	claim.SetClassReference(meta.ReferenceTo(&classes.Items[0], corev1alpha1.ResourceClassGroupVersionKind))
+
+	// Do not requeue, claim controller will see update and claim
+	// with class reference set will pass predicates.
+	return reconcile.Result{Requeue: false}, errors.Wrap(IgnoreNotFound(r.client.Update(ctx, claim)), errUpdateClaimStatus)
+}

--- a/pkg/resource/defaultclass_test.go
+++ b/pkg/resource/defaultclass_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2019 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
+	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/meta"
+	"github.com/crossplaneio/crossplane/pkg/test"
+)
+
+var _ reconcile.Reconciler = &DefaultClassReconciler{}
+
+func TestDefaultClassReconcile(t *testing.T) {
+	type args struct {
+		m  manager.Manager
+		of ClaimKind
+	}
+
+	type want struct {
+		result reconcile.Result
+		err    error
+	}
+
+	errBoom := errors.New("boom")
+	errUnexpected := errors.New("unexpected object type")
+	class := corev1alpha1.ResourceClass{}
+	class.SetName("default-class")
+	class.SetNamespace("default-namespace")
+
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"GetClaimError": {
+			args: args{
+				m: &MockManager{
+					c: &test.MockClient{MockGet: test.NewMockGetFn(errBoom)},
+					s: MockSchemeWith(&MockClaim{}),
+				},
+				of: ClaimKind(MockGVK(&MockClaim{})),
+			},
+			want: want{err: errors.Wrap(errBoom, errGetClaim)},
+		},
+		"ListDefaultClassesError": {
+			args: args{
+				m: &MockManager{
+					c: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o runtime.Object) error {
+							switch o := o.(type) {
+							case *MockClaim:
+								*o = MockClaim{}
+								return nil
+							default:
+								return errUnexpected
+							}
+						}),
+						MockList: test.NewMockListFn(errBoom),
+						MockStatusUpdate: test.NewMockStatusUpdateFn(nil, func(got runtime.Object) error {
+							want := &MockClaim{}
+							want.SetConditions(v1alpha1.ReconcileError(errors.New(errFailedList)))
+							if diff := cmp.Diff(want, got, test.EquateConditions()); diff != "" {
+								t.Errorf("-want, +got:\n%s", diff)
+							}
+							return nil
+						}),
+					},
+					s: MockSchemeWith(&MockClaim{}),
+				},
+				of: ClaimKind(MockGVK(&MockClaim{})),
+			},
+			want: want{result: reconcile.Result{}},
+		},
+		"NoDefaultClass": {
+			args: args{
+				m: &MockManager{
+					c: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o runtime.Object) error {
+							switch o := o.(type) {
+							case *MockClaim:
+								*o = MockClaim{}
+								return nil
+							default:
+								return errUnexpected
+							}
+						}),
+						MockList: test.NewMockListFn(nil, func(o runtime.Object) error {
+							switch o := o.(type) {
+							case *corev1alpha1.ResourceClassList:
+								cm := &corev1alpha1.ResourceClassList{}
+								cm.Items = []corev1alpha1.ResourceClass{}
+								*o = *cm
+								return nil
+							default:
+								return errUnexpected
+							}
+						}),
+						MockStatusUpdate: test.NewMockStatusUpdateFn(nil, func(got runtime.Object) error {
+							want := &MockClaim{}
+							want.SetConditions(v1alpha1.ReconcileError(errors.New(errNoDefaultClass)))
+							if diff := cmp.Diff(want, got, test.EquateConditions()); diff != "" {
+								t.Errorf("-want, +got:\n%s", diff)
+							}
+							return nil
+						}),
+					},
+					s: MockSchemeWith(&MockClaim{}),
+				},
+				of: ClaimKind(MockGVK(&MockClaim{})),
+			},
+			want: want{result: reconcile.Result{RequeueAfter: defaultClassWait}},
+		},
+		"MultipleDefaultClasses": {
+			args: args{
+				m: &MockManager{
+					c: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o runtime.Object) error {
+							switch o := o.(type) {
+							case *MockClaim:
+								*o = MockClaim{}
+								return nil
+							default:
+								return errUnexpected
+							}
+						}),
+						MockList: test.NewMockListFn(nil, func(o runtime.Object) error {
+							switch o := o.(type) {
+							case *corev1alpha1.ResourceClassList:
+								cm := &corev1alpha1.ResourceClassList{}
+								cm.Items = []corev1alpha1.ResourceClass{
+									{},
+									{},
+								}
+								*o = *cm
+								return nil
+							default:
+								return errUnexpected
+							}
+						}),
+						MockStatusUpdate: test.NewMockStatusUpdateFn(nil, func(got runtime.Object) error {
+							want := &MockClaim{}
+							want.SetConditions(v1alpha1.ReconcileError(errors.New(errMultipleDefaultClasses)))
+							if diff := cmp.Diff(want, got, test.EquateConditions()); diff != "" {
+								t.Errorf("-want, +got:\n%s", diff)
+							}
+							return nil
+						}),
+					},
+					s: MockSchemeWith(&MockClaim{}),
+				},
+				of: ClaimKind(MockGVK(&MockClaim{})),
+			},
+			want: want{result: reconcile.Result{RequeueAfter: defaultClassWait}},
+		},
+		"Successful": {
+			args: args{
+				m: &MockManager{
+					c: &test.MockClient{
+						MockGet: test.NewMockGetFn(nil, func(o runtime.Object) error {
+							switch o := o.(type) {
+							case *MockClaim:
+								*o = MockClaim{}
+								return nil
+							default:
+								return errUnexpected
+							}
+						}),
+						MockList: test.NewMockListFn(nil, func(o runtime.Object) error {
+							switch o := o.(type) {
+							case *corev1alpha1.ResourceClassList:
+								cm := &corev1alpha1.ResourceClassList{}
+								cm.Items = []corev1alpha1.ResourceClass{
+									class,
+								}
+								*o = *cm
+								return nil
+							default:
+								return errUnexpected
+							}
+						}),
+						MockUpdate: test.NewMockUpdateFn(nil, func(got runtime.Object) error {
+							want := &MockClaim{}
+							want.SetClassReference(meta.ReferenceTo(class.GetObjectMeta(), corev1alpha1.ResourceClassGroupVersionKind))
+							if diff := cmp.Diff(want, got, test.EquateConditions()); diff != "" {
+								t.Errorf("-want, +got:\n%s", diff)
+							}
+							return nil
+						}),
+					},
+					s: MockSchemeWith(&MockClaim{}),
+				},
+				of: ClaimKind(MockGVK(&MockClaim{})),
+			},
+			want: want{result: reconcile.Result{Requeue: false}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := NewDefaultClassReconciler(tc.args.m, tc.args.of)
+			got, err := r.Reconcile(reconcile.Request{})
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("r.Reconcile(...): -want error, +got error:\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.want.result, got); diff != "" {
+				t.Errorf("r.Reconcile(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/resource/interfaces_test.go
+++ b/pkg/resource/interfaces_test.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
 )
@@ -62,6 +63,11 @@ type MockReclaimer struct{ Policy v1alpha1.ReclaimPolicy }
 func (m *MockReclaimer) SetReclaimPolicy(p v1alpha1.ReclaimPolicy) { m.Policy = p }
 func (m *MockReclaimer) GetReclaimPolicy() v1alpha1.ReclaimPolicy  { return m.Policy }
 
+type MockObjectKind struct{ GVK schema.GroupVersionKind }
+
+func (m *MockObjectKind) SetGroupVersionKind(kind schema.GroupVersionKind) { m.GVK = kind }
+func (m *MockObjectKind) GroupVersionKind() schema.GroupVersionKind        { return m.GVK }
+
 var _ Claim = &MockClaim{}
 
 type MockClaim struct {
@@ -73,6 +79,10 @@ type MockClaim struct {
 	MockConnectionSecretWriterTo
 	MockConditionSetter
 	MockBindable
+}
+
+func (m *MockClaim) GetObjectKind() schema.ObjectKind {
+	return &MockObjectKind{GVK: schema.GroupVersionKind{Group: "mock.crossplane.io", Version: "v1alpha", Kind: "claim"}}
 }
 
 var _ Managed = &MockManaged{}

--- a/pkg/resource/predicates.go
+++ b/pkg/resource/predicates.go
@@ -72,3 +72,25 @@ func HasProvisioner(c client.Client, cr ClassReferencer, provisioner string) boo
 
 	return strings.EqualFold(cs.Provisioner, provisioner)
 }
+
+// NoClassReference accepts ResourceClaims that do not reference a specific ResourceClass
+func NoClassReference() PredicateFn {
+	return func(obj runtime.Object) bool {
+		cr, ok := obj.(ClassReferencer)
+		if !ok {
+			return false
+		}
+		return cr.GetClassReference() == nil
+	}
+}
+
+// NoManagedResourceReference accepts ResourceClaims that do not reference a specific Managed Resource
+func NoManagedResourceReference() PredicateFn {
+	return func(obj runtime.Object) bool {
+		cr, ok := obj.(ManagedResourceReferencer)
+		if !ok {
+			return false
+		}
+		return cr.GetResourceReference() == nil
+	}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
This is my first pass at implementing default resource classes. It follows the pattern of @negz claim reconciler, allowing for each concrete resource type to create a default controller that shares a common reconciler implementation. Notable points related to the current status of this PR:

* Default resource classes are being denoted by labels on the resource class rather than fields (which is how the design is currently described in the [one-pager](https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-default-resource-class.md)). This is due to the fact that CRD's are currently only able to utilize `metadata.name` and `metadata.namespace` as field selectors in Kubernetes. See the example class and claim used below.
* The current implementation continue attempting to reconcile the claim if no default resource class exists. This is an open question as we may want attempted reconciliation to continue in case a default resource class is defined after the fact, or we may just want the claim to fail. If we do continue attempting to reconcile, we likely want a longer delay implemented.
* This PR only implements default resource classes for AWS S3 buckets. It can be easily implemented for other types after review because of the common reconciler pattern.

Steps to Demo Functionality:

1. Follow the steps to add [AWS Cloud Provider](https://crossplane.io/docs/v0.2/cloud-providers/aws/aws-provider.html)
2. Create AWS Provider [object](https://github.com/crossplaneio/crossplane/blob/master/cluster/examples/providers/aws.yaml): `kubectl create -f aws.yml`
3. Create default resource class: `kubectl create -f aws-default-bucket-class.yml`

*aws-default-bucket-class.yml*
```yml
apiVersion: core.crossplane.io/v1alpha1
kind: ResourceClass
metadata:
  name: s3bucket
  namespace: crossplane-system
  labels:
    bucket.storage.crossplane.io/default: "true"
parameters:
  versioning: "false"
  predefinedACL: private
  region: us-east-1
provisioner: s3bucket.storage.aws.crossplane.io/v1alpha1
providerRef:
  name: example
  namespace: crossplane-system
reclaimPolicy: Delete
```
4. Create resource claim without class reference: `kubectl create -f aws-bucket-claim.yml`

*aws-bucket-claim.yml*
```yml
apiVersion: storage.crossplane.io/v1alpha1
kind: Bucket
metadata:
  name: s3bucket
spec:
  name: crossplane-example-%s
  predefinedACL: Private
  localPermission: ReadWrite
  writeConnectionSecretToRef:
    name: s3bucket
```

Fixes #151 

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml