### PR TITLE
Enable Strongly Typed Resource Classes

### DIFF
--- a/pkg/apis/core/v1alpha1/resource.go
+++ b/pkg/apis/core/v1alpha1/resource.go
@@ -73,6 +73,19 @@ type ResourceClass struct {
 	ReclaimPolicy ReclaimPolicy `json:"reclaimPolicy,omitempty"`
 }
 
+// NOTE(hasheddan): cannot check for satisfying resource.Class interface
+// because of circular imports
+
+// GetReclaimPolicy of this ResourceClass.
+func (r *ResourceClass) GetReclaimPolicy() ReclaimPolicy {
+	return r.ReclaimPolicy
+}
+
+// SetReclaimPolicy of this ResourceClass.
+func (r *ResourceClass) SetReclaimPolicy(p ReclaimPolicy) {
+	r.ReclaimPolicy = p
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ResourceClassList contains a list of resource classes.

--- a/pkg/controller/aws/cache/claim.go
+++ b/pkg/controller/aws/cache/claim.go
@@ -39,6 +39,7 @@ import (
 func AddClaim(mgr manager.Manager) error {
 	r := resource.NewClaimReconciler(mgr,
 		resource.ClaimKind(cachev1alpha1.RedisClusterGroupVersionKind),
+		resource.ClassKind(corev1alpha1.ResourceClassGroupVersionKind),
 		resource.ManagedKind(v1alpha1.ReplicationGroupGroupVersionKind),
 		resource.WithManagedBinder(resource.NewAPIManagedStatusBinder(mgr.GetClient())),
 		resource.WithManagedFinalizer(resource.NewAPIManagedStatusUnbinder(mgr.GetClient())),
@@ -71,10 +72,15 @@ func AddClaim(mgr manager.Manager) error {
 // ConfigureReplicationGroup configures the supplied resource (presumed
 // to be a ReplicationGroup) using the supplied resource claim (presumed
 // to be a RedisCluster) and resource class.
-func ConfigureReplicationGroup(_ context.Context, cm resource.Claim, cs *corev1alpha1.ResourceClass, mg resource.Managed) error {
+func ConfigureReplicationGroup(_ context.Context, cm resource.Claim, cs resource.Class, mg resource.Managed) error {
 	rc, cmok := cm.(*cachev1alpha1.RedisCluster)
 	if !cmok {
 		return errors.Errorf("expected resource claim %s to be %s", cm.GetName(), cachev1alpha1.RedisClusterGroupVersionKind)
+	}
+
+	rs, csok := cs.(*corev1alpha1.ResourceClass)
+	if !csok {
+		return errors.Errorf("expected resource class %s to be %s", cs.GetName(), corev1alpha1.ResourceClassGroupVersionKind)
 	}
 
 	i, mgok := mg.(*v1alpha1.ReplicationGroup)
@@ -82,15 +88,15 @@ func ConfigureReplicationGroup(_ context.Context, cm resource.Claim, cs *corev1a
 		return errors.Errorf("expected managed resource %s to be %s", mg.GetName(), v1alpha1.ReplicationGroupGroupVersionKind)
 	}
 
-	spec := v1alpha1.NewReplicationGroupSpec(cs.Parameters)
+	spec := v1alpha1.NewReplicationGroupSpec(rs.Parameters)
 
 	if err := resolveAWSClassInstanceValues(spec, rc); err != nil {
 		return errors.Wrap(err, "cannot resolve AWS class instance values")
 	}
 
 	spec.WriteConnectionSecretToReference = corev1.LocalObjectReference{Name: string(cm.GetUID())}
-	spec.ProviderReference = cs.ProviderReference
-	spec.ReclaimPolicy = cs.ReclaimPolicy
+	spec.ProviderReference = rs.ProviderReference
+	spec.ReclaimPolicy = rs.ReclaimPolicy
 
 	i.Spec = *spec
 

--- a/pkg/controller/aws/compute/claim.go
+++ b/pkg/controller/aws/compute/claim.go
@@ -39,6 +39,7 @@ import (
 func AddClaim(mgr manager.Manager) error {
 	r := resource.NewClaimReconciler(mgr,
 		resource.ClaimKind(computev1alpha1.KubernetesClusterGroupVersionKind),
+		resource.ClassKind(corev1alpha1.ResourceClassGroupVersionKind),
 		resource.ManagedKind(v1alpha1.EKSClusterGroupVersionKind),
 		resource.WithManagedConfigurators(
 			resource.ManagedConfiguratorFn(ConfigureEKSCluster),
@@ -66,9 +67,14 @@ func AddClaim(mgr manager.Manager) error {
 // ConfigureEKSCluster configures the supplied resource (presumed to be a
 // EKSCluster) using the supplied resource claim (presumed to be a
 // KubernetesCluster) and resource class.
-func ConfigureEKSCluster(_ context.Context, cm resource.Claim, cs *corev1alpha1.ResourceClass, mg resource.Managed) error {
+func ConfigureEKSCluster(_ context.Context, cm resource.Claim, cs resource.Class, mg resource.Managed) error {
 	if _, cmok := cm.(*computev1alpha1.KubernetesCluster); !cmok {
 		return errors.Errorf("expected resource claim %s to be %s", cm.GetName(), computev1alpha1.KubernetesClusterGroupVersionKind)
+	}
+
+	rs, csok := cs.(*corev1alpha1.ResourceClass)
+	if !csok {
+		return errors.Errorf("expected resource class %s to be %s", cs.GetName(), corev1alpha1.ResourceClassGroupVersionKind)
 	}
 
 	i, mgok := mg.(*v1alpha1.EKSCluster)
@@ -76,10 +82,10 @@ func ConfigureEKSCluster(_ context.Context, cm resource.Claim, cs *corev1alpha1.
 		return errors.Errorf("expected managed resource %s to be %s", mg.GetName(), v1alpha1.EKSClusterGroupVersionKind)
 	}
 
-	spec := v1alpha1.NewEKSClusterSpec(cs.Parameters)
+	spec := v1alpha1.NewEKSClusterSpec(rs.Parameters)
 	spec.WriteConnectionSecretToReference = corev1.LocalObjectReference{Name: string(cm.GetUID())}
-	spec.ProviderReference = cs.ProviderReference
-	spec.ReclaimPolicy = cs.ReclaimPolicy
+	spec.ProviderReference = rs.ProviderReference
+	spec.ReclaimPolicy = rs.ReclaimPolicy
 
 	i.Spec = *spec
 

--- a/pkg/controller/azure/compute/compute_suite_test.go
+++ b/pkg/controller/azure/compute/compute_suite_test.go
@@ -150,9 +150,9 @@ func testInstance(p *azurev1alpha1.Provider) *computev1alpha1.AKSCluster {
 			ResourceSpec: corev1alpha1.ResourceSpec{
 				ReclaimPolicy:                    corev1alpha1.ReclaimDelete,
 				ProviderReference:                meta.ReferenceTo(p, azurev1alpha1.ProviderGroupVersionKind),
-				WriteConnectionSecretToReference: corev1.LocalObjectReference{"coolSecret"},
+				WriteConnectionSecretToReference: corev1.LocalObjectReference{Name: "coolSecret"},
 			},
-			WriteServicePrincipalSecretTo: corev1.LocalObjectReference{"coolPrincipal"},
+			WriteServicePrincipalSecretTo: corev1.LocalObjectReference{Name: "coolPrincipal"},
 			ResourceGroupName:             "rg1",
 			Location:                      "loc1",
 			Version:                       "1.12.5",

--- a/pkg/controller/defaultclass/bucket.go
+++ b/pkg/controller/defaultclass/bucket.go
@@ -34,7 +34,7 @@ import (
 // of kind Bucket to a resource class that declares it as the Bucket
 // default
 func AddBucket(mgr manager.Manager) error {
-	r := resource.NewDefaultClassReconciler(mgr,
+	r := resource.NewDeprecatedDefaultClassReconciler(mgr,
 		resource.ClaimKind(storagev1alpha1.BucketGroupVersionKind),
 	)
 

--- a/pkg/controller/defaultclass/kubernetescluster.go
+++ b/pkg/controller/defaultclass/kubernetescluster.go
@@ -34,7 +34,7 @@ import (
 // of kind KubernetesCluster to a resource class that declares it as the KubernetesCluster
 // default
 func AddKubernetesCluster(mgr manager.Manager) error {
-	r := resource.NewDefaultClassReconciler(mgr,
+	r := resource.NewDeprecatedDefaultClassReconciler(mgr,
 		resource.ClaimKind(computev1alpha1.KubernetesClusterGroupVersionKind),
 	)
 

--- a/pkg/controller/defaultclass/mysqlinstance.go
+++ b/pkg/controller/defaultclass/mysqlinstance.go
@@ -34,7 +34,7 @@ import (
 // of kind MySQLInstance to a resource class that declares it as the MySQLInstance
 // default
 func AddMySQLInstance(mgr manager.Manager) error {
-	r := resource.NewDefaultClassReconciler(mgr,
+	r := resource.NewDeprecatedDefaultClassReconciler(mgr,
 		resource.ClaimKind(databasev1alpha1.MySQLInstanceGroupVersionKind),
 	)
 

--- a/pkg/controller/defaultclass/postgresqlinstance.go
+++ b/pkg/controller/defaultclass/postgresqlinstance.go
@@ -34,7 +34,7 @@ import (
 // of kind PostgreSQLInstance to a resource class that declares it as the PostgreSQLInstance
 // default
 func AddPostgreSQLInstance(mgr manager.Manager) error {
-	r := resource.NewDefaultClassReconciler(mgr,
+	r := resource.NewDeprecatedDefaultClassReconciler(mgr,
 		resource.ClaimKind(databasev1alpha1.PostgreSQLInstanceGroupVersionKind),
 	)
 

--- a/pkg/controller/defaultclass/rediscluster.go
+++ b/pkg/controller/defaultclass/rediscluster.go
@@ -34,7 +34,7 @@ import (
 // of kind RedisCluster to a resource class that declares it as the RedisCluster
 // default
 func AddRedisCluster(mgr manager.Manager) error {
-	r := resource.NewDefaultClassReconciler(mgr,
+	r := resource.NewDeprecatedDefaultClassReconciler(mgr,
 		resource.ClaimKind(cachev1alpha1.RedisClusterGroupVersionKind),
 	)
 

--- a/pkg/controller/gcp/database/add.go
+++ b/pkg/controller/gcp/database/add.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
 	databasev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/database/v1alpha1"
 	"github.com/crossplaneio/crossplane/pkg/apis/gcp/database/v1alpha1"
 	"github.com/crossplaneio/crossplane/pkg/resource"
@@ -62,6 +63,7 @@ func Add(mgr manager.Manager) error {
 func AddPostgreSQLClaim(mgr manager.Manager) error {
 	r := resource.NewClaimReconciler(mgr,
 		resource.ClaimKind(databasev1alpha1.PostgreSQLInstanceGroupVersionKind),
+		resource.ClassKind(corev1alpha1.ResourceClassGroupVersionKind),
 		resource.ManagedKind(v1alpha1.CloudsqlInstanceGroupVersionKind),
 		resource.WithManagedBinder(resource.NewAPIManagedStatusBinder(mgr.GetClient())),
 		resource.WithManagedFinalizer(resource.NewAPIManagedStatusUnbinder(mgr.GetClient())),
@@ -93,6 +95,7 @@ func AddPostgreSQLClaim(mgr manager.Manager) error {
 func AddMySQLClaim(mgr manager.Manager) error {
 	r := resource.NewClaimReconciler(mgr,
 		resource.ClaimKind(databasev1alpha1.MySQLInstanceGroupVersionKind),
+		resource.ClassKind(corev1alpha1.ResourceClassGroupVersionKind),
 		resource.ManagedKind(v1alpha1.CloudsqlInstanceGroupVersionKind),
 		resource.WithManagedBinder(resource.NewAPIManagedStatusBinder(mgr.GetClient())),
 		resource.WithManagedFinalizer(resource.NewAPIManagedStatusUnbinder(mgr.GetClient())),

--- a/pkg/resource/api.go
+++ b/pkg/resource/api.go
@@ -57,7 +57,7 @@ func NewAPIManagedCreator(c client.Client, t runtime.ObjectTyper) *APIManagedCre
 }
 
 // Create the supplied resource using the supplied class and claim.
-func (a *APIManagedCreator) Create(ctx context.Context, cm Claim, cs *v1alpha1.ResourceClass, mg Managed) error {
+func (a *APIManagedCreator) Create(ctx context.Context, cm Claim, cs Class, mg Managed) error {
 	cmr := meta.ReferenceTo(cm, MustGetKind(cm, a.typer))
 	csr := meta.ReferenceTo(cs, MustGetKind(cs, a.typer))
 	mgr := meta.ReferenceTo(mg, MustGetKind(mg, a.typer))

--- a/pkg/resource/api_test.go
+++ b/pkg/resource/api_test.go
@@ -52,7 +52,7 @@ func TestCreate(t *testing.T) {
 	type args struct {
 		ctx context.Context
 		cm  Claim
-		cs  *v1alpha1.ResourceClass
+		cs  Class
 		mg  Managed
 	}
 
@@ -71,12 +71,12 @@ func TestCreate(t *testing.T) {
 				client: &test.MockClient{
 					MockCreate: test.NewMockCreateFn(errBoom),
 				},
-				typer: MockSchemeWith(&MockClaim{}, &v1alpha1.ResourceClass{}, &MockManaged{}),
+				typer: MockSchemeWith(&MockClaim{}, &MockClass{}, &MockManaged{}),
 			},
 			args: args{
 				ctx: context.Background(),
 				cm:  &MockClaim{},
-				cs:  &v1alpha1.ResourceClass{},
+				cs:  &MockClass{},
 				mg:  &MockManaged{},
 			},
 			want: errors.Wrap(errBoom, errCreateManaged),
@@ -87,12 +87,12 @@ func TestCreate(t *testing.T) {
 					MockCreate: test.NewMockCreateFn(nil),
 					MockUpdate: test.NewMockUpdateFn(errBoom),
 				},
-				typer: MockSchemeWith(&MockClaim{}, &v1alpha1.ResourceClass{}, &MockManaged{}),
+				typer: MockSchemeWith(&MockClaim{}, &MockClass{}, &MockManaged{}),
 			},
 			args: args{
 				ctx: context.Background(),
 				cm:  &MockClaim{},
-				cs:  &v1alpha1.ResourceClass{},
+				cs:  &MockClass{},
 				mg:  &MockManaged{},
 			},
 			want: errors.Wrap(errBoom, errUpdateClaim),
@@ -110,8 +110,8 @@ func TestCreate(t *testing.T) {
 						})
 						want.SetClassReference(&corev1.ObjectReference{
 							Name:       csname,
-							APIVersion: MockGVK(&v1alpha1.ResourceClass{}).GroupVersion().String(),
-							Kind:       MockGVK(&v1alpha1.ResourceClass{}).Kind,
+							APIVersion: MockGVK(&MockClass{}).GroupVersion().String(),
+							Kind:       MockGVK(&MockClass{}).Kind,
 						})
 						if diff := cmp.Diff(want, got, test.EquateConditions()); diff != "" {
 							t.Errorf("-want, +got:\n%s", diff)
@@ -133,12 +133,12 @@ func TestCreate(t *testing.T) {
 						return nil
 					}),
 				},
-				typer: MockSchemeWith(&MockClaim{}, &v1alpha1.ResourceClass{}, &MockManaged{}),
+				typer: MockSchemeWith(&MockClaim{}, &MockClass{}, &MockManaged{}),
 			},
 			args: args{
 				ctx: context.Background(),
 				cm:  &MockClaim{ObjectMeta: metav1.ObjectMeta{Name: cmname}},
-				cs:  &v1alpha1.ResourceClass{ObjectMeta: metav1.ObjectMeta{Name: csname}},
+				cs:  &MockClass{ObjectMeta: metav1.ObjectMeta{Name: csname}},
 				mg:  &MockManaged{ObjectMeta: metav1.ObjectMeta{Name: mgname}},
 			},
 			want: nil,

--- a/pkg/resource/claim_reconciler_test.go
+++ b/pkg/resource/claim_reconciler_test.go
@@ -63,6 +63,7 @@ func TestClaimReconciler(t *testing.T) {
 	type args struct {
 		m    manager.Manager
 		of   ClaimKind
+		use  ClassKind
 		with ManagedKind
 		o    []ClaimReconcilerOption
 	}
@@ -84,9 +85,10 @@ func TestClaimReconciler(t *testing.T) {
 			args: args{
 				m: &MockManager{
 					c: &test.MockClient{MockGet: test.NewMockGetFn(errBoom)},
-					s: MockSchemeWith(&MockClaim{}, &MockManaged{}),
+					s: MockSchemeWith(&MockClaim{}, &MockClass{}, &MockManaged{}),
 				},
 				of:   ClaimKind(MockGVK(&MockClaim{})),
+				use:  ClassKind(MockGVK(&MockClass{})),
 				with: ManagedKind(MockGVK(&MockManaged{})),
 			},
 			want: want{err: errors.Wrap(errBoom, errGetClaim)},
@@ -118,9 +120,10 @@ func TestClaimReconciler(t *testing.T) {
 							return nil
 						}),
 					},
-					s: MockSchemeWith(&MockClaim{}, &MockManaged{}),
+					s: MockSchemeWith(&MockClaim{}, &MockClass{}, &MockManaged{}),
 				},
 				of:   ClaimKind(MockGVK(&MockClaim{})),
+				use:  ClassKind(MockGVK(&MockClass{})),
 				with: ManagedKind(MockGVK(&MockManaged{})),
 			},
 			want: want{result: reconcile.Result{RequeueAfter: aShortWait}},
@@ -150,9 +153,10 @@ func TestClaimReconciler(t *testing.T) {
 							return nil
 						}),
 					},
-					s: MockSchemeWith(&MockClaim{}, &MockManaged{}),
+					s: MockSchemeWith(&MockClaim{}, &MockClass{}, &MockManaged{}),
 				},
 				of:   ClaimKind(MockGVK(&MockClaim{})),
+				use:  ClassKind(MockGVK(&MockClass{})),
 				with: ManagedKind(MockGVK(&MockManaged{})),
 				o: []ClaimReconcilerOption{
 					WithManagedFinalizer(ManagedFinalizerFn(func(_ context.Context, _ Managed) error { return errBoom })),
@@ -185,9 +189,10 @@ func TestClaimReconciler(t *testing.T) {
 							return nil
 						}),
 					},
-					s: MockSchemeWith(&MockClaim{}, &MockManaged{}),
+					s: MockSchemeWith(&MockClaim{}, &MockClass{}, &MockManaged{}),
 				},
 				of:   ClaimKind(MockGVK(&MockClaim{})),
+				use:  ClassKind(MockGVK(&MockClass{})),
 				with: ManagedKind(MockGVK(&MockManaged{})),
 				o: []ClaimReconcilerOption{
 					WithManagedFinalizer(ManagedFinalizerFn(func(_ context.Context, _ Managed) error { return nil })),
@@ -221,9 +226,10 @@ func TestClaimReconciler(t *testing.T) {
 							return nil
 						}),
 					},
-					s: MockSchemeWith(&MockClaim{}, &MockManaged{}),
+					s: MockSchemeWith(&MockClaim{}, &MockClass{}, &MockManaged{}),
 				},
 				of:   ClaimKind(MockGVK(&MockClaim{})),
+				use:  ClassKind(MockGVK(&MockClass{})),
 				with: ManagedKind(MockGVK(&MockManaged{})),
 				o: []ClaimReconcilerOption{
 					WithManagedFinalizer(ManagedFinalizerFn(func(_ context.Context, _ Managed) error { return nil })),
@@ -257,9 +263,10 @@ func TestClaimReconciler(t *testing.T) {
 							return nil
 						}),
 					},
-					s: MockSchemeWith(&MockClaim{}, &MockManaged{}),
+					s: MockSchemeWith(&MockClaim{}, &MockClass{}, &MockManaged{}),
 				},
 				of:   ClaimKind(MockGVK(&MockClaim{})),
+				use:  ClassKind(MockGVK(&MockClass{})),
 				with: ManagedKind(MockGVK(&MockManaged{})),
 				o: []ClaimReconcilerOption{
 					WithManagedFinalizer(ManagedFinalizerFn(func(_ context.Context, _ Managed) error { return nil })),
@@ -279,7 +286,7 @@ func TestClaimReconciler(t *testing.T) {
 								cm.SetClassReference(&corev1.ObjectReference{})
 								*o = *cm
 								return nil
-							case *v1alpha1.ResourceClass:
+							case *MockClass:
 								return errBoom
 							default:
 								return errUnexpected
@@ -295,9 +302,10 @@ func TestClaimReconciler(t *testing.T) {
 							return nil
 						}),
 					},
-					s: MockSchemeWith(&MockClaim{}, &MockManaged{}),
+					s: MockSchemeWith(&MockClaim{}, &MockClass{}, &MockManaged{}),
 				},
 				of:   ClaimKind(MockGVK(&MockClaim{})),
+				use:  ClassKind(MockGVK(&MockClass{})),
 				with: ManagedKind(MockGVK(&MockManaged{})),
 			},
 			want: want{result: reconcile.Result{RequeueAfter: aShortWait}},
@@ -313,7 +321,7 @@ func TestClaimReconciler(t *testing.T) {
 								cm.SetClassReference(&corev1.ObjectReference{})
 								*o = *cm
 								return nil
-							case *v1alpha1.ResourceClass:
+							case *MockClass:
 								return nil
 							default:
 								return errUnexpected
@@ -329,12 +337,13 @@ func TestClaimReconciler(t *testing.T) {
 							return nil
 						}),
 					},
-					s: MockSchemeWith(&MockClaim{}, &MockManaged{}),
+					s: MockSchemeWith(&MockClaim{}, &MockClass{}, &MockManaged{}),
 				},
 				of:   ClaimKind(MockGVK(&MockClaim{})),
+				use:  ClassKind(MockGVK(&MockClass{})),
 				with: ManagedKind(MockGVK(&MockManaged{})),
 				o: []ClaimReconcilerOption{WithManagedConfigurators(ManagedConfiguratorFn(
-					func(_ context.Context, _ Claim, _ *v1alpha1.ResourceClass, _ Managed) error { return errBoom },
+					func(_ context.Context, _ Claim, _ Class, _ Managed) error { return errBoom },
 				))},
 			},
 			want: want{result: reconcile.Result{RequeueAfter: aShortWait}},
@@ -350,7 +359,7 @@ func TestClaimReconciler(t *testing.T) {
 								cm.SetClassReference(&corev1.ObjectReference{})
 								*o = *cm
 								return nil
-							case *v1alpha1.ResourceClass:
+							case *MockClass:
 								return nil
 							default:
 								return errUnexpected
@@ -366,16 +375,17 @@ func TestClaimReconciler(t *testing.T) {
 							return nil
 						}),
 					},
-					s: MockSchemeWith(&MockClaim{}, &MockManaged{}),
+					s: MockSchemeWith(&MockClaim{}, &MockClass{}, &MockManaged{}),
 				},
 				of:   ClaimKind(MockGVK(&MockClaim{})),
+				use:  ClassKind(MockGVK(&MockClass{})),
 				with: ManagedKind(MockGVK(&MockManaged{})),
 				o: []ClaimReconcilerOption{
 					WithManagedConfigurators(ManagedConfiguratorFn(
-						func(_ context.Context, _ Claim, _ *v1alpha1.ResourceClass, _ Managed) error { return nil },
+						func(_ context.Context, _ Claim, _ Class, _ Managed) error { return nil },
 					)),
 					WithManagedCreator(ManagedCreatorFn(
-						func(_ context.Context, _ Claim, _ *v1alpha1.ResourceClass, _ Managed) error { return errBoom },
+						func(_ context.Context, _ Claim, _ Class, _ Managed) error { return errBoom },
 					)),
 				},
 			},
@@ -414,9 +424,10 @@ func TestClaimReconciler(t *testing.T) {
 							return nil
 						}),
 					},
-					s: MockSchemeWith(&MockClaim{}, &MockManaged{}),
+					s: MockSchemeWith(&MockClaim{}, &MockClass{}, &MockManaged{}),
 				},
 				of:   ClaimKind(MockGVK(&MockClaim{})),
+				use:  ClassKind(MockGVK(&MockClass{})),
 				with: ManagedKind(MockGVK(&MockManaged{})),
 			},
 			want: want{result: reconcile.Result{Requeue: false}},
@@ -452,9 +463,10 @@ func TestClaimReconciler(t *testing.T) {
 							return nil
 						}),
 					},
-					s: MockSchemeWith(&MockClaim{}, &MockManaged{}),
+					s: MockSchemeWith(&MockClaim{}, &MockClass{}, &MockManaged{}),
 				},
 				of:   ClaimKind(MockGVK(&MockClaim{})),
+				use:  ClassKind(MockGVK(&MockClass{})),
 				with: ManagedKind(MockGVK(&MockManaged{})),
 			},
 			want: want{result: reconcile.Result{Requeue: false}},
@@ -490,9 +502,10 @@ func TestClaimReconciler(t *testing.T) {
 							return nil
 						}),
 					},
-					s: MockSchemeWith(&MockClaim{}, &MockManaged{}),
+					s: MockSchemeWith(&MockClaim{}, &MockClass{}, &MockManaged{}),
 				},
 				of:   ClaimKind(MockGVK(&MockClaim{})),
+				use:  ClassKind(MockGVK(&MockClass{})),
 				with: ManagedKind(MockGVK(&MockManaged{})),
 				o: []ClaimReconcilerOption{
 					WithManagedConnectionPropagator(ManagedConnectionPropagatorFn(
@@ -533,9 +546,10 @@ func TestClaimReconciler(t *testing.T) {
 							return nil
 						}),
 					},
-					s: MockSchemeWith(&MockClaim{}, &MockManaged{}),
+					s: MockSchemeWith(&MockClaim{}, &MockClass{}, &MockManaged{}),
 				},
 				of:   ClaimKind(MockGVK(&MockClaim{})),
+				use:  ClassKind(MockGVK(&MockClass{})),
 				with: ManagedKind(MockGVK(&MockManaged{})),
 				o: []ClaimReconcilerOption{
 					WithManagedConnectionPropagator(ManagedConnectionPropagatorFn(
@@ -579,9 +593,10 @@ func TestClaimReconciler(t *testing.T) {
 							return nil
 						}),
 					},
-					s: MockSchemeWith(&MockClaim{}, &MockManaged{}),
+					s: MockSchemeWith(&MockClaim{}, &MockClass{}, &MockManaged{}),
 				},
 				of:   ClaimKind(MockGVK(&MockClaim{})),
+				use:  ClassKind(MockGVK(&MockClass{})),
 				with: ManagedKind(MockGVK(&MockManaged{})),
 			},
 			want: want{result: reconcile.Result{Requeue: false}},
@@ -590,7 +605,7 @@ func TestClaimReconciler(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			r := NewClaimReconciler(tc.args.m, tc.args.of, tc.args.with, tc.args.o...)
+			r := NewClaimReconciler(tc.args.m, tc.args.of, tc.args.use, tc.args.with, tc.args.o...)
 			got, err := r.Reconcile(reconcile.Request{})
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {

--- a/pkg/resource/configurator.go
+++ b/pkg/resource/configurator.go
@@ -25,7 +25,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
 	"github.com/crossplaneio/crossplane/pkg/meta"
 )
 
@@ -34,7 +33,7 @@ type ConfiguratorChain []ManagedConfigurator
 
 // Configure calls each ManagedConfigurator serially. It returns the first
 // error it encounters, if any.
-func (cc ConfiguratorChain) Configure(ctx context.Context, cm Claim, cs *v1alpha1.ResourceClass, mg Managed) error {
+func (cc ConfiguratorChain) Configure(ctx context.Context, cm Claim, cs Class, mg Managed) error {
 	for _, c := range cc {
 		if err := c.Configure(ctx, cm, cs, mg); err != nil {
 			return err
@@ -55,7 +54,7 @@ func NewObjectMetaConfigurator(t runtime.ObjectTyper) *ObjectMetaConfigurator {
 }
 
 // Configure the supplied Managed resource's object metadata.
-func (c *ObjectMetaConfigurator) Configure(_ context.Context, cm Claim, cs *v1alpha1.ResourceClass, mg Managed) error {
+func (c *ObjectMetaConfigurator) Configure(_ context.Context, cm Claim, cs Class, mg Managed) error {
 	mg.SetNamespace(cs.GetNamespace())
 	mg.SetName(fmt.Sprintf("%s-%s", kindish(cm), cm.GetUID()))
 

--- a/pkg/resource/configurator_test.go
+++ b/pkg/resource/configurator_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
 	"github.com/crossplaneio/crossplane/pkg/test"
 )
 
@@ -43,7 +42,7 @@ func TestConfiguratorChain(t *testing.T) {
 	type args struct {
 		ctx context.Context
 		cm  Claim
-		cs  *v1alpha1.ResourceClass
+		cs  Class
 		mg  Managed
 	}
 
@@ -57,35 +56,35 @@ func TestConfiguratorChain(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				cm:  &MockClaim{},
-				cs:  &v1alpha1.ResourceClass{},
+				cs:  &MockClass{},
 				mg:  &MockManaged{},
 			},
 			want: nil,
 		},
 		"SuccessulConfigurator": {
 			cc: ConfiguratorChain{
-				ManagedConfiguratorFn(func(_ context.Context, _ Claim, _ *v1alpha1.ResourceClass, _ Managed) error {
+				ManagedConfiguratorFn(func(_ context.Context, _ Claim, _ Class, _ Managed) error {
 					return nil
 				}),
 			},
 			args: args{
 				ctx: context.Background(),
 				cm:  &MockClaim{},
-				cs:  &v1alpha1.ResourceClass{},
+				cs:  &MockClass{},
 				mg:  &MockManaged{},
 			},
 			want: nil,
 		},
 		"ConfiguratorReturnsError": {
 			cc: ConfiguratorChain{
-				ManagedConfiguratorFn(func(_ context.Context, _ Claim, _ *v1alpha1.ResourceClass, _ Managed) error {
+				ManagedConfiguratorFn(func(_ context.Context, _ Claim, _ Class, _ Managed) error {
 					return errBoom
 				}),
 			},
 			args: args{
 				ctx: context.Background(),
 				cm:  &MockClaim{},
-				cs:  &v1alpha1.ResourceClass{},
+				cs:  &MockClass{},
 				mg:  &MockManaged{},
 			},
 			want: errBoom,
@@ -109,7 +108,7 @@ func TestConfigureObjectMeta(t *testing.T) {
 	type args struct {
 		ctx context.Context
 		cm  Claim
-		cs  *v1alpha1.ResourceClass
+		cs  Class
 		mg  Managed
 	}
 
@@ -128,7 +127,7 @@ func TestConfigureObjectMeta(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				cm:  &MockClaim{ObjectMeta: metav1.ObjectMeta{UID: uid}},
-				cs:  &v1alpha1.ResourceClass{ObjectMeta: metav1.ObjectMeta{Namespace: ns}},
+				cs:  &MockClass{ObjectMeta: metav1.ObjectMeta{Namespace: ns}},
 				mg:  &MockManaged{},
 			},
 			want: want{

--- a/pkg/resource/defaultclass.go
+++ b/pkg/resource/defaultclass.go
@@ -1,11 +1,11 @@
 /*
-Copyright 2018 The Crossplane Authors.
+Copyright 2019 The Crossplane Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,10 +18,11 @@ package resource
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -29,7 +30,6 @@ import (
 
 	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
 	"github.com/crossplaneio/crossplane/pkg/logging"
-	"github.com/crossplaneio/crossplane/pkg/meta"
 )
 
 const (
@@ -38,54 +38,73 @@ const (
 	defaultClassReconcileTimeout = 1 * time.Minute
 )
 
-var logDefaultClass = logging.Logger.WithName("controller").WithValues("controller", controllerNameDefaultClass)
-
 // Error strings
 const (
-	errFailedList             = "unable to list default resource classes"
-	errNoDefaultClass         = "unable to locate a default resource class for claim kind"
-	errMultipleDefaultClasses = "multiple default classes defined for claim kind"
+	errFailedList             = "unable to list policies for claim kind"
+	errFailedPolicyConversion = "unable to convert located policy to correct kind"
+	errNoPolicies             = "unable to locate a policy that specifies a default class for claim kind"
+	errMultiplePolicies       = "multiple policies that specify a default class defined for claim kind"
 )
 
+// A PolicyKind contains the type metadata for a kind of policy.
+type PolicyKind struct {
+	Singular schema.GroupVersionKind
+	Plural   schema.GroupVersionKind
+}
+
 // DefaultClassReconciler reconciles resource claims to the
-// default resource class for their given kind. Predicates
-// ensure that only claims with no resource class reference
-// are reconciled.
+// default resource class for their given kind according to existing
+// policies. Predicates ensure that only claims with no resource class
+// reference are reconciled.
 type DefaultClassReconciler struct {
-	client   client.Client
-	newClaim func() Claim
-	options  *client.ListOptions
+	client         client.Client
+	converter      runtime.ObjectConvertor
+	policyKind     schema.GroupVersionKind
+	policyListKind schema.GroupVersionKind
+	newClaim       func() Claim
+	newPolicy      func() Policy
 }
 
-// NewDefaultClassReconciler creates a new DefaultReconciler for the claim kind
-func NewDefaultClassReconciler(m manager.Manager, of ClaimKind) *DefaultClassReconciler {
+// A DefaultClassReconcilerOption configures a DefaultClassReconciler.
+type DefaultClassReconcilerOption func(*DefaultClassReconciler)
+
+// WithObjectConverter specifies how the DefaultClassReconciler should convert
+// an *UnstructuredList into a concrete list type.
+func WithObjectConverter(oc runtime.ObjectConvertor) DefaultClassReconcilerOption {
+	return func(r *DefaultClassReconciler) {
+		r.converter = oc
+	}
+}
+
+// NewDefaultClassReconciler creates a new DefaultReconciler for the claim kind.
+func NewDefaultClassReconciler(m manager.Manager, of ClaimKind, by PolicyKind, o ...DefaultClassReconcilerOption) *DefaultClassReconciler {
 	nc := func() Claim { return MustCreateObject(schema.GroupVersionKind(of), m.GetScheme()).(Claim) }
+	np := func() Policy { return MustCreateObject(by.Singular, m.GetScheme()).(Policy) }
+	npl := func() PolicyList { return MustCreateObject(by.Plural, m.GetScheme()).(PolicyList) }
 
-	// Panic early if we've been asked to reconcile a claim that has
+	// Panic early if we've been asked to reconcile a claim, policy, or policy list that has
 	// not been registered with our controller manager's scheme.
-	_ = nc()
+	_, _, _ = nc(), np(), npl()
 
-	gk := strings.ToLower(schema.GroupVersionKind(of).GroupKind().String())
-
-	// Create list options query that will be used to search
-	// for resource class that is default for claim kind.
-	options := &client.ListOptions{}
-	if err := options.SetLabelSelector(gk + "/default=" + "true"); err != nil {
-		// Panic if unable to set label selector or else panic will occur
-		// when returned reconciler is invoked.
-		panic(err)
+	r := &DefaultClassReconciler{
+		client:         m.GetClient(),
+		converter:      m.GetScheme(),
+		policyKind:     by.Singular,
+		policyListKind: by.Plural,
+		newClaim:       nc,
+		newPolicy:      np,
 	}
 
-	return &DefaultClassReconciler{
-		client:   m.GetClient(),
-		newClaim: nc,
-		options:  options,
+	for _, ro := range o {
+		ro(r)
 	}
+
+	return r
 }
 
-// Reconcile reconciles a claim to the default class reference for its kind
+// Reconcile reconciles a claim to the default class reference for its kind.
 func (r *DefaultClassReconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) {
-	logDefaultClass.V(logging.Debug).Info("Reconciling", "request", req)
+	log.V(logging.Debug).Info("Reconciling", "request", req, "controller", controllerNameDefaultClass)
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultClassReconcileTimeout)
 	defer cancel()
@@ -97,10 +116,14 @@ func (r *DefaultClassReconciler) Reconcile(req reconcile.Request) (reconcile.Res
 		return reconcile.Result{}, errors.Wrap(IgnoreNotFound(err), errGetClaim)
 	}
 
-	// Get resource classes with claim kind as default
-	classes := &corev1alpha1.ResourceClassList{}
-	if err := r.client.List(ctx, r.options, classes); err != nil {
-		// If this is the first time we encounter no defaults we'll be
+	// Get policies for claim kind in claim's namespace
+	policies := &unstructured.UnstructuredList{}
+	policies.SetGroupVersionKind(r.policyListKind)
+	options := &client.ListOptions{
+		Namespace: req.Namespace,
+	}
+	if err := r.client.List(ctx, options, policies); err != nil {
+		// If this is the first time we encounter listing error we'll be
 		// requeued implicitly due to the status update. If not, we don't
 		// care to requeue because list parameters will not change.
 		claim.SetConditions(corev1alpha1.ReconcileError(errors.New(errFailedList)))
@@ -108,25 +131,37 @@ func (r *DefaultClassReconciler) Reconcile(req reconcile.Request) (reconcile.Res
 	}
 
 	// Check to see if no defaults defined for claim kind.
-	if len(classes.Items) == 0 {
-		// If this is the first time we encounter no defaults we'll be
+	if len(policies.Items) == 0 {
+		// If this is the first time we encounter no policies we'll be
 		// requeued implicitly due to the status update. If not, we will requeue
-		// after a time to see if a default class has been created.
-		claim.SetConditions(corev1alpha1.ReconcileError(errors.New(errNoDefaultClass)))
+		// after a time to see if a policy has been created.
+		claim.SetConditions(corev1alpha1.ReconcileError(errors.New(errNoPolicies)))
 		return reconcile.Result{RequeueAfter: defaultClassWait}, errors.Wrap(IgnoreNotFound(r.client.Status().Update(ctx, claim)), errUpdateClaimStatus)
 	}
 
-	// Check to see if multiple defaults defined for claim kind.
-	if len(classes.Items) > 1 {
-		// If this is the first time we encounter multiple defaults we'll be
+	// Check to see if multiple policies defined for claim kind.
+	if len(policies.Items) > 1 {
+		// If this is the first time we encounter multiple policies we'll be
 		// requeued implicitly due to the status update. If not, we will requeue
-		// after a time to see if only one default class exists.
-		claim.SetConditions(corev1alpha1.ReconcileError(errors.New(errMultipleDefaultClasses)))
+		// after a time to see if only one policy class exists.
+		claim.SetConditions(corev1alpha1.ReconcileError(errors.New(errMultiplePolicies)))
 		return reconcile.Result{RequeueAfter: defaultClassWait}, errors.Wrap(IgnoreNotFound(r.client.Status().Update(ctx, claim)), errUpdateClaimStatus)
 	}
 
-	// Set class reference on claim to default resource class
-	claim.SetClassReference(meta.ReferenceTo(&classes.Items[0], corev1alpha1.ResourceClassGroupVersionKind))
+	// Make sure single item is of correct policy kind.
+	policy := r.newPolicy()
+	p := policies.Items[0]
+	p.SetGroupVersionKind(r.policyKind)
+	if err := r.converter.Convert(&p, policy, ctx); err != nil {
+		// If this is the first time we encounter conversion error we'll be
+		// requeued implicitly due to the status update. If not, we don't
+		// care to requeue because conversion will likely not change.
+		claim.SetConditions(corev1alpha1.ReconcileError(errors.New(errFailedPolicyConversion)))
+		return reconcile.Result{}, errors.Wrap(IgnoreNotFound(r.client.Status().Update(ctx, claim)), errUpdateClaimStatus)
+	}
+
+	// Set class reference on claim to default resource class.
+	claim.SetClassReference(policy.GetDefaultClassReference())
 
 	// Do not requeue, claim controller will see update and claim
 	// with class reference set will pass predicates.

--- a/pkg/resource/deprecateddefaultclass.go
+++ b/pkg/resource/deprecateddefaultclass.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2019 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	corev1alpha1 "github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane/pkg/logging"
+	"github.com/crossplaneio/crossplane/pkg/meta"
+)
+
+const (
+	controllerNameDeprecatedDefaultClass   = "deprecateddefaultclass.crossplane.io"
+	deprecatedDefaultClassWait             = 1 * time.Minute
+	deprecatedDefaultClassReconcileTimeout = 1 * time.Minute
+)
+
+// Error strings
+const (
+	errFailedListDeprecated   = "unable to list default resource classes"
+	errNoDefaultClass         = "unable to locate a default resource class for claim kind"
+	errMultipleDefaultClasses = "multiple default classes defined for claim kind"
+)
+
+// DeprecatedDefaultClassReconciler reconciles resource claims to the
+// default resource class for their given kind. Predicates
+// ensure that only claims with no resource class reference
+// are reconciled.
+type DeprecatedDefaultClassReconciler struct {
+	client   client.Client
+	newClaim func() Claim
+	options  *client.ListOptions
+}
+
+// NewDeprecatedDefaultClassReconciler creates a new DefaultReconciler for the claim kind
+func NewDeprecatedDefaultClassReconciler(m manager.Manager, of ClaimKind) *DeprecatedDefaultClassReconciler {
+	nc := func() Claim { return MustCreateObject(schema.GroupVersionKind(of), m.GetScheme()).(Claim) }
+
+	// Panic early if we've been asked to reconcile a claim that has
+	// not been registered with our controller manager's scheme.
+	_ = nc()
+
+	gk := strings.ToLower(schema.GroupVersionKind(of).GroupKind().String())
+
+	// Create list options query that will be used to search
+	// for resource class that is default for claim kind.
+	options := &client.ListOptions{}
+	if err := options.SetLabelSelector(gk + "/default=" + "true"); err != nil {
+		// Panic if unable to set label selector or else panic will occur
+		// when returned reconciler is invoked.
+		panic(err)
+	}
+
+	return &DeprecatedDefaultClassReconciler{
+		client:   m.GetClient(),
+		newClaim: nc,
+		options:  options,
+	}
+}
+
+// Reconcile reconciles a claim to the default class reference for its kind
+func (r *DeprecatedDefaultClassReconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) {
+	log.V(logging.Debug).Info("Reconciling", "request", req, "controller", controllerNameDeprecatedDefaultClass)
+
+	ctx, cancel := context.WithTimeout(context.Background(), deprecatedDefaultClassReconcileTimeout)
+	defer cancel()
+
+	claim := r.newClaim()
+	if err := r.client.Get(ctx, req.NamespacedName, claim); err != nil {
+		// There's no need to requeue if we no longer exist. Otherwise we'll be
+		// requeued implicitly because we return an error.
+		return reconcile.Result{}, errors.Wrap(IgnoreNotFound(err), errGetClaim)
+	}
+
+	// Get resource classes with claim kind as default
+	// NOTE(hasheddan): corev1alpha1 import here prevents checking that
+	// ResourceClass satisfies Class interface. Would be a circular import.
+	classes := &corev1alpha1.ResourceClassList{}
+	if err := r.client.List(ctx, r.options, classes); err != nil {
+		// If this is the first time we encounter no defaults we'll be
+		// requeued implicitly due to the status update. If not, we don't
+		// care to requeue because list parameters will not change.
+		claim.SetConditions(corev1alpha1.ReconcileError(errors.New(errFailedListDeprecated)))
+		return reconcile.Result{}, errors.Wrap(IgnoreNotFound(r.client.Status().Update(ctx, claim)), errUpdateClaimStatus)
+	}
+
+	// Check to see if no defaults defined for claim kind.
+	if len(classes.Items) == 0 {
+		// If this is the first time we encounter no defaults we'll be
+		// requeued implicitly due to the status update. If not, we will requeue
+		// after a time to see if a default class has been created.
+		claim.SetConditions(corev1alpha1.ReconcileError(errors.New(errNoDefaultClass)))
+		return reconcile.Result{RequeueAfter: deprecatedDefaultClassWait}, errors.Wrap(IgnoreNotFound(r.client.Status().Update(ctx, claim)), errUpdateClaimStatus)
+	}
+
+	// Check to see if multiple defaults defined for claim kind.
+	if len(classes.Items) > 1 {
+		// If this is the first time we encounter multiple defaults we'll be
+		// requeued implicitly due to the status update. If not, we will requeue
+		// after a time to see if only one default class exists.
+		claim.SetConditions(corev1alpha1.ReconcileError(errors.New(errMultipleDefaultClasses)))
+		return reconcile.Result{RequeueAfter: deprecatedDefaultClassWait}, errors.Wrap(IgnoreNotFound(r.client.Status().Update(ctx, claim)), errUpdateClaimStatus)
+	}
+
+	// Set class reference on claim to default resource class
+	claim.SetClassReference(meta.ReferenceTo(&classes.Items[0], corev1alpha1.ResourceClassGroupVersionKind))
+
+	// Do not requeue, claim controller will see update and claim
+	// with class reference set will pass predicates.
+	return reconcile.Result{Requeue: false}, errors.Wrap(IgnoreNotFound(r.client.Update(ctx, claim)), errUpdateClaimStatus)
+}

--- a/pkg/resource/interfaces.go
+++ b/pkg/resource/interfaces.go
@@ -68,6 +68,12 @@ type Reclaimer interface {
 	GetReclaimPolicy() v1alpha1.ReclaimPolicy
 }
 
+// A DefaultClassReferencer may reference a default resource class.
+type DefaultClassReferencer interface {
+	SetDefaultClassReference(r *corev1.ObjectReference)
+	GetDefaultClassReference() *corev1.ObjectReference
+}
+
 // A Claim is a Kubernetes object representing an abstract resource claim (e.g.
 // an SQL database) that may be bound to a concrete managed resource (e.g. a
 // CloudSQL instance).
@@ -83,6 +89,15 @@ type Claim interface {
 	Bindable
 }
 
+// A Class is a Kubernetes object representing configuration
+// specifications for a manged resource.
+type Class interface {
+	runtime.Object
+	metav1.Object
+
+	Reclaimer
+}
+
 // A Managed is a Kubernetes object representing a concrete managed
 // resource (e.g. a CloudSQL instance).
 type Managed interface {
@@ -96,4 +111,20 @@ type Managed interface {
 
 	ConditionSetter
 	Bindable
+}
+
+// A Policy is a Kubernetes object representing a default
+// behavior for a given claim kind.
+type Policy interface {
+	runtime.Object
+	metav1.Object
+
+	DefaultClassReferencer
+}
+
+// A PolicyList is a Kubernetes object representing representing
+// a list of policies.
+type PolicyList interface {
+	runtime.Object
+	metav1.ListInterface
 }

--- a/pkg/resource/interfaces_test.go
+++ b/pkg/resource/interfaces_test.go
@@ -20,7 +20,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/crossplaneio/crossplane/pkg/apis/core/v1alpha1"
 )
@@ -44,6 +43,11 @@ type MockClassReferencer struct{ Ref *corev1.ObjectReference }
 func (m *MockClassReferencer) SetClassReference(r *corev1.ObjectReference) { m.Ref = r }
 func (m *MockClassReferencer) GetClassReference() *corev1.ObjectReference  { return m.Ref }
 
+type MockDefaultClassReferencer struct{ Ref *corev1.ObjectReference }
+
+func (m *MockDefaultClassReferencer) SetDefaultClassReference(r *corev1.ObjectReference) { m.Ref = r }
+func (m *MockDefaultClassReferencer) GetDefaultClassReference() *corev1.ObjectReference  { return m.Ref }
+
 type MockManagedResourceReferencer struct{ Ref *corev1.ObjectReference }
 
 func (m *MockManagedResourceReferencer) SetResourceReference(r *corev1.ObjectReference) { m.Ref = r }
@@ -63,11 +67,6 @@ type MockReclaimer struct{ Policy v1alpha1.ReclaimPolicy }
 func (m *MockReclaimer) SetReclaimPolicy(p v1alpha1.ReclaimPolicy) { m.Policy = p }
 func (m *MockReclaimer) GetReclaimPolicy() v1alpha1.ReclaimPolicy  { return m.Policy }
 
-type MockObjectKind struct{ GVK schema.GroupVersionKind }
-
-func (m *MockObjectKind) SetGroupVersionKind(kind schema.GroupVersionKind) { m.GVK = kind }
-func (m *MockObjectKind) GroupVersionKind() schema.GroupVersionKind        { return m.GVK }
-
 var _ Claim = &MockClaim{}
 
 type MockClaim struct {
@@ -81,8 +80,13 @@ type MockClaim struct {
 	MockBindable
 }
 
-func (m *MockClaim) GetObjectKind() schema.ObjectKind {
-	return &MockObjectKind{GVK: schema.GroupVersionKind{Group: "mock.crossplane.io", Version: "v1alpha", Kind: "claim"}}
+var _ Class = &MockClass{}
+
+type MockClass struct {
+	runtime.Object
+
+	metav1.ObjectMeta
+	MockReclaimer
 }
 
 var _ Managed = &MockManaged{}
@@ -97,4 +101,21 @@ type MockManaged struct {
 	MockReclaimer
 	MockConditionSetter
 	MockBindable
+}
+
+var _ Policy = &MockPolicy{}
+
+type MockPolicy struct {
+	runtime.Object
+
+	metav1.ObjectMeta
+	MockDefaultClassReferencer
+}
+
+var _ PolicyList = &MockPolicyList{}
+
+type MockPolicyList struct {
+	runtime.Object
+
+	metav1.ListInterface
 }


### PR DESCRIPTION
### Description of your changes
This PR builds on the work done in #607. Key changes include:
- Establishes `Class`, `Policy`, and `PolicyList` interfaces
- Creates new `DefaultClassReconciler` and converts old to `DeprecatedDefaultClassReconciler`
- Updates all `Configurator` functions to accept `Class` interface instead of `ResourceClass` type
- Updates `pkg/resource` functions that previously accepted `ResourceClass` type to accept `ClassInterface`
- Updates all `pkg/resource` tests to use general `Class` / `MockClass` interfaces
- Implements new predicate function `HasClassReferenceKind` for future use with claim reconciler
- Updates `NewClaimReconciler` to accept a `ClassKind` (all calls to the function currently pass the general `ResourceClassGroupVersionKind`)

### The Path Forward
This work allows for the incremental implementation of strongly typed resource classes. The overall effort will include:
- Create `Policy` and `PolicyList` for each `Claim` kind
- Create strongly typed resource class for every `Managed` kind (may happen after moving providers out of tree)
- Update `Configurator` functions to use strongly typed resource classes
- Remove `DeprecatedDefaultClassReconciler` and modify default class controllers to use `DefaultClassReconciler`

### Related Issues
#90, #588, #594, #613  

### Checklist.
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml