### PR TITLE
project setup: add submodule management to Makefile

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,20 +21,14 @@ The following tools are need on the host:
 
 ## Build
 
-First ensure that you have the build submodule synced and updated:
-
-```
-make init
-```
-
-After initial setup, `make submodules` can be used to update the
-submodule.
-
-You can then build the Crossplane binaries and all container images for the host platform by simply running the command below. Building in parallel with the `-j` option is recommended.
+You can build the Crossplane binaries and all container images for the host platform by simply running the command below. Building in parallel with the `-j` option is recommended.
 
 ```
 make -j4
 ```
+
+The first time `make` is run, the build submodule will be synced and
+updated. After initial setup, it can be updated by running `make submodules`.
 
 Run `make help` for more options.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,8 +24,11 @@ The following tools are need on the host:
 First ensure that you have the build submodule synced and updated:
 
 ```
-git submodule sync && git submodule update --init --recursive
+make init
 ```
+
+After initial setup, `make submodules` can be used to update the
+submodule.
 
 You can then build the Crossplane binaries and all container images for the host platform by simply running the command below. Building in parallel with the `-j` option is recommended.
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ S3_BUCKET ?= crossplane.releases
 # ====================================================================================
 # Setup Go
 
+# Set a sane default so that the nprocs calculation below is less noisy on the initial
+# loading of this file
+NPROCS ?= 1
+
 # each of our test suites starts a kube-apiserver and running many test suites in
 # parallel can lead to high CPU utilization. by default we reduce the parallelism
 # to half the number of CPU cores.

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,17 @@ PROJECT_NAME := crossplane
 PROJECT_REPO := github.com/crossplaneio/$(PROJECT_NAME)
 
 PLATFORMS ?= linux_amd64 linux_arm64
-include build/makelib/common.mk
+# -include will silently skip missing files, which allows us
+# to load those files with a target in the Makefile. If only
+# "include" was used, the make command would fail and refuse
+# to run a target until the include commands succeeded.
+-include build/makelib/common.mk
 
 # ====================================================================================
 # Setup Output
 
 S3_BUCKET ?= crossplane.releases
-include build/makelib/output.mk
+-include build/makelib/output.mk
 
 # ====================================================================================
 # Setup Go
@@ -23,7 +27,7 @@ GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/crossplane
 GO_LDFLAGS += -X $(GO_PROJECT)/pkg/version.Version=$(VERSION)
-include build/makelib/golang.mk
+-include build/makelib/golang.mk
 
 # ====================================================================================
 # Setup Helm
@@ -32,19 +36,19 @@ HELM_BASE_URL = https://charts.crossplane.io
 HELM_S3_BUCKET = crossplane.charts
 HELM_CHARTS = crossplane
 HELM_CHART_LINT_ARGS_crossplane = --set nameOverride='',imagePullSecrets=''
-include build/makelib/helm.mk
+-include build/makelib/helm.mk
 
 # ====================================================================================
 # Setup Kubebuilder
 
-include build/makelib/kubebuilder.mk
+-include build/makelib/kubebuilder.mk
 
 # ====================================================================================
 # Setup Images
 
 DOCKER_REGISTRY = crossplane
 IMAGES = crossplane
-include build/makelib/image.mk
+-include build/makelib/image.mk
 
 # ====================================================================================
 # Setup Docs
@@ -52,12 +56,20 @@ include build/makelib/image.mk
 SOURCE_DOCS_DIR = docs
 DEST_DOCS_DIR = docs
 DOCS_GIT_REPO = https://$(GIT_API_TOKEN)@github.com/crossplaneio/crossplaneio.github.io.git
-include build/makelib/docs.mk
+-include build/makelib/docs.mk
 
 # ====================================================================================
 # Targets
 
 # run `make help` to see the targets and options
+
+# We want submodules to be set up the first time `make` is run.
+# We manage the build/ folder and its Makefiles as a submodule.
+# The first time `make` is run, the includes of build/*.mk files will
+# all fail, and this target will be run. The next time, the default as defined
+# by the includes will be run instead.
+init: submodules
+	@echo Initial setup complete. If make was run without arguments, please run it again now.
 
 go.test.unit: $(KUBEBUILDER)
 
@@ -77,4 +89,9 @@ cobertura:
 # Ensure a PR is ready for review.
 reviewable: vendor generate manifests lint
 
-.PHONY: manifests cobertura reviewable
+# Update the submodules, such as the common build scripts.
+submodules:
+	@git submodule sync
+	@git submodule update --init --recursive
+
+.PHONY: manifests cobertura reviewable init submodules

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,9 @@ DOCS_GIT_REPO = https://$(GIT_API_TOKEN)@github.com/crossplaneio/crossplaneio.gi
 # The first time `make` is run, the includes of build/*.mk files will
 # all fail, and this target will be run. The next time, the default as defined
 # by the includes will be run instead.
-init: submodules
-	@echo Initial setup complete. If make was run without arguments, please run it again now.
+fallthrough: submodules
+	@echo Initial setup complete. Running make again . . .
+	@make
 
 go.test.unit: $(KUBEBUILDER)
 
@@ -94,4 +95,4 @@ submodules:
 	@git submodule sync
 	@git submodule update --init --recursive
 
-.PHONY: manifests cobertura reviewable init submodules
+.PHONY: manifests cobertura reviewable submodules fallthrough


### PR DESCRIPTION
### Description of your changes

Before crossplane can be built locally, the git submodules must be initialized.
Later, a developer may want to update the submodules again by hand. Originally,
this was explained in the documentation, and the command could be copied and
pasted into the terminal. It's more convenient to have a recipe in the Makefile
to do this instead.

Probably the most controversial part of the change will be the change to silently ignore failures of the `include` directives of the Makefile, so I would appreciate any thoughts on that part! I was also not sure what naming people would prefer for the Make targets, so I made some best guesses, but am interested in hearing thoughts on this too.

This isn't related to any existing issue, but came up in the crossplane Slack and the improvement was supported by @negz .

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml