### PR TITLE
aws: clean-up AWS CRDs with the latest controller-tools

### DIFF
--- a/cluster/charts/crossplane/crds/aws/identity.aws.crossplane.io_iamrolepolicyattachments.yaml
+++ b/cluster/charts/crossplane/crds/aws/identity.aws.crossplane.io_iamrolepolicyattachments.yaml
@@ -25,7 +25,9 @@ spec:
   group: identity.aws.crossplane.io
   names:
     kind: IAMRolePolicyAttachment
+    listKind: IAMRolePolicyAttachmentList
     plural: iamrolepolicyattachments
+    singular: iamrolepolicyattachment
   scope: ""
   subresources:
     status: {}

--- a/cluster/charts/crossplane/crds/aws/identity.aws.crossplane.io_iamroles.yaml
+++ b/cluster/charts/crossplane/crds/aws/identity.aws.crossplane.io_iamroles.yaml
@@ -25,7 +25,9 @@ spec:
   group: identity.aws.crossplane.io
   names:
     kind: IAMRole
+    listKind: IAMRoleList
     plural: iamroles
+    singular: iamrole
   scope: ""
   subresources:
     status: {}
@@ -196,10 +198,6 @@ spec:
                 IAM Identifiers (http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
                 in the IAM User Guide guide.
               type: string
-            assumeRolePolicyDocument:
-              description: AssumeRolePolicyDocument is the policy that grants an entity
-                permission to assume the role.
-              type: string
             bindingPhase:
               description: Phase represents the binding phase of the resource.
               enum:
@@ -245,14 +243,9 @@ spec:
                 role. For more information about IDs, see IAM Identifiers (http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)
                 in the Using IAM guide.
               type: string
-            roleName:
-              description: RoleName is the friendly name that identifies the role.
-              type: string
           required:
           - arn
-          - assumeRolePolicyDocument
           - roleID
-          - roleName
           type: object
       type: object
   version: v1alpha1

--- a/cluster/charts/crossplane/crds/aws/network.aws.crossplane.io_internetgateways.yaml
+++ b/cluster/charts/crossplane/crds/aws/network.aws.crossplane.io_internetgateways.yaml
@@ -25,7 +25,9 @@ spec:
   group: network.aws.crossplane.io
   names:
     kind: InternetGateway
+    listKind: InternetGatewayList
     plural: internetgateways
+    singular: internetgateway
   scope: ""
   subresources:
     status: {}

--- a/cluster/charts/crossplane/crds/aws/network.aws.crossplane.io_routetables.yaml
+++ b/cluster/charts/crossplane/crds/aws/network.aws.crossplane.io_routetables.yaml
@@ -22,7 +22,9 @@ spec:
   group: network.aws.crossplane.io
   names:
     kind: RouteTable
+    listKind: RouteTableList
     plural: routetables
+    singular: routetable
   scope: ""
   subresources:
     status: {}

--- a/cluster/charts/crossplane/crds/aws/network.aws.crossplane.io_securitygroups.yaml
+++ b/cluster/charts/crossplane/crds/aws/network.aws.crossplane.io_securitygroups.yaml
@@ -28,7 +28,9 @@ spec:
   group: network.aws.crossplane.io
   names:
     kind: SecurityGroup
+    listKind: SecurityGroupList
     plural: securitygroups
+    singular: securitygroup
   scope: ""
   subresources:
     status: {}

--- a/cluster/charts/crossplane/crds/aws/network.aws.crossplane.io_subnets.yaml
+++ b/cluster/charts/crossplane/crds/aws/network.aws.crossplane.io_subnets.yaml
@@ -34,7 +34,9 @@ spec:
   group: network.aws.crossplane.io
   names:
     kind: Subnet
+    listKind: SubnetList
     plural: subnets
+    singular: subnet
   scope: ""
   subresources:
     status: {}

--- a/cluster/charts/crossplane/crds/aws/network.aws.crossplane.io_vpcs.yaml
+++ b/cluster/charts/crossplane/crds/aws/network.aws.crossplane.io_vpcs.yaml
@@ -28,7 +28,9 @@ spec:
   group: network.aws.crossplane.io
   names:
     kind: VPC
+    listKind: VPCList
     plural: vpcs
+    singular: vpc
   scope: ""
   subresources:
     status: {}

--- a/cluster/charts/crossplane/crds/aws/storage.aws.crossplane.io_dbsubnetgroups.yaml
+++ b/cluster/charts/crossplane/crds/aws/storage.aws.crossplane.io_dbsubnetgroups.yaml
@@ -28,7 +28,9 @@ spec:
   group: storage.aws.crossplane.io
   names:
     kind: DBSubnetGroup
+    listKind: DBSubnetGroupList
     plural: dbsubnetgroups
+    singular: dbsubnetgroup
   scope: ""
   subresources:
     status: {}


### PR DESCRIPTION
### Description of your changes

This PR is simply the output of running `make reviewable` on the latest in master. Perhaps the AWS CRDs did not get the latest controller-tools run on them before they made it to master.

### Checklist

I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml