### PR TITLE
[WIP] Change Azure example to KubernetesApp

### DIFF
--- a/cluster/examples/workloads/kubernetes/wordpress-azure/app.yaml
+++ b/cluster/examples/workloads/kubernetes/wordpress-azure/app.yaml
@@ -1,0 +1,103 @@
+apiVersion: storage.crossplane.io/v1alpha1
+kind: MySQLInstance
+metadata:
+  name: sql
+  namespace: complex
+spec:
+  classRef:
+    name: standard-mysql
+    namespace: crossplane-system
+  engineVersion: "5.7"
+---
+apiVersion: workload.crossplane.io/v1alpha1
+kind: KubernetesApplication
+metadata:
+  name: wordpress-demo
+  namespace: complex
+  labels:
+    app: wordpress-demo
+spec:
+  resourceSelector:
+    matchLabels:
+      app: wordpress-demo
+  clusterSelector:
+    matchLabels:
+      app: wordpress-demo
+  resourceTemplates:
+  - metadata:
+      name: wordpress-demo-namespace
+      labels:
+        app: wordpress-demo
+    spec:
+      template:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: wordpress
+          labels:
+            app: wordpress
+  - metadata:
+      name: wordpress-demo-deployment
+      labels:
+        app: wordpress-demo
+    spec:
+      secrets:
+      - name: sql  # Resource claim secret name is derived from claim name
+      template:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          namespace: wordpress
+          name: wordpress
+          labels:
+            app: wordpress
+        spec:
+          selector:
+            matchLabels:
+              app: wordpress
+          template:
+            metadata:
+              labels:
+                app: wordpress
+            spec:
+              containers:
+                - name: wordpress
+                  image: wordpress:4.6.1-apache
+                  env:
+                    - name: WORDPRESS_DB_HOST
+                      valueFrom:
+                        secretKeyRef:
+                          name: wordpress-demo-deployment-sql
+                          key: endpoint
+                    - name: WORDPRESS_DB_USER
+                      valueFrom:
+                        secretKeyRef:
+                          name: wordpress-demo-deployment-sql
+                          key: username
+                    - name: WORDPRESS_DB_PASSWORD
+                      valueFrom:
+                        secretKeyRef:
+                          name: wordpress-demo-deployment-sql
+                          key: password
+                  ports:
+                    - containerPort: 80
+                      name: wordpress
+  - metadata:
+      name: wordpress-demo-service
+      labels:
+        app: wordpress-demo
+    spec:
+      template:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          namespace: wordpress
+          name: wordpress
+          labels:
+            app: wordpress
+        spec:
+          ports:
+            - port: 80
+          selector:
+            app: wordpress
+          type: LoadBalancer

--- a/cluster/examples/workloads/kubernetes/wordpress-azure/cluster.yaml
+++ b/cluster/examples/workloads/kubernetes/wordpress-azure/cluster.yaml
@@ -1,0 +1,20 @@
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: complex
+---
+apiVersion: compute.crossplane.io/v1alpha1
+kind: KubernetesCluster
+metadata:
+  name: wordpress-demo-cluster
+  namespace: complex
+  labels:
+    app: wordpress-demo
+spec:
+  writeConnectionSecretToRef:
+    name: wordpress-demo-cluster
+  classRef:
+    name: standard-cluster
+    namespace: crossplane-system
+---

--- a/cluster/examples/workloads/kubernetes/wordpress-azure/resource-class.yaml
+++ b/cluster/examples/workloads/kubernetes/wordpress-azure/resource-class.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: core.crossplane.io/v1alpha1
+kind: ResourceClass
+metadata:
+  name: standard-cluster
+  namespace: crossplane-system
+parameters:
+  resourceGroupName: group-westus-1
+  location: West US 2
+  version: "1.12.8"
+  nodeCount: "1"
+  nodeVMSize: Standard_B2s
+  dnsNamePrefix: crossplane-aks
+  disableRBAC: "false"
+provisioner: akscluster.compute.azure.crossplane.io/v1alpha1
+providerRef:
+  name: example
+  namespace: crossplane-system
+reclaimPolicy: Delete
+---
+# ResourceClass that defines the blueprint for how a "standard" Azure MySQL Server
+# should be dynamically provisioned
+apiVersion: core.crossplane.io/v1alpha1
+kind: ResourceClass
+metadata:
+  name: standard-mysql
+  namespace: crossplane-system
+parameters:
+  adminLoginName: myadmin
+  resourceGroupName: group-westus-1
+  location: West US
+  sslEnforced: "false"
+  tier: Basic
+  vcores: "1"
+  family: Gen5
+  storageGB: "25"
+  backupRetentionDays: "7"
+  geoRedundantBackup: "false"
+provisioner: mysqlserver.database.azure.crossplane.io/v1alpha1
+providerRef:
+  name: example
+  namespace: crossplane-system
+reclaimPolicy: Delete

