### PR TITLE
Fix typo in license headers

### DIFF
--- a/pkg/resource/api.go
+++ b/pkg/resource/api.go
@@ -1,7 +1,7 @@
 /*
 Copyright 2019 The Crossplane Authors.
 
-Licensed under the Apache License, Vemgion 2.0 (the "License");
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 

--- a/pkg/resource/api_test.go
+++ b/pkg/resource/api_test.go
@@ -1,7 +1,7 @@
 /*
 Copyright 2019 The Crossplane Authors.
 
-Licensed under the Apache License, Vemgion 2.0 (the "License");
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 


### PR DESCRIPTION
This looks suspiciously like a find and replace bug.