### PR TITLE
make it possible to debug the core process of the extension manager

### DIFF
--- a/pkg/controller/stacks/request/stackrequest.go
+++ b/pkg/controller/stacks/request/stackrequest.go
@@ -54,9 +54,6 @@ const (
 	requeueAfterOnSuccess = 10 * time.Second
 
 	packageContentsVolumeName = "package-contents"
-
-	// PodImageNameEnvVar is the env variable for setting the image name used for the unpack/install process when debugging the main process
-	PodImageNameEnvVar = "UNPACK_IMAGE"
 )
 
 var (
@@ -64,6 +61,9 @@ var (
 	resultRequeue    = reconcile.Result{Requeue: true}
 	requeueOnSuccess = reconcile.Result{RequeueAfter: requeueAfterOnSuccess}
 	jobBackoff       = int32(0)
+
+	// PodImageNameEnvVar is the env variable for setting the image name used for the unpack/install process when debugging the main process
+	PodImageNameEnvVar = "UNPACK_IMAGE"
 )
 
 // Reconciler reconciles a Instance object
@@ -522,7 +522,7 @@ func (d *executorInfoDiscoverer) discoverExecutorInfo(ctx context.Context) (*exe
 			return nil, err
 		}
 
-		image, err := util.GetContainerImage(pod, "")
+		image, err = util.GetContainerImage(pod, "")
 		if err != nil {
 			log.Error(err, "failed to get image for pod", "image", image)
 			return nil, err

--- a/pkg/controller/stacks/request/stackrequest_test.go
+++ b/pkg/controller/stacks/request/stackrequest_test.go
@@ -834,7 +834,7 @@ func TestDiscoverExecutorInfo(t *testing.T) {
 
 			os.Setenv(util.PodNameEnvVar, "podName")
 			os.Setenv(util.PodNamespaceEnvVar, "podNamespace")
-			os.Setenv(PodImageNameEnvVar, tt.imageName)
+			os.Setenv(podImageNameEnvVar, tt.imageName)
 
 			got, gotErr := tt.d.discoverExecutorInfo(ctx)
 


### PR DESCRIPTION
The extension manager detects the name of the running pod and namespace
so that it can fetch itself as a running Kubernetes object and then pluck the container
image value out.  The container `image` is then reused in unpack `Job` objects the extension manager creates.

This PR bypasses the image lookup in the presence of an environment
variable.  This allows the parent process to be debugged because the
normal POD identification fails when running in a debugger.  There is
no pod when debugging, there is just a process connecting to the
Kubernetes API.

This PR does not assist in debugging the unpacker command of the
extension manager, only the extension manager core process.

In VSCode, the Debug Configuration looks like this:

```json
        {
            "name": "Launch Extension Manager in Default K8s Context",
            "type": "go",
            "request": "launch",
            "mode": "auto",
            "program": "${workspaceFolder}/cmd/crossplane/main.go",
            "env": {
                "KUBECONFIG": "${env:HOME}/.kube/config",
                "UNPACK_IMAGE": "crossplane/crossplane:master"
            },
            "args": ["extension", "manage", "--debug", "--sync=60s"]
        }
```

I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yam