### PR TITLE
cloudsql instances: prefix all instance names with Kind by default

### DIFF
--- a/pkg/apis/gcp/database/v1alpha1/cloudsql_instance_types_test.go
+++ b/pkg/apis/gcp/database/v1alpha1/cloudsql_instance_types_test.go
@@ -281,7 +281,7 @@ func TestCloudsqlInstance_DatabaseUserName(t *testing.T) {
 	}
 }
 
-func TestBucket_GetResourceName(t *testing.T) {
+func TestCloudsqlInstance_GetResourceName(t *testing.T) {
 	om := metav1.ObjectMeta{
 		Namespace: "foo",
 		Name:      "bar",
@@ -300,7 +300,7 @@ func TestBucket_GetResourceName(t *testing.T) {
 				meta: om,
 				spec: CloudsqlInstanceSpec{},
 			},
-			want: "test-uid",
+			want: "cloudsqlinstance-test-uid",
 		},
 		"FormatString": {
 			fields: fields{
@@ -337,7 +337,7 @@ func TestBucket_GetResourceName(t *testing.T) {
 				Spec:       tt.fields.spec,
 			}
 			if got := b.GetResourceName(); got != tt.want {
-				t.Errorf("Bucket.GetBucketName() = %v, want %v", got, tt.want)
+				t.Errorf("CloudsqlInstance.GetResourceName() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
### Description of your changes

Fixes #585; see #585 for more context. Previously, cloudsql instance names defaulted
to being a generated UUID. However, on the GCP side, cloudsql instance
names must begin with a letter, so any UUIDs starting with a number
would fail instance creation. This change prefixes the instance names
with the Kind by default so that they won't be affected by the naming restriction
anymore. The default format is now `Kind-UUID` instead of `UUID`.

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml