### PR TITLE
Fix misnamed classRef field in the examples

### DIFF
--- a/cluster/examples/workloads/kubernetes/wordpress-aws/app.yaml
+++ b/cluster/examples/workloads/kubernetes/wordpress-aws/app.yaml
@@ -5,7 +5,7 @@ metadata:
   name: sql
   namespace: complex
 spec:
-  classReference:
+  classRef:
     name: standard-mysql
     namespace: crossplane-system
   engineVersion: "5.7"

--- a/cluster/examples/workloads/kubernetes/wordpress-aws/cluster.yaml
+++ b/cluster/examples/workloads/kubernetes/wordpress-aws/cluster.yaml
@@ -12,7 +12,7 @@ metadata:
     provider: aws
     app: wordpress-demo
 spec:
-  classReference:
+  classRef:
     name: standard-cluster
     namespace: crossplane-system
 ---

--- a/design/one-pager-default-resource-class.md
+++ b/design/one-pager-default-resource-class.md
@@ -45,7 +45,7 @@ metadata:
   name: cloud-postgresql-claim
   namespace: demo
 spec:
-  classReference:
+  classRef:
     name: cloud-postgresql
     namespace: crossplane-system
   engineVersion: "9.6"

--- a/design/one-pager-resource-reclaim-policy.md
+++ b/design/one-pager-resource-reclaim-policy.md
@@ -71,7 +71,7 @@ metadata:
   name: my-bucket
   namespace: default
 spec:
-  classReference:
+  classRef:
     name: standard-aws-bucket
     namespace: crossplane-system
   name: my-bucket-1234

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -51,7 +51,7 @@ metadata:
   name: demo
   namespace: default
 spec:
-  classReference:
+  classRef:
     name: standard-mysql
     namespace: crossplane-system
   engineVersion: "5.7"

--- a/docs/postgresql.md
+++ b/docs/postgresql.md
@@ -77,7 +77,7 @@ Note that the first command gives us the status of the `ResourceClaim` (general 
 and the second command gives the status of the environment specific database resource that Crossplane is provisioning using the `ResourceClass` "blueprint".
 
 ```console
-kubectl -n demo get postgresqlinstance -o custom-columns=NAME:.metadata.name,STATUS:.status.bindingPhase,CLASS:.spec.classReference.name,VERSION:.spec.engineVersion,AGE:.metadata.creationTimestamp
+kubectl -n demo get postgresqlinstance -o custom-columns=NAME:.metadata.name,STATUS:.status.bindingPhase,CLASS:.spec.classRef.name,VERSION:.spec.engineVersion,AGE:.metadata.creationTimestamp
 kubectl -n crossplane-system get ${DATABASE_TYPE} -o custom-columns=NAME:.metadata.name,STATUS:.status.bindingPhase,STATE:.status.state,CLASS:.spec.classRef.name,VERSION:.spec.${versionfield},AGE:.metadata.creationTimestamp
 ```
 
@@ -86,7 +86,7 @@ kubectl -n crossplane-system get ${DATABASE_TYPE} -o custom-columns=NAME:.metada
 Once the dynamic provisioning process has finished creating and preparing the database, the status output will look similar to the following:
 
 ```console
-> kubectl -n demo get postgresqlinstance -o custom-columns=NAME:.metadata.name,STATUS:.status.bindingPhase,CLASS:.spec.classReference.name,VERSION:.spec.engineVersion,AGE:.metadata.creationTimestamp
+> kubectl -n demo get postgresqlinstance -o custom-columns=NAME:.metadata.name,STATUS:.status.bindingPhase,CLASS:.spec.classRef.name,VERSION:.spec.engineVersion,AGE:.metadata.creationTimestamp
 NAME                     STATUS    CLASS              VERSION   AGE
 cloud-postgresql-claim   Bound     cloud-postgresql   9.6       2018-12-23T04:00:11Z
 

--- a/docs/running-resources.md
+++ b/docs/running-resources.md
@@ -28,7 +28,7 @@ kind: MySQLInstance
 metadata:
   name: demo-mysql
 spec:
-  classReference:
+  classRef:
     name: standard-mysql
     namespace: crossplane-system
   engineVersion: "5.7"
@@ -68,7 +68,7 @@ metadata:
   name: demo-cluster
   namespace: crossplane-system
 spec:
-  classReference:
+  classRef:
     name: standard-cluster
     namespace: crossplane-system
 ```


### PR DESCRIPTION
### Description of your changes
In the examples, there is a misnamed field `spec.classReference`.
It should be `spec.classRef` according to the codebase.

See https://github.com/crossplaneio/crossplane/blob/master/pkg/apis/core/v1alpha1/resource.go#L94

I accepted the codebase as authoritative here but if the final decision is to use `classReference`, I can switch it to that everywhere.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml