### PR TITLE
Use controller-tools from master instead of our fork

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1031,6 +1031,14 @@
   version = "v2.2.2"
 
 [[projects]]
+  branch = "v3"
+  digest = "1:46754188622566b86271d7526cb643b88c2b9589ee224c2d55e282f0f35a0df8"
+  name = "gopkg.in/yaml.v3"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "674ba3eaed223079f9377fbb0c98c0951bf6ec10"
+
+[[projects]]
   digest = "1:9e593df1695ea6942188dd19c1d0f21c635fcf9f5f03611fc623c696cd2847a9"
   name = "honnef.co/go/tools"
   packages = [
@@ -1402,7 +1410,7 @@
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:1edc986a412b40d477a5c0077e7749d280fffa4446f7ec2e24c3e0cf4b128070"
+  digest = "1:6852be48889f976ee43ef7ca2e1a25ee9cfd3d0d46dbcdfcf32f8b7186c019e0"
   name = "sigs.k8s.io/controller-tools"
   packages = [
     "cmd/controller-gen",
@@ -1415,11 +1423,12 @@
     "pkg/loader",
     "pkg/markers",
     "pkg/rbac",
+    "pkg/schemapatcher",
+    "pkg/schemapatcher/internal/yaml",
     "pkg/webhook",
   ]
   pruneopts = "UT"
-  revision = "8e509cc6044facab5022c3af8f713f8b736d9108"
-  source = "https://github.com/muvaf/controller-tools.git"
+  revision = "ba11932048e4538f6e435f5ca0cdea19bf458338"
 
 [[projects]]
   digest = "1:9070222ca967d09b3966552a161dd4420d62315964bf5e1efd8cc4c7c30ebca8"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -44,11 +44,9 @@ required = [
   name="sigs.k8s.io/controller-runtime"
   version="v0.2.0"
 
-# The fork is based on v0.2.0. See https://github.com/kubernetes-sigs/controller-tools/issues/301
 [[override]]
   name="sigs.k8s.io/controller-tools"
-  source = "https://github.com/muvaf/controller-tools.git"
-  revision = "8e509cc6044facab5022c3af8f713f8b736d9108"
+  revision = "ba11932048e4538f6e435f5ca0cdea19bf458338"
 
 [[override]]
   name = "contrib.go.opencensus.io/exporter/ocagent"

--- a/cluster/charts/crossplane/crds/aws/aws.crossplane.io_providers.yaml
+++ b/cluster/charts/crossplane/crds/aws/aws.crossplane.io_providers.yaml
@@ -20,7 +20,9 @@ spec:
   group: aws.crossplane.io
   names:
     kind: Provider
+    listKind: ProviderList
     plural: providers
+    singular: provider
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/aws/cache.aws.crossplane.io_replicationgroupclasses.yaml
+++ b/cluster/charts/crossplane/crds/aws/cache.aws.crossplane.io_replicationgroupclasses.yaml
@@ -19,7 +19,9 @@ spec:
   group: cache.aws.crossplane.io
   names:
     kind: ReplicationGroupClass
+    listKind: ReplicationGroupClassList
     plural: replicationgroupclasses
+    singular: replicationgroupclass
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/aws/cache.aws.crossplane.io_replicationgroups.yaml
+++ b/cluster/charts/crossplane/crds/aws/cache.aws.crossplane.io_replicationgroups.yaml
@@ -22,7 +22,9 @@ spec:
   group: cache.aws.crossplane.io
   names:
     kind: ReplicationGroup
+    listKind: ReplicationGroupList
     plural: replicationgroups
+    singular: replicationgroup
   scope: ""
   subresources:
     status: {}

--- a/cluster/charts/crossplane/crds/aws/compute.aws.crossplane.io_eksclusterclasses.yaml
+++ b/cluster/charts/crossplane/crds/aws/compute.aws.crossplane.io_eksclusterclasses.yaml
@@ -19,7 +19,9 @@ spec:
   group: compute.aws.crossplane.io
   names:
     kind: EKSClusterClass
+    listKind: EKSClusterClassList
     plural: eksclusterclasses
+    singular: eksclusterclass
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/aws/compute.aws.crossplane.io_eksclusters.yaml
+++ b/cluster/charts/crossplane/crds/aws/compute.aws.crossplane.io_eksclusters.yaml
@@ -34,7 +34,9 @@ spec:
   group: compute.aws.crossplane.io
   names:
     kind: EKSCluster
+    listKind: EKSClusterList
     plural: eksclusters
+    singular: ekscluster
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/aws/database.aws.crossplane.io_rdsinstanceclasses.yaml
+++ b/cluster/charts/crossplane/crds/aws/database.aws.crossplane.io_rdsinstanceclasses.yaml
@@ -19,7 +19,9 @@ spec:
   group: database.aws.crossplane.io
   names:
     kind: RDSInstanceClass
+    listKind: RDSInstanceClassList
     plural: rdsinstanceclasses
+    singular: rdsinstanceclass
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/aws/database.aws.crossplane.io_rdsinstances.yaml
+++ b/cluster/charts/crossplane/crds/aws/database.aws.crossplane.io_rdsinstances.yaml
@@ -25,7 +25,9 @@ spec:
   group: database.aws.crossplane.io
   names:
     kind: RDSInstance
+    listKind: RDSInstanceList
     plural: rdsinstances
+    singular: rdsinstance
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/aws/storage.aws.crossplane.io_s3bucketclasses.yaml
+++ b/cluster/charts/crossplane/crds/aws/storage.aws.crossplane.io_s3bucketclasses.yaml
@@ -19,7 +19,9 @@ spec:
   group: storage.aws.crossplane.io
   names:
     kind: S3BucketClass
+    listKind: S3BucketClassList
     plural: s3bucketclasses
+    singular: s3bucketclass
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/aws/storage.aws.crossplane.io_s3buckets.yaml
+++ b/cluster/charts/crossplane/crds/aws/storage.aws.crossplane.io_s3buckets.yaml
@@ -22,7 +22,9 @@ spec:
   group: storage.aws.crossplane.io
   names:
     kind: S3Bucket
+    listKind: S3BucketList
     plural: s3buckets
+    singular: s3bucket
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/azure/azure.crossplane.io_providers.yaml
+++ b/cluster/charts/crossplane/crds/azure/azure.crossplane.io_providers.yaml
@@ -14,7 +14,9 @@ spec:
   group: azure.crossplane.io
   names:
     kind: Provider
+    listKind: ProviderList
     plural: providers
+    singular: provider
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/azure/azure.crossplane.io_resourcegroups.yaml
+++ b/cluster/charts/crossplane/crds/azure/azure.crossplane.io_resourcegroups.yaml
@@ -9,7 +9,9 @@ spec:
   group: azure.crossplane.io
   names:
     kind: ResourceGroup
+    listKind: ResourceGroupList
     plural: resourcegroups
+    singular: resourcegroup
   scope: ""
   validation:
     openAPIV3Schema:

--- a/cluster/charts/crossplane/crds/azure/cache.azure.crossplane.io_redis.yaml
+++ b/cluster/charts/crossplane/crds/azure/cache.azure.crossplane.io_redis.yaml
@@ -22,7 +22,9 @@ spec:
   group: cache.azure.crossplane.io
   names:
     kind: Redis
+    listKind: RedisList
     plural: redis
+    singular: redis
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/azure/cache.azure.crossplane.io_redisclasses.yaml
+++ b/cluster/charts/crossplane/crds/azure/cache.azure.crossplane.io_redisclasses.yaml
@@ -19,7 +19,9 @@ spec:
   group: cache.azure.crossplane.io
   names:
     kind: RedisClass
+    listKind: RedisClassList
     plural: redisclasses
+    singular: redisclass
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/azure/compute.azure.crossplane.io_aksclusterclasses.yaml
+++ b/cluster/charts/crossplane/crds/azure/compute.azure.crossplane.io_aksclusterclasses.yaml
@@ -19,7 +19,9 @@ spec:
   group: compute.azure.crossplane.io
   names:
     kind: AKSClusterClass
+    listKind: AKSClusterClassList
     plural: aksclusterclasses
+    singular: aksclusterclass
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/azure/compute.azure.crossplane.io_aksclusters.yaml
+++ b/cluster/charts/crossplane/crds/azure/compute.azure.crossplane.io_aksclusters.yaml
@@ -34,7 +34,9 @@ spec:
   group: compute.azure.crossplane.io
   names:
     kind: AKSCluster
+    listKind: AKSClusterList
     plural: aksclusters
+    singular: akscluster
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/azure/database.azure.crossplane.io_mysqlservers.yaml
+++ b/cluster/charts/crossplane/crds/azure/database.azure.crossplane.io_mysqlservers.yaml
@@ -25,7 +25,9 @@ spec:
   group: database.azure.crossplane.io
   names:
     kind: MysqlServer
+    listKind: MysqlServerList
     plural: mysqlservers
+    singular: mysqlserver
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/azure/database.azure.crossplane.io_postgresqlservers.yaml
+++ b/cluster/charts/crossplane/crds/azure/database.azure.crossplane.io_postgresqlservers.yaml
@@ -25,7 +25,9 @@ spec:
   group: database.azure.crossplane.io
   names:
     kind: PostgresqlServer
+    listKind: PostgresqlServerList
     plural: postgresqlservers
+    singular: postgresqlserver
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/azure/database.azure.crossplane.io_sqlserverclasses.yaml
+++ b/cluster/charts/crossplane/crds/azure/database.azure.crossplane.io_sqlserverclasses.yaml
@@ -19,7 +19,9 @@ spec:
   group: database.azure.crossplane.io
   names:
     kind: SQLServerClass
+    listKind: SQLServerClassList
     plural: sqlserverclasses
+    singular: sqlserverclass
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/azure/storage.azure.crossplane.io_accountclasses.yaml
+++ b/cluster/charts/crossplane/crds/azure/storage.azure.crossplane.io_accountclasses.yaml
@@ -19,7 +19,9 @@ spec:
   group: storage.azure.crossplane.io
   names:
     kind: AccountClass
+    listKind: AccountClassList
     plural: accountclasses
+    singular: accountclass
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/azure/storage.azure.crossplane.io_accounts.yaml
+++ b/cluster/charts/crossplane/crds/azure/storage.azure.crossplane.io_accounts.yaml
@@ -25,7 +25,9 @@ spec:
   group: storage.azure.crossplane.io
   names:
     kind: Account
+    listKind: AccountList
     plural: accounts
+    singular: account
   scope: ""
   subresources:
     status: {}

--- a/cluster/charts/crossplane/crds/azure/storage.azure.crossplane.io_containerclasses.yaml
+++ b/cluster/charts/crossplane/crds/azure/storage.azure.crossplane.io_containerclasses.yaml
@@ -19,7 +19,9 @@ spec:
   group: storage.azure.crossplane.io
   names:
     kind: ContainerClass
+    listKind: ContainerClassList
     plural: containerclasses
+    singular: containerclass
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/azure/storage.azure.crossplane.io_containers.yaml
+++ b/cluster/charts/crossplane/crds/azure/storage.azure.crossplane.io_containers.yaml
@@ -25,7 +25,9 @@ spec:
   group: storage.azure.crossplane.io
   names:
     kind: Container
+    listKind: ContainerList
     plural: containers
+    singular: container
   scope: ""
   subresources:
     status: {}

--- a/cluster/charts/crossplane/crds/cache.crossplane.io_redisclusterpolicies.yaml
+++ b/cluster/charts/crossplane/crds/cache.crossplane.io_redisclusterpolicies.yaml
@@ -9,7 +9,9 @@ spec:
   group: cache.crossplane.io
   names:
     kind: RedisClusterPolicy
+    listKind: RedisClusterPolicyList
     plural: redisclusterpolicies
+    singular: redisclusterpolicy
   scope: ""
   validation:
     openAPIV3Schema:

--- a/cluster/charts/crossplane/crds/cache.crossplane.io_redisclusters.yaml
+++ b/cluster/charts/crossplane/crds/cache.crossplane.io_redisclusters.yaml
@@ -22,7 +22,9 @@ spec:
   group: cache.crossplane.io
   names:
     kind: RedisCluster
+    listKind: RedisClusterList
     plural: redisclusters
+    singular: rediscluster
   scope: ""
   subresources:
     status: {}

--- a/cluster/charts/crossplane/crds/compute.crossplane.io_kubernetesclusterpolicies.yaml
+++ b/cluster/charts/crossplane/crds/compute.crossplane.io_kubernetesclusterpolicies.yaml
@@ -9,7 +9,9 @@ spec:
   group: compute.crossplane.io
   names:
     kind: KubernetesClusterPolicy
+    listKind: KubernetesClusterPolicyList
     plural: kubernetesclusterpolicies
+    singular: kubernetesclusterpolicy
   scope: ""
   validation:
     openAPIV3Schema:

--- a/cluster/charts/crossplane/crds/compute.crossplane.io_kubernetesclusters.yaml
+++ b/cluster/charts/crossplane/crds/compute.crossplane.io_kubernetesclusters.yaml
@@ -22,7 +22,9 @@ spec:
   group: compute.crossplane.io
   names:
     kind: KubernetesCluster
+    listKind: KubernetesClusterList
     plural: kubernetesclusters
+    singular: kubernetescluster
   scope: ""
   subresources:
     status: {}

--- a/cluster/charts/crossplane/crds/core.crossplane.io_resourceclasses.yaml
+++ b/cluster/charts/crossplane/crds/core.crossplane.io_resourceclasses.yaml
@@ -22,7 +22,9 @@ spec:
   group: core.crossplane.io
   names:
     kind: ResourceClass
+    listKind: ResourceClassList
     plural: resourceclasses
+    singular: resourceclass
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/database.crossplane.io_mysqlinstancepolicies.yaml
+++ b/cluster/charts/crossplane/crds/database.crossplane.io_mysqlinstancepolicies.yaml
@@ -9,7 +9,9 @@ spec:
   group: database.crossplane.io
   names:
     kind: MySQLInstancePolicy
+    listKind: MySQLInstancePolicyList
     plural: mysqlinstancepolicies
+    singular: mysqlinstancepolicy
   scope: ""
   validation:
     openAPIV3Schema:

--- a/cluster/charts/crossplane/crds/database.crossplane.io_mysqlinstances.yaml
+++ b/cluster/charts/crossplane/crds/database.crossplane.io_mysqlinstances.yaml
@@ -22,7 +22,9 @@ spec:
   group: database.crossplane.io
   names:
     kind: MySQLInstance
+    listKind: MySQLInstanceList
     plural: mysqlinstances
+    singular: mysqlinstance
   scope: ""
   subresources:
     status: {}

--- a/cluster/charts/crossplane/crds/database.crossplane.io_postgresqlinstancepolicies.yaml
+++ b/cluster/charts/crossplane/crds/database.crossplane.io_postgresqlinstancepolicies.yaml
@@ -9,7 +9,9 @@ spec:
   group: database.crossplane.io
   names:
     kind: PostgreSQLInstancePolicy
+    listKind: PostgreSQLInstancePolicyList
     plural: postgresqlinstancepolicies
+    singular: postgresqlinstancepolicy
   scope: ""
   validation:
     openAPIV3Schema:

--- a/cluster/charts/crossplane/crds/database.crossplane.io_postgresqlinstances.yaml
+++ b/cluster/charts/crossplane/crds/database.crossplane.io_postgresqlinstances.yaml
@@ -22,7 +22,9 @@ spec:
   group: database.crossplane.io
   names:
     kind: PostgreSQLInstance
+    listKind: PostgreSQLInstanceList
     plural: postgresqlinstances
+    singular: postgresqlinstance
   scope: ""
   subresources:
     status: {}

--- a/cluster/charts/crossplane/crds/gcp/cache.gcp.crossplane.io_cloudmemorystoreinstanceclasses.yaml
+++ b/cluster/charts/crossplane/crds/gcp/cache.gcp.crossplane.io_cloudmemorystoreinstanceclasses.yaml
@@ -19,7 +19,9 @@ spec:
   group: cache.gcp.crossplane.io
   names:
     kind: CloudMemorystoreInstanceClass
+    listKind: CloudMemorystoreInstanceClassList
     plural: cloudmemorystoreinstanceclasses
+    singular: cloudmemorystoreinstanceclass
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/gcp/cache.gcp.crossplane.io_cloudmemorystoreinstances.yaml
+++ b/cluster/charts/crossplane/crds/gcp/cache.gcp.crossplane.io_cloudmemorystoreinstances.yaml
@@ -22,7 +22,9 @@ spec:
   group: cache.gcp.crossplane.io
   names:
     kind: CloudMemorystoreInstance
+    listKind: CloudMemorystoreInstanceList
     plural: cloudmemorystoreinstances
+    singular: cloudmemorystoreinstance
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/gcp/compute.gcp.crossplane.io_gkeclusterclasses.yaml
+++ b/cluster/charts/crossplane/crds/gcp/compute.gcp.crossplane.io_gkeclusterclasses.yaml
@@ -19,7 +19,9 @@ spec:
   group: compute.gcp.crossplane.io
   names:
     kind: GKEClusterClass
+    listKind: GKEClusterClassList
     plural: gkeclusterclasses
+    singular: gkeclusterclass
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/gcp/compute.gcp.crossplane.io_gkeclusters.yaml
+++ b/cluster/charts/crossplane/crds/gcp/compute.gcp.crossplane.io_gkeclusters.yaml
@@ -34,7 +34,9 @@ spec:
   group: compute.gcp.crossplane.io
   names:
     kind: GKECluster
+    listKind: GKEClusterList
     plural: gkeclusters
+    singular: gkecluster
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/gcp/database.gcp.crossplane.io_cloudsqlinstanceclasses.yaml
+++ b/cluster/charts/crossplane/crds/gcp/database.gcp.crossplane.io_cloudsqlinstanceclasses.yaml
@@ -19,7 +19,9 @@ spec:
   group: database.gcp.crossplane.io
   names:
     kind: CloudsqlInstanceClass
+    listKind: CloudsqlInstanceClassList
     plural: cloudsqlinstanceclasses
+    singular: cloudsqlinstanceclass
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/gcp/database.gcp.crossplane.io_cloudsqlinstances.yaml
+++ b/cluster/charts/crossplane/crds/gcp/database.gcp.crossplane.io_cloudsqlinstances.yaml
@@ -25,7 +25,9 @@ spec:
   group: database.gcp.crossplane.io
   names:
     kind: CloudsqlInstance
+    listKind: CloudsqlInstanceList
     plural: cloudsqlinstances
+    singular: cloudsqlinstance
   scope: ""
   subresources:
     status: {}

--- a/cluster/charts/crossplane/crds/gcp/gcp.crossplane.io_providers.yaml
+++ b/cluster/charts/crossplane/crds/gcp/gcp.crossplane.io_providers.yaml
@@ -20,7 +20,9 @@ spec:
   group: gcp.crossplane.io
   names:
     kind: Provider
+    listKind: ProviderList
     plural: providers
+    singular: provider
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/gcp/storage.gcp.crossplane.io_bucketclasses.yaml
+++ b/cluster/charts/crossplane/crds/gcp/storage.gcp.crossplane.io_bucketclasses.yaml
@@ -19,7 +19,9 @@ spec:
   group: storage.gcp.crossplane.io
   names:
     kind: BucketClass
+    listKind: BucketClassList
     plural: bucketclasses
+    singular: bucketclass
   scope: ""
   subresources: {}
   validation:

--- a/cluster/charts/crossplane/crds/gcp/storage.gcp.crossplane.io_buckets.yaml
+++ b/cluster/charts/crossplane/crds/gcp/storage.gcp.crossplane.io_buckets.yaml
@@ -25,7 +25,9 @@ spec:
   group: storage.gcp.crossplane.io
   names:
     kind: Bucket
+    listKind: BucketList
     plural: buckets
+    singular: bucket
   scope: ""
   subresources:
     status: {}

--- a/cluster/charts/crossplane/crds/stacks.crossplane.io_stackrequests.yaml
+++ b/cluster/charts/crossplane/crds/stacks.crossplane.io_stackrequests.yaml
@@ -25,7 +25,9 @@ spec:
   group: stacks.crossplane.io
   names:
     kind: StackRequest
+    listKind: StackRequestList
     plural: stackrequests
+    singular: stackrequest
   scope: ""
   subresources:
     status: {}

--- a/cluster/charts/crossplane/crds/stacks.crossplane.io_stacks.yaml
+++ b/cluster/charts/crossplane/crds/stacks.crossplane.io_stacks.yaml
@@ -19,7 +19,9 @@ spec:
   group: stacks.crossplane.io
   names:
     kind: Stack
+    listKind: StackList
     plural: stacks
+    singular: stack
   scope: ""
   subresources:
     status: {}

--- a/cluster/charts/crossplane/crds/storage.crossplane.io_bucketpolicies.yaml
+++ b/cluster/charts/crossplane/crds/storage.crossplane.io_bucketpolicies.yaml
@@ -9,7 +9,9 @@ spec:
   group: storage.crossplane.io
   names:
     kind: BucketPolicy
+    listKind: BucketPolicyList
     plural: bucketpolicies
+    singular: bucketpolicy
   scope: ""
   validation:
     openAPIV3Schema:

--- a/cluster/charts/crossplane/crds/storage.crossplane.io_buckets.yaml
+++ b/cluster/charts/crossplane/crds/storage.crossplane.io_buckets.yaml
@@ -25,7 +25,9 @@ spec:
   group: storage.crossplane.io
   names:
     kind: Bucket
+    listKind: BucketList
     plural: buckets
+    singular: bucket
   scope: ""
   subresources:
     status: {}


### PR DESCRIPTION
### Description of your changes
https://github.com/kubernetes-sigs/controller-tools/issues/301 issue is fixed by https://github.com/kubernetes-sigs/controller-tools/pull/303 , so we don't need to use our own fork anymore. We're going with the latest commit on master since there hasn't been a release that includes the fix yet.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml