### PR TITLE
wordpress gcp example: export mysql secret

### DIFF
--- a/cluster/examples/workloads/kubernetes/wordpress-gcp/app.yaml
+++ b/cluster/examples/workloads/kubernetes/wordpress-gcp/app.yaml
@@ -9,6 +9,11 @@ spec:
     name: standard-mysql
     namespace: crossplane-system
   engineVersion: "5.7"
+  # A secret is exported by providing the secret name
+  # to export it under. This is the name of the secret
+  # in the crossplane cluster, and it's scoped to this claim's namespace.
+  writeConnectionSecretToRef:
+    name: sql
 ---
 apiVersion: workload.crossplane.io/v1alpha1
 kind: KubernetesApplication
@@ -43,7 +48,10 @@ spec:
         app: wordpress-demo
     spec:
       secrets:
-      - name: sql  # Resource claim secret name is derived from claim name
+        # This must match the writeConnectionSecretToRef field
+        # on the database claim; it is the name of the secret to
+        # pull from the crossplane cluster, from this Application's namespace.
+      - name: sql
       template:
         apiVersion: apps/v1
         kind: Deployment
@@ -68,6 +76,12 @@ spec:
                     - name: WORDPRESS_DB_HOST
                       valueFrom:
                         secretKeyRef:
+                          # This is the name of the secret to use to consume the secret
+                          # within the managed cluster. The reason it's different from the
+                          # name of the secret above is because within the managed cluster,
+                          # a crossplane-managed secret is written as '{metadata.name}-{secretname}'.
+                          # The metadata name is specified above for this resource, and so is
+                          # the secret name.
                           name: wordpress-demo-deployment-sql
                           key: endpoint
                     - name: WORDPRESS_DB_USER

--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -26,7 +26,7 @@ All of the objects that represent managed resources such as databases, clusters,
 In general, simply getting the `yaml` output of a Crossplane object will give insightful information about its condition:
 
 ```console
-kubetl get <resource-type> -o yaml
+kubectl get <resource-type> -o yaml
 ```
 
 For example, to get complete information about an Azure AKS cluster object, the following command will generate the below sample (truncated) output:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->
### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
In order for the wordpress application to consume the secrets for the
database, the secrets need to be exported. Previously, they were not
being exported at all.

This change ensures that the wordpress gcp example works through the step of spinning up the wordpress deployment, but the example is still affected by #428 , and this changeset does not fix that.


### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml