### PR TITLE
workload: preserve non-default secret type when syncing

### DIFF
--- a/pkg/controller/workload/kubernetes/resource/resource.go
+++ b/pkg/controller/workload/kubernetes/resource/resource.go
@@ -256,6 +256,7 @@ func createSecretTemplates(local []corev1.Secret, namespace, namePrefix string) 
 				Annotations: l.GetAnnotations(),
 			},
 			Data: l.Data,
+			Type: l.Type,
 		}
 	}
 	return templates


### PR DESCRIPTION
### Description of your changes

Fixes #645:
This commit modifies the syncing of secrets so that a remote secret will
preserve the type of its corresponding local secret. Before this change the
remote secret type value was always "Opaque" (the default SecretType).

### Checklist
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.