### PR TITLE
Fix kind registration chain

### DIFF
--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -28,6 +28,7 @@ import (
 	"github.com/crossplaneio/crossplane/pkg/apis/cache"
 	"github.com/crossplaneio/crossplane/pkg/apis/compute"
 	"github.com/crossplaneio/crossplane/pkg/apis/core"
+	"github.com/crossplaneio/crossplane/pkg/apis/database"
 	"github.com/crossplaneio/crossplane/pkg/apis/extensions"
 	"github.com/crossplaneio/crossplane/pkg/apis/gcp"
 	"github.com/crossplaneio/crossplane/pkg/apis/storage"
@@ -44,6 +45,7 @@ func init() {
 		core.AddToScheme,
 		extensions.AddToScheme,
 		gcp.AddToScheme,
+		database.AddToScheme,
 		storage.AddToScheme,
 		workload.AddToScheme,
 	)

--- a/pkg/apis/database/database.go
+++ b/pkg/apis/database/database.go
@@ -20,7 +20,7 @@ package database
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/crossplaneio/crossplane/pkg/apis/storage/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/apis/database/v1alpha1"
 )
 
 func init() {

--- a/pkg/apis/database/database_test.go
+++ b/pkg/apis/database/database_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/crossplaneio/crossplane/pkg/apis/storage/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/apis/database/v1alpha1"
 )
 
 func TestAddToScheme(t *testing.T) {


### PR DESCRIPTION
### Description of your changes

Adds MySQLInstance kind back again to the type registration
chain with new GVK that is introduced in #570. This fix need is
needed, otherwise Crossplane pod goes into CrashLoopBackoff.
See comments in #570

Signed-off-by: Muvaffak Onus <onus.muvaffak@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml