### PR TITLE
fix kubectl output field "READY" for extension and extensionrequests

### DIFF
--- a/cluster/charts/crossplane/crds/extensions/v1alpha1/extension.yaml
+++ b/cluster/charts/crossplane/crds/extensions/v1alpha1/extension.yaml
@@ -7,8 +7,8 @@ metadata:
   name: extensions.extensions.crossplane.io
 spec:
   additionalPrinterColumns:
-  - JSONPath: .status.Conditions[?(@.Status=="True")].Type
-    name: STATUS
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: READY
     type: string
   - JSONPath: .spec.version
     name: VERSION

--- a/cluster/charts/crossplane/crds/extensions/v1alpha1/extensionrequest.yaml
+++ b/cluster/charts/crossplane/crds/extensions/v1alpha1/extensionrequest.yaml
@@ -7,8 +7,8 @@ metadata:
   name: extensionrequests.extensions.crossplane.io
 spec:
   additionalPrinterColumns:
-  - JSONPath: .status.Conditions[?(@.Status=="True")].Type
-    name: STATUS
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: READY
     type: string
   - JSONPath: .spec.source
     name: SOURCE

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -32,7 +32,7 @@ import (
 
 // ExtensionRequest is the CRD type for a request to add an extension to Crossplane.
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.Conditions[?(@.Status=="True")].Type"
+// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=="Ready")].status"
 // +kubebuilder:printcolumn:name="SOURCE",type="string",JSONPath=".spec.source"
 // +kubebuilder:printcolumn:name="PACKAGE",type="string",JSONPath=".spec.package"
 // +kubebuilder:printcolumn:name="CRD",type="string",JSONPath=".spec.crd"
@@ -83,7 +83,7 @@ type ExtensionRequestStatus struct {
 
 // Extension is the CRD type for a request to add an extension to Crossplane.
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.Conditions[?(@.Status=="True")].Type"
+// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=="Ready")].status"
 // +kubebuilder:printcolumn:name="VERSION",type="string",JSONPath=".spec.version"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 type Extension struct {


### PR DESCRIPTION
This PR fixes the kubectl output field `STATUS` for `extension` and `extensionrequest` objects.

The field is renamed to `READY` to match the appropriate conditioned status.

```
$ kubectl get extension,extensionrequest
NAME                                                                              READY   VERSION   AGE
extension.extensions.crossplane.io/sample-extension-metacontroller-from-package   True    0.0.1     20m

NAME                                                                                     READY   SOURCE   PACKAGE                                     CRD   AGE
extensionrequest.extensions.crossplane.io/sample-extension-metacontroller-from-package   True             displague/sample-extension-metacontroller         20m
```

I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.
