### PR TITLE
revise design-doc for stacks

### DIFF
--- a/design/design-doc-stacks.md
+++ b/design/design-doc-stacks.md
@@ -27,15 +27,16 @@ Step 2 can be repeated many times to provision multiple "instances" of the types
 
 ## Terminology
 
-* **Custom Resource Definition** - A standard Kubernetes CRD, which defines a new type of resource that can be managed declaratively. This serves as the unit of management in Crossplane.  Composed of a spec and a status section, supports API level versioning (e.g., v1alpha1)
-  * Atomic / External CRDs - usually represent external resources, cannot be broken down any further (leaves)
+* **Custom Resource Definition** - A standard Kubernetes CRD, which defines a new type of resource that can be managed declaratively. This serves as the unit of management in Crossplane.  The CRD is composed of spec and status sections and supports API level versioning (e.g., v1alpha1)
+  * Atomic / External CRDs - usually represent external resources, and cannot be broken down any further (leaves)
   * Composite CRDs - these are also resources that capture parent/child relationships. They have a selector that can help query/find children resources.
-  * Claim CRDs - these are abstract resources that bind to concrete resources.
+  * Claim CRDs - these are abstract resources that bind to managed resources.
 * **Custom Controllers** -- this is the implementation of one or more CRDs. Can be implemented in different ways, such as golang code (controller-runtime), templates, functions/hooks, templates, a new DSL, etc. The implementation itself is versioned using semantic versioning (e.g., v1.0.4)
 * **Stack** -- this is the unit of extending Crossplane with new functionality.  It is comprised of the CRDs, Custom Controller, and metadata about the Stack.  A Crossplane cluster can be queried for all installed Stacks as a way of learning what functionality a particular Crossplane supports.
 * **Stack Registry** -- this is a registry for Stacks where they can be published, downloaded, explored, categorized, etc. The registry understands a Stack’s custom controller and its CRDs and indexes by both -- you could lookup a custom controller by the CRD name and vice versa.