--- a/docs/cloud-providers/azure/azure-provider.md
+++ b/docs/cloud-providers/azure/azure-provider.md
@@ -10,6 +10,7 @@ The general steps we will take are summarized below:
 ## Preparing your Microsoft Azure Account
 
 In order to manage resources in Azure, you must provide credentials for a Azure service principal that Crossplane can use to authenticate.
+
 This assumes that you have already [set up the Azure CLI client](https://docs.microsoft.com/en-us/cli/azure/authenticate-azure-cli?view=azure-cli-latest) with your credentials.
 
 Create a JSON file that contains all the information needed to connect and authenticate to Azure:
@@ -23,6 +24,12 @@ Take note of the `clientID` value from the JSON file that we just created, and s
 
 ```console
 export AZURE_CLIENT_ID=<clientId value from json file>
+```
+
+This can be automated with `jq`.
+
+```console
+export AZURE_CLIENT_ID=$(jq -r .clientId < crossplane-azure-provider-key.json)
 ```
 
 Now add the required permissions to the service principal that will allow it to manage the necessary resources in Azure:

--- a/docs/cloud-providers/azure/azure-provider.md
+++ b/docs/cloud-providers/azure/azure-provider.md
@@ -32,7 +32,7 @@ This can be automated with `jq`.
 export AZURE_CLIENT_ID=$(jq -r .clientId < crossplane-azure-provider-key.json)
 ```
 
-Now add the required permissions to the service principal that will allow it to manage the necessary resources in Azure:
+Now add the required permissions to the service principal that will allow it to manage the necessary resources with the Azure Active Directory Graph:
 
 ```console
 # add required Azure Active Directory permissions

--- a/docs/workloads/azure/wordpress-azure.md
+++ b/docs/workloads/azure/wordpress-azure.md
@@ -11,31 +11,29 @@ In this environment, the following components will be dynamically provisioned an
 
 Before starting this guide, you should have already [configured your Azure account](../../cloud-providers/azure/azure-provider.md) for usage by Crossplane.
 
-- You should have a `crossplane-azure-provider-key.json` file on your local filesystem, preferably at the root of where you cloned the [Crossplane repo](https://github.com/crossplaneio/crossplane).
-- You should have a azure resource group with name `group-westus-1`. If not, change the value of `resourceGroupName` to an existing resource group in `cluster/examples/workloads/wordpress/azure/provider.yaml`
-
-
+You should have a `crossplane-azure-provider-key.json` file on your local filesystem, preferably at the root of where you cloned the [Crossplane repo](https://github.com/crossplaneio/crossplane).
+You should have a azure resource group with name `group-westus-1`. If not, change the value of `resourceGroupName` to an existing resource group in `cluster/examples/workloads/wordpress/azure/provider.yaml`
 
 ## Administrator Tasks
 
 This section covers the tasks performed by the cluster or cloud administrator, which includes:
 
-- Import Azure provider credentials
-- Define Resource classes for cluster and database resources
-- Create a target Kubernetes cluster (using dynamic provisioning with the cluster resource class)
+* Import Azure provider credentials
+* Define Resource classes for cluster and database resources
+* Create a target Kubernetes cluster (using dynamic provisioning with the cluster resource class)
 
 **Note**: all artifacts created by the administrator are stored/hosted in the `crossplane-system` namespace, which has
 restricted access, i.e. `Application Owner(s)` should not have access to them.
 
 For the next steps, make sure your `kubectl` context points to the cluster where `Crossplane` was deployed.
 
-- Create the Azure provider object in your cluster:
+* Create the Azure provider object in your cluster:
 
   ```console
   sed "s/BASE64ENCODED_AZURE_PROVIDER_CREDS/`base64 crossplane-azure-provider-key.json | tr -d '\n'`/g;" cluster/examples/workloads/wordpress/azure/provider.yaml | kubectl create -f -
   ```
 
-- Next, create the AKS cluster that will eventually be the target cluster for your Workload deployment:
+* Next, create the AKS cluster that will eventually be the target cluster for your Workload deployment:
 
   ```console
   kubectl create -f cluster/examples/workloads/wordpress/azure/cluster.yaml
@@ -56,20 +54,20 @@ For the next steps, make sure your `kubectl` context points to the cluster where
 
 To recap the operations that we just performed as the administrator:
 
-- Defined a `Provider` with Microsoft Azure service principal credentials
-- Defined `ResourceClasses` for `KubernetesCluster` and `MySQLInstance`
-- Provisioned (dynamically) an AKS Cluster using the `ResourceClass`
+* Defined a `Provider` with Microsoft Azure service principal credentials
+* Defined `ResourceClasses` for `KubernetesCluster` and `MySQLInstance`
+* Provisioned (dynamically) an AKS Cluster using the `ResourceClass`
 
 ## Application Developer Tasks
 
 This section covers the tasks performed by the application developer, which includes:
 
-- Define Workload in terms of Resources and Payload (Deployment/Service) which will be deployed into the target Kubernetes Cluster
-- Define the dependency resource requirements, in this case a `MySQL` database
+* Define Workload in terms of Resources and Payload (Deployment/Service) which will be deployed into the target Kubernetes Cluster
+* Define the dependency resource requirements, in this case a `MySQL` database
 
 Let's begin deploying the workload as the application developer:
 
-- Now that the target AKS cluster is ready, we can deploy the Workload that contains all the Wordpress resources, including the SQL database, with the following single command:
+* Now that the target AKS cluster is ready, we can deploy the Workload that contains all the Wordpress resources, including the SQL database, with the following single command:
 
   ```console
   kubectl create -f cluster/examples/workloads/wordpress-azure/workload.yaml
@@ -89,7 +87,7 @@ Let's begin deploying the workload as the application developer:
   mysql-58425bda-f72d-11e8-bcbe-0800278fedb1   Ready     standard-mysql   5.7
   ```
 
-- Now we can watch the Wordpress pod come online and a public IP address will get assigned to it:
+* Now we can watch the Wordpress pod come online and a public IP address will get assigned to it:
 
   ```console
   kubectl get workload -o custom-columns=NAME:.metadata.name,CLUSTER:.spec.targetCluster.name,NAMESPACE:.spec.targetNamespace,DEPLOYMENT:.spec.targetDeployment.metadata.name,SERVICE-EXTERNAL-IP:.status.service.loadBalancer.ingress[0].ip
@@ -102,13 +100,13 @@ Let's begin deploying the workload as the application developer:
   test-workload   demo-cluster   demo        wordpress    104.43.240.15
   ```
 
-- Once Wordpress is running and has a public IP address through its service, we can get the URL with the following command:
+* Once Wordpress is running and has a public IP address through its service, we can get the URL with the following command:
 
   ```console
   echo "http://$(kubectl get workload test-workload -o jsonpath='{.status.service.loadBalancer.ingress[0].ip}')"
   ```
 
-- Paste that URL into your browser and you should see Wordpress running and ready for you to walk through the setup experience.
+* Paste that URL into your browser and you should see Wordpress running and ready for you to walk through the setup experience.
 
 ## Clean-up
 


### PR DESCRIPTION
This PR updates the Azure provider documentation for use throughout Crossplane examples and revises the Azure Compute Workload (Wordpress on AKS) documentation to use the newer KubernetesApplication resource classes to perform the same action.

Fixes https://github.com/crossplaneio/crossplane/issues/538

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml