### PR TITLE
add initial one-pager for stack ui metadata

### DIFF
--- a/design/design-doc-stacks.md
+++ b/design/design-doc-stacks.md
@@ -210,6 +210,7 @@ Inside of a package, the following filesystem layout is expected:
 ├── app.yaml # Application metadata.
 ├── install.yaml # Optional install metadata.
 ├── rbac.yaml # Optional RBAC permissions.
+├── ui-schema.yaml #  Optional UI Metadata
 └── resources
       └── databases.foocompany.io # Group directory
             ├── group.yaml # Optional Group metadata
@@ -221,6 +222,7 @@ Inside of a package, the following filesystem layout is expected:
                 │   └── resource.yaml # Resource level metadata.
                 └── v1beta1
                     ├── mysql.v1beta1.crd.yaml
+                    ├── ui-schema.yaml #  Optional UI Metadata
                     ├── icon.jpg
                     └── resource.yaml
 ```
@@ -228,6 +230,7 @@ Inside of a package, the following filesystem layout is expected:
 * `app.yaml`: This file is the general metadata and information about the Stack, such as its name, description, version, owners, etc.  This metadata will be saved in the `Extension` record's spec fields.
 * `install.yaml`: This file contains the information for how the custom controller for the Stack should be installed into Crossplane.  Initially, only simple `Deployment` based controllers will be supported, but eventually other types of implementations will be supported as well, e.g., templates, functions/hooks, templates, a new DSL, etc.
 * `resources` directory: This directory contains all the CRDs and optional metadata about them.  These CRDs are the types that the custom controller implements the logic for.  They will be directly installed into Crossplane so that users can create instances of them to start consuming their new Stack functionality.
+* `ui-schema.yaml`: UI metadata that will be transformed and annotated according to the [Stack UI Metadata One Pager](one-pager-stack-ui-metadata.md)
 
 ### Example `app.yaml`
 

--- a/design/one-pager-stack-ui-metadata.md
+++ b/design/one-pager-stack-ui-metadata.md
@@ -1,0 +1,170 @@
+# Stack Package UI configuration metadata
+
+* Owner: Steven Rathbauer (@rathpc), Marques Johansson (@displague)
+* Reviewers: Crossplane Maintainers
+* Status: Draft
+
+## Terms
+
+* **Stack**: A Stack is a Crossplane extension-manager managed package.  These packages may bundle one or many Crossplane applications or infrastructure provider controllers.
+* **Stacks**: Stacks could refer to more than one Crossplane extension-manager packages or the Extension-Manager system as a whole.
+
+See the [Stacks Design Doc](design-doc-stacks.md) for more details about Crossplane Stacks.
+
+## Objective
+
+This document aims to provide details on the necessary metadata that will drive the UI on a configuration page with respect to Crossplane Stacks and the user configurable custom-resource fields exposed with a Stack. This is meant to be a dynamic spec that will not attempt to accommodate all potential UI elements.  This spec does not intend to be as complete as [XForms](https://en.wikipedia.org/wiki/XForms) or [HTML Forms](https://www.w3.org/TR/html52/sec-forms.html), for example.
+
+Users may choose to annotate Stack bundled CRD today with UI hints.  This proposal suggests a means for the extension manager to apply CRD annotations at install and upgrade time.  This separation provides a better developer experience preventing the need for modifying escaped, nested, quoted, YAML or JSON annotations within a CRD document while iterating over UI design.
+
+A YAML file named `ui-schema.yaml` is proposed for inclusion in Stacks.  This will standardize the approach Stack creators use to offer UI context to their package and offer a more engaging user experience.
+
+Tools that deliver a user-interface based on this proposal may include:
+
+* CLI help output
+* CLI auto-completion for arguments
+* Advanced validation (beyond what Kubernetes' OAS3 support delivers)
+* ncurses-style installers
+* web-based package managers (out-of-cluster and in-cluster)
+* web-based configuration panels
+
+This spec is not concerned with a specific UI implementation but serves to provide a foundation for supporting Stack developers and users through basic form input.
+
+## Proposed File format
+
+The `ui-schema.yaml` content will not be dictated in this design doc.  Rather, the [formal specification](#formal-specification) is a simple guideline for the type and size of the document.  The contents are otherwise left open to interpretation by Stack tools with the expectation that these tools will promote interoperable standards.  Specifications suggested through examples and supporting text in this design document should not be considered doctrine.
+
+## Proposed UI Elements
+
+The following are proposed UI elements for Stack tool authors to consider supporting.
+
+* Sections
+* Title
+* Subtitle
+* Input: Text, Number, Password, Hidden, Readonly
+* Textarea
+* Select Dropdown: Single, Multiple
+* Checkbox: Single, Group
+* Radio Button Group
+
+Support for all of these UI types is not mandated or required.  Other UI elements, not listed here, may also be offered.
+
+## Stack Implementation
+
+The optional addition of a `ui-schema.yaml` file within the package tree will be used to drive the UI.
+
+The primary purpose of the `ui-schema.yaml` format is to allow for easy authoring of the definition of UI markup, validation, and errors for a more complete UI and UX. The `ui-schema.yaml` file will be parsed and validated as part of package validation and ultimately serialized as a `JSON` annotation on the respective CRD at install time.
+
+A root `ui-schema.yaml` file may be used to set global UI metadata.  This may be useful for describing required fields that appear across resources and versions.  Resource specific UI metadata should take priority over global UI metadata.
+
+### Example addition of `ui-schema.yaml` in a package tree
+
+```text
+.registry/
+├── icon.png
+├── app.yaml # Application metadata.
+├── ui-schema.yaml # Optional UI spec for configuration metadata
+├── install.yaml # Optional install metadata.
+├── rbac.yaml # Optional RBAC permissions.
+└── resources
+      └── databases.foocompany.io # Group directory
+            ├── group.yaml # Optional Group metadata
+            ├── icon.png # Optional Group icon
+            └── mysql # Kind directory by convention
+                └── v1alpha1
+                    ├── mysql.v1alpha1.crd.yaml # Required CRD
+                    ├── ui-schema.yaml # Optional UI spec for configuration metadata
+                    ├── icon.png # Optional resource icon
+                    ├── resource.yaml # Resource level metadata.
+```
+
+### Example ui-schema.yaml
+
+This file contains multiple sections and a variety of different input types with validation overrides, extended validation and custom error messages.
+
+```yaml
+uiSpecVersion: 0.3
+uiSpec:
+- title: Configuration
+  description: Enter information specific to the configuration you wish to create.
+  items:
+  - name: dbReplicas
+    controlType: singleInput
+    type: integer
+    path: .spec.dbReplicas
+    title: DB Replicas
+    description: The number of DB Replicas
+    default: 1
+    validation:
+    - minimum: 1
+    - maximum: 3
+  - name: masterPassword
+    controlType: singleInput
+    type: password
+    path: .spec.masterPassword
+    title: DB Master Password
+    description: The master DB password. Must be between 8-32 characters long
+  - name: subdomain
+    controlType: singleInput
+    type: string
+    path: .spec.subdomain
+    title: Subdomain
+    pattern: ^([A-Za-z0-9](?:(?:[-A-Za-z0-9]){0,61}[A-Za-z0-9])?){2,62}$
+    description: Enter a value for your subdomain. It cannot start or end with a dash and must be between 2-62 characters long
+    validation:
+    - minLength: 2
+    - maxLength: 62
+  - name: instanceSize
+    controlType: singleSelect
+    path: .spec.instanceSize
+    title: Instance Size
+    enum:
+    - 'Option-1'
+    - 'Option-2'
+    - 'Option-3'
+    validation:
+    - required: true
+      customError: You must select an instance size for your configuration!
+```
+
+### CRD Annotation Example
+
+An example injection of the `ui-schema.yaml` as a CRD annotation follows.  Keep in mind that Kubernetes annotations are limited to 256kb (less in older versions).
+
+```yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    extensions.crossplane.io/ui-spec: {"uiSpecVersion":0.3,"uiSpec":[{"title":"Configuration","description":"Enter information specific to the configuration you wish to create.","items":[{"name":"dbReplicas","controlType":"singleInput","type":"integer","path":".spec.dbReplicas","title":"DB Replicas","description":"The number of DB Replicas","default":1,"validation":[{"minimum":1},{"maximum":3}]},{"name":"masterPassword","controlType":"singleInput","type":"password","path":".spec.masterPassword","title":"DB Master Password","description":"The master DB password. Must be between 8-32 characters long"},{"name":"subdomain","controlType":"singleInput","type":"string","path":".spec.subdomain","title":"Subdomain","pattern":"^([A-Za-z0-9](?:(?:[-A-Za-z0-9]){0,61}[A-Za-z0-9])?){2,62}$","description":"Enter a value for your subdomain. It cannot start or end with a dash and must be between 2-62 characters long","validation":[{"minLength":2},{"maxLength":62}]},{"name":"instanceSize","controlType":"singleSelect","path":".spec.instanceSize","title":"Instance Size","enum":["Option-1","Option-2","Option-3"],"validation":[{"required":true,"customError":"You must select an instance size for your configuration!"}]}]}]}
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: rdsinstances.database.aws.crossplane.io
+.
+.
+.
+.
+.
+```
+
+## Formal Specification
+
+The current design calls for unbiased processing of the UI YAML to annotations, regardless of content.
+
+Because the YAML will be transcribed as JSON in the annotation:
+
+* the file must contain a valid YAML document
+* the transcribed JSON must be less than 256kb
+
+These are the only requirements.
+
+TBD: A specification for the supported elements and their properties.  A validator and validation document pair should be offered.  There is no clear YAML validation format as there is DTD for XML documents.  Validation may be deferred to the capabilities of YAML parsing in Go via <https://github.com/go-yaml/yaml/>.  Unrecognized fields will be ignored while typed parameters will expect to conform to a Go type.
+
+## Open Questions
+
+* Should alternate UI schema be supported?
+  * Should this be provided as multiple `ui-schema.yaml` files (with different names) or embedded in a single file?
+    * Should a single CRD annotations include the nested or alternative schemas?
+    * Should multiple CRD annotations represent alternate schemas? How does this affect the annotation key?
+* Should dependent and co-dependent fields be supported? (Not relevant if Crossplane remains unopinionated about the file contents)


### PR DESCRIPTION
Add an initial one-pager draft for how Stacks should bundle UI
annotations.

This document was initially drafted by @rathpc out of tree.

Closes #544 

[skip ci]