-* **Stack Package** -- this is a package format for Stacks that contains the custom controller definition, metadata, CRDs, etc. It is essentially just a tarball (container image) that bundles all these resources together into a single unit. This is the packaging format that is supported by the registry and installer.
-* **Stack Manager (SM)** -- this is the component that is responsible for installing a Stack’s custom controllers and resources in Crossplane. It can download packages, resolve dependencies, install resources and execute controllers.  This component is also responsible for managing the complete lifecycle of Stacks, including upgrading them as new versions become available.
+* **Stack Package** -- this is a package format for Stacks that contains the Stack definition, metadata, icons, CRDs, and other Stack specific files.  See [Stack Package Format](#stack-package-format).
+* **Stack Manager (SM)** -- this is the component that is responsible for installing a Stack’s custom controllers and resources in Crossplane. It can download packages, resolve dependencies, install resources and execute controllers.  This component is also responsible for managing the complete life-cycle of Stacks, including upgrading them as new versions become available.
+* **unpacking** -- the process of extracting the Stack files from a Stack Package.
 
 These concepts comprise the extensibility story for Crossplane.  With them, users will be able to add new supported functionality of all varieties to Crossplane.
 The currently supported functionality, such as PostgreSQL, Redis, etc. can be packaged and published using the concepts described above, so that the initial installation of Crossplane is very sparse.
@@ -62,11 +63,15 @@ This section describes the end to end installation flow implemented by the Stack
     * package name (`gitlab`) OR
     * CRD name (`gitlabcluster.gitlab.com/v1alpha1`)
       * Note: this code path is exactly the same as dependency resolution
-* Performs dependency resolution that determines all packages/Stacks that are required by this Stack and all of its dependent Stacks
-* Pulls all necessary Stack packages from the registry
-* Unpacks them and installs all owned/defined CRDs and transforms the unpackaged content into an `Extension` CRD instance that serves as a record of the install
-* Starts up the custom controller so that it is in the running state
-* Marks the `ExtensionRequest` status as succeeded
+* The SM performs dependency resolution that determines all packages/Stacks that are required by this Stack and all of its dependent Stacks (Not Implemented)
+* The SM pulls all necessary Stack packages from the registry
+* The SM creates an unpack job that sends the artifacts to `stdout` which the SM ingests to install the Stack
+  * Stack metadata (`app.yaml`, `install.yaml`, `rbac.yaml`) is extracted and transformed to create an `Extension` CRD instance that serves as a record of the install
+  * All owned/defined CRDs are installed and annotated with their related metadata (`group.yaml`, `resource.yaml`, and icon file)
+  * RBAC rules necessary for the controller or controller installer are installed (`rbac.yaml`)
+  * Stack installation instructions (`install.yaml`), in the form of Kubernetes YAML state files, are parsed and sent to the Kubernetes API
+* Kubernetes starts up the custom controller so that it is in the running state
+* The SM marks the `ExtensionRequest` status as succeeded
 
 ## `ExtensionRequest` CRD
 
@@ -195,18 +200,21 @@ spec:
 
 ## Stack Package Format
 
-A Stack package is simply the bundle that contains the custom controller definition, metadata, CRDs, etc. for a given Stack.
-It is essentially just a tarball (e.g., a container image) that packages all these resources together into a single unit and is the format that is understood and supported by the Stack registry and Stack manager.
-More details will be provided when a Stack registry project is bootstrapped and launched.
-This section can be thought of as the initial thinking for the format of a Stack package to start generating discussion and iteration.
+A Stack package is the bundle that contains the custom controller definition, CRDs, icons, and other metadata for a given Stack.
+
+The Stack Package Format is essentially just a tarball (e.g., a [container image](https://github.com/opencontainers/image-spec/blob/master/spec.md)).  All of the Stack resources are brought together into this single unit which is understood and supported by the Stack registry and Stack manager.
 
 As previously mentioned, after downloading and unpacking a Stack package, the Stack Manager will not only install its contents into Crossplane, but it will also translate them into an `Extension` record.
 
-Inside of a package, the following filesystem layout is expected:
+More details will be provided when a Stack registry project is bootstrapped and launched.
 
-```
+### Stack Filesystem Layout
+
+Inside of a package, the filesystem layout shown below is expected for the best experience.  This layout will accommodate current and future Stack consuming tools, such as client tools, back-end indexing and cataloging tools, and the Stack Manager itself.
+
+```text
 .registry/
-├── icon.jpg
+├── icon.svg
 ├── app.yaml # Application metadata.
 ├── install.yaml # Optional install metadata.
 ├── rbac.yaml # Optional RBAC permissions.
@@ -214,23 +222,55 @@ Inside of a package, the following filesystem layout is expected:
 └── resources
       └── databases.foocompany.io # Group directory
             ├── group.yaml # Optional Group metadata
-            ├── icon.jpg # Optional Group icon
+            ├── icon.svg # Optional Group icon
             └── mysql # Kind directory by convention
                 ├── v1alpha1
                 │   ├── mysql.v1alpha1.crd.yaml # Required CRD
-                │   ├── icon.jpg # Optional resource icon
+                │   ├── icon.svg # Optional resource icon
                 │   └── resource.yaml # Resource level metadata.
                 └── v1beta1
                     ├── mysql.v1beta1.crd.yaml
                     ├── ui-schema.yaml #  Optional UI Metadata
-                    ├── icon.jpg
+                    ├── icon.svg
                     └── resource.yaml
 ```
 
+In this example, the directory names "databases.foocompany.io", "mysql", "v1alpha1", and "v1alpha2" are for human-readability and should be considered arbitrary.  The group, kind, and version data will be parsed from any leaf level CRD files ignoring the directory names.
+
+### Stack Files
+
 * `app.yaml`: This file is the general metadata and information about the Stack, such as its name, description, version, owners, etc.  This metadata will be saved in the `Extension` record's spec fields.
 * `install.yaml`: This file contains the information for how the custom controller for the Stack should be installed into Crossplane.  Initially, only simple `Deployment` based controllers will be supported, but eventually other types of implementations will be supported as well, e.g., templates, functions/hooks, templates, a new DSL, etc.
-* `resources` directory: This directory contains all the CRDs and optional metadata about them.  These CRDs are the types that the custom controller implements the logic for.  They will be directly installed into Crossplane so that users can create instances of them to start consuming their new Stack functionality.
-* `ui-schema.yaml`: UI metadata that will be transformed and annotated according to the [Stack UI Metadata One Pager](one-pager-stack-ui-metadata.md)
+* `icon.svg`: This file (or `icon.png`, `icon.jpg`, `icon.gif`, or potentially other supported filenames, TBD) will be used in a visual context when listing or describing this stack.  The preferred formats/filenames are `svg`, `png`, `jpg`, `gif` in that order (if multiple files exist).  For bitmap formats, the width to height ratio should be 1:1. Limitations may be placed on the acceptable file dimensions and byte size (TBD).
+* `resources` directory: This directory contains all the CRDs and optional metadata about them.
+  * `group.yaml`: Related Stack resources (CRDs) can be described at a high level within a group directory using this file.
+  * `resource.yaml` and `icon.svg`: Files that describe the resource with descriptions, titles, or images, may be used to inform out-of-cluster or in-cluster Stack managing tools.  This may affect the annotations of the `Extension` record or the Resource CRD (TBD).
+  * `ui-schema.yaml`: UI metadata that will be transformed and annotated according to the [Stack UI Metadata One Pager](one-pager-stack-ui-metadata.md)
+  * `*crd.yaml`: These CRDs are the types that the custom controller implements the logic for.  They will be directly installed into Crossplane so that users can create instances of them to start consuming their new Stack functionality.  Notice that the filenames can vary from `very.descriptive.name.crd.yaml` to `crd.yaml`.
+  Multiple CRDs can reside in the same file.  These CRDs may also be pre-annotated at build time with annotations describing the `resource.yaml`, `icon.svg`, and `ui-schema.yaml` files to avoid bundling additional files and incurring a minor processing penalty at runtime.
+
+Examples of annotations that the Stack manager produces are included in the [Example Package Files](example-package-files) section.  Icon annotations should be provided as [RFC-2397](https://tools.ietf.org/html/rfc2397) Data URIs and there is a strong preference that these URIs use base64 encoding.
+
+The minimum required file tree for a single tool, such as the Stack Manager, could be condensed to the following:
+
+```text
+.registry/
+├── app.yaml
+├── install.yaml
+├── rbac.yaml
+└── resources
+      └── crd.yaml
+```
+
+Strictly speaking, `install.yaml` and `rbac.yaml` are optional, but a Stack bereft of these files would only introduce a data storage CRD with no active controller to act on CRs.  A Stack with no implementation could still be useful as a dependency of another Stack if CRs or the CRD itself can influence the behavior of active Stacks.
+
+## Example Package Files
+
+A concrete examples of this package format can be examined at <https://github.com/crossplaneio/sample-extension>.
+
+A Git repository may choose to include the `.registry` directory with all of the files described above but that may not always be the case.  Stacks are easy to create as build artifacts through a combination of shell scripting, Make, Docker, or any other tool-chain or process that can produce an OCI image.
+
+An example project that processes the artifacts of Kubebuilder 2 to create a Stack is available at <https://github.com/crossplaneio/sample-stack-wordpress>.
 
 ### Example `app.yaml`
 
@@ -260,6 +300,10 @@ owners:
 # Human readable company name.
 company: Upbound
 
+# A single category that best fits this Stack
+# Arbitrary categories may be used but it is expected that a preferred set of categories will emerge among Stack tools
+category: Database
+
 # Keywords that describe this application and help search indexing
 keywords:
 - "samples"
@@ -267,14 +311,167 @@ keywords:
 - "tutorials"
 
 # Links to more information about the application (about page, source code, etc.)
-links:
-- description: Website
-  url: "https://upbound.io"
-- description: Source Code
-  url: "https://github.com/crossplaneio/sample-extension"
+website: "https://crossplane.io"
+source: "https://github.com/crossplaneio/sample-extension"
 
 # License SPDX name: https://spdx.org/licenses/
 license: Apache-2.0
+```
+
+### Example `install.yaml`
+
+The `install.yaml` file is expected to conform to a standard Kubernetes YAML file describing a single `Deployment` object.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crossplane-sample-extension
+  labels:
+    core.crossplane.io/name: "crossplane-sample-extension"
+spec:
+  selector:
+    matchLabels:
+      core.crossplane.io/name: "crossplane-sample-extension"
+  replicas: 1
+  template:
+    metadata:
+      name: sample-extension-controller
+      labels:
+        core.crossplane.io/name: "crossplane-sample-extension"
+    spec:
+      containers:
+      - name: sample-extension-controller
+        image: crossplane/sample-extension:latest
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+```
+
+### Example `group.yaml`
+
+```yaml
+group: databases.foocompany.io
+title: Sample Controller Types
+description: |
+    This is a crd group description
+```
+
+### Example `resource.yaml`
+
+```yaml
+resource: mysql
+title: MySQL
+category: Database
+description: |
+  # MySQL Resource by FooCompany
+
+  This is the Crossplane Stack for FooCompany MySQL
+
+  ## Details
+
+  More markdown.
+```
+
+### Example `rbac.yaml`
+
+```yaml
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - serviceaccounts
+  - events
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - samples.crossplane.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+```
+
+### Example `crd.yaml`
+
+```yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: mytypes.samples.crossplane.io
+spec:
+  group: samples.crossplane.io
+  names:
+    kind: Mytype
+    plural: mytypes
+  scope: Namespaced
+  version: v1alpha1
+```
+
+#### Example `crd.yaml` with Stack annotations
+
+It is the job of the SM or a Stack build tool to process the recommended meta-data files into the final CRD installed in the cluster.  These annotations will assist Stack tools in discovery and identification of resources in cluster that can be managed.
+
+```yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mytypes.samples.crossplane.io
+  labels:
+    controller-tools.k8s.io: "1.0"
+  annotations:
+    stacks.crossplane.io/name: "crossplane-sample-extension"
+    stacks.crossplane.io/resource-group-title: "Title of the Group"
+    stacks.crossplane.io/resource-group-description: |
+        Description of the Group
+    stacks.crossplane.io/resource-category: "Databases"
+    stacks.crossplane.io/resource-title: "Title of the Resource"
+    stacks.crossplane.io/resource-description: |
+        Description of the Resource
+    stacks.crossplane.io/icon-data-uri: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciLz4K
+    stacks.crossplane.io/ui-spec: |
+      uiSpecVersion: 0.3
+      uiSpec:
+      - title: Configuration
+        description: Enter information specific to the configuration you wish to create.
+        items:
+        - name: dbReplicas
+          controlType: singleInput
+          type: integer
+          path: .spec.dbReplicas
+          title: DB Replicas
+          description: The number of DB Replicas
+          default: 1
+          validation:
+          - minimum: 1
+          - maximum: 3
+      ---
+      additionalSpec: example
+      stillYaml: true
+      usesSameSpecConvention: "not necessary"
+spec:
+  group: samples.crossplane.io
+  names:
+    kind: Mytype
+    plural: mytypes
+  scope: Namespaced
+  version: v1alpha1
 ```
 
 ## Dependency Resolution
@@ -290,10 +487,30 @@ The full set of packages and Stacks that a Stack depend on will be downloaded, u
 ## Package Processing
 
 The process of installing a Stack involves downloading its package, extracting the package contents into its relevant CRDs and `Extension` record, and applying them to the Crossplane cluster.
-There are a few different options for this flow, which are described below, but a key aspect of the proposed implementation is to take advantage of the existing machinery in Kubernetes around container image download, verification, and extraction.
-This will be much more efficient and reliable than writing new code within Crossplane to do this work ourselves.
 
-Possible solutions for package processing are listed below, along with their pros and cons.
+See the [Installation Flow](#installation-flow) for a more complete view of the current package processing implementation.
+
+The extension manager uses a "Job initContainer and shared volume" approach which copies the package contents from the package initContainer to a shared volume.  The SM, using command arguments to the Crossplane container, performs processing logic over the shared volume contents. The artifacts of this are sent to `stdout` where the main entry-point of the Crossplane container parses the unpacking container's `stdout`.  The parsed artifacts are then sent to the Kubernetes API for install.
+
+The processing/unpacking logic can easily move to its own image that can be used as a base layer in the future (or a CLI tool).  This approach is not very divergent from the current implementation which divides these functions through the use of image entry-point command arguments.
+
+A key aspect of the current implementation is that it takes advantage of the existing machinery in Kubernetes around container image download, verification, and extraction.
+This is much more efficient and reliable than writing new code within Crossplane to do this work.
+
+### Packaging Considerations
+
+All packages should strive to minimize the amount of YAML they require.  Packages should avoid including any files that are not necessary for the Stack metadata or the controller, when including the controller in the same image.
+
+Some packaging considerations do not need to be enforced by spec and are left to the Stack developer.
+
+* Stack metadata may be bundled with the controller image, but this does not need to be the case nor should it be enforced one way or the other.
+  * There may be benefits to metadata-only Stack images and their small byte sizes.
+  * There is a benefit to requiring less image fetching by the container runtime
+  * There may be benefits to maintaining fewer images (combined Stack metadata + controller image vs separate Stack metadata and controller images)
+
+### Alternate Packaging Designs
+
+Alternative designs for package processing and their related considerations (pros and cons) are listed below.  These ideas or parts of them may surface in future implementations.
 
 * Stack package base image
   * A base image containing the unpacking logic could be defined and all other Stack packages are based on it, e.g., `FROM crossplane-extension`
@@ -304,24 +521,27 @@ Possible solutions for package processing are listed below, along with their pro
   * Package images only contain the package contents, no processing logic is included in the package
   * The SM starts a job pod with an init container for the package image and copies all its contents to a shared volume in the job pod.  The Crossplane package processing logic runs in the main pod container and runs over the shared volume, sending all artifacts to `stdout`.
   * PRO: Package images are significantly smaller since they will only contain yaml files and icons, no binaries or libraries.
+  * PRO: The processing/unpacking logic can easily move to its own image that can be used as a base layer in the future (or a CLI tool), so this approach is not very divergent.
   * CON: The SM needs to understand package content and layout.
 * CLI tool
   * The unpacking logic could be built into a CLI tool that can be run over a package image.
   * PRO: This is the most versatile option as it can be used in contexts outside of a Crossplane cluster.
   * CON: Doesn't integrate very cleanly into the Crossplane mainline scenario with the SM.
 
-**Recommendation:** It is recommended to start with the "Job initContainer and shared volume" approach that copies the package contents from the package initContainer to a shared volume and has a Crossplane container main entry point perform the processing logic over the shared volume contents, sending out the artifacts to `stdout`.
-Stack packages should only have a few KB of yaml files, so it's a significant concern to blow that image size up to many MB right now.
-The processing/unpacking logic can easily move to its own image that can be used as a base layer in the future (or a CLI tool), so this approach is not very divergent.
-It is a good place to start and iterate over as we learn more without investing much effort that cannot be reused.
+Each of these designs offered a good place to start.  Through iteration over time we will learn more, hopefully without investing much effort that cannot be reused.
 
 ## Questions and Open Issues
 
+* Stack Manager security model and isolation [#580](https://github.com/crossplaneio/crossplane/issues/580)
+* Offloading redundant Stack Manager functionality to Stack building tools
 * Dependency resolution design: [#434](https://github.com/crossplaneio/crossplane/issues/434)
-* Updating/Upgrading Extension: [#435](https://github.com/crossplaneio/crossplane/issues/435)
+* Updating/Upgrading Extensions: [#435](https://github.com/crossplaneio/crossplane/issues/435)
 * Document how to build and publish an extension [#503](https://github.com/crossplaneio/crossplane/issues/503)
 * Support installation of extensions from private registries [#505](https://github.com/crossplaneio/crossplane/issues/505)
 * Standardize extension package format and layout [#507](https://github.com/crossplaneio/crossplane/issues/507)
 * Figure out model for crossplane core vs extensions [#531](https://github.com/crossplaneio/crossplane/issues/531)
 * Single extension should be able to install multiple controllers [#532](https://github.com/crossplaneio/crossplane/issues/532)
 * Prototype alternate extension implementations [#548](https://github.com/crossplaneio/crossplane/issues/548)
+* Is there a benefit to `kind.version.` prefixed `crd.yaml` filenames
+* What categories are valid? Is there a well-defined Category tree? Are arbitrary categories invalid or ignored?
+* Should links be predefined (`website`, `source`) or freeform `links:[{description:"Website",url:"..."}, ...]`?

--- a/design/one-pager-stack-ui-metadata.md
+++ b/design/one-pager-stack-ui-metadata.md
@@ -53,7 +53,7 @@ Support for all of these UI types is not mandated or required.  Other UI element
 
 The optional addition of a `ui-schema.yaml` file within the package tree will be used to drive the UI.
 
-The primary purpose of the `ui-schema.yaml` format is to allow for easy authoring of the definition of UI markup, validation, and errors for a more complete UI and UX. The `ui-schema.yaml` file will be parsed and validated as part of package validation and ultimately serialized as a `JSON` annotation on the respective CRD at install time.
+The primary purpose of the `ui-schema.yaml` format is to allow for easy authoring of the definition of UI markup, validation, and errors for a more complete UI and UX. The `ui-schema.yaml` file will be parsed and validated as part of package validation and ultimately serialized as a `YAML` annotation on the respective CRD at install time.
 
 A root `ui-schema.yaml` file may be used to set global UI metadata.  This may be useful for describing required fields that appear across resources and versions.  Resource specific UI metadata should take priority over global UI metadata.
 
@@ -135,17 +135,12 @@ An example injection of the `ui-schema.yaml` as a CRD annotation follows.  Keep 
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  name: rdsinstances.database.aws.crossplane.io
   annotations:
-    extensions.crossplane.io/ui-spec: {"uiSpecVersion":0.3,"uiSpec":[{"title":"Configuration","description":"Enter information specific to the configuration you wish to create.","items":[{"name":"dbReplicas","controlType":"singleInput","type":"integer","path":".spec.dbReplicas","title":"DB Replicas","description":"The number of DB Replicas","default":1,"validation":[{"minimum":1},{"maximum":3}]},{"name":"masterPassword","controlType":"singleInput","type":"password","path":".spec.masterPassword","title":"DB Master Password","description":"The master DB password. Must be between 8-32 characters long"},{"name":"subdomain","controlType":"singleInput","type":"string","path":".spec.subdomain","title":"Subdomain","pattern":"^([A-Za-z0-9](?:(?:[-A-Za-z0-9]){0,61}[A-Za-z0-9])?){2,62}$","description":"Enter a value for your subdomain. It cannot start or end with a dash and must be between 2-62 characters long","validation":[{"minLength":2},{"maxLength":62}]},{"name":"instanceSize","controlType":"singleSelect","path":".spec.instanceSize","title":"Instance Size","enum":["Option-1","Option-2","Option-3"],"validation":[{"required":true,"customError":"You must select an instance size for your configuration!"}]}]}]}
-  creationTimestamp: null
+    stacks.crossplane.io/ui-spec: |
+      {"uiSpecVersion":0.3,"uiSpec":[{"title":"Configuration","description":"Enter information specific to the configuration you wish to create.","items":[{"name":"dbReplicas","controlType":"singleInput","type":"integer","path":".spec.dbReplicas","title":"DB Replicas","description":"The number of DB Replicas","default":1,"validation":[{"minimum":1},{"maximum":3}]},{"name":"masterPassword","controlType":"singleInput","type":"password","path":".spec.masterPassword","title":"DB Master Password","description":"The master DB password. Must be between 8-32 characters long"},{"name":"subdomain","controlType":"singleInput","type":"string","path":".spec.subdomain","title":"Subdomain","pattern":"^([A-Za-z0-9](?:(?:[-A-Za-z0-9]){0,61}[A-Za-z0-9])?){2,62}$","description":"Enter a value for your subdomain. It cannot start or end with a dash and must be between 2-62 characters long","validation":[{"minLength":2},{"maxLength":62}]},{"name":"instanceSize","controlType":"singleSelect","path":".spec.instanceSize","title":"Instance Size","enum":["Option-1","Option-2","Option-3"],"validation":[{"required":true,"customError":"You must select an instance size for your configuration!"}]}]}]}
   labels:
     controller-tools.k8s.io: "1.0"
-  name: rdsinstances.database.aws.crossplane.io
-.
-.
-.
-.
-.
 ```
 
 ## Formal Specification


### PR DESCRIPTION
Revise design doc for stacks
  * include examples of all yaml files and their annotation equivalents
  * link to the crossplane/sample-extension and crossplane/sample-stack-wordpress project
  * clear up historical alternatives and current Stack design (expand on the current implementation)
  * add spec and explanations for Extension links and category (to match existing gitlab stack)
  * stacks should prefer predetermined icon names
  * crd file names and directories are arbitrary
  * note more open questions
    
Relates to issue crossplaneio/crossplane#503, crossplaneio/crossplane#507