### PR TITLE
Disable GCP API authentication when testing

### DIFF
--- a/pkg/controller/gcp/compute/network_test.go
+++ b/pkg/controller/gcp/compute/network_test.go
@@ -25,8 +25,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
 	v1 "k8s.io/api/core/v1"
@@ -56,7 +54,7 @@ const testGCPCredentialsJSON = `
   "project_id": "fake-project",
   "private_key_id": "fake-id",
   "private_key": "-----BEGIN PRIVATE KEY-----\nIAMAFAKEPRIVATEKEY-----END PRIVATE KEY-----\n",
-  "client_email": "crossplane-test@crossplane-playground.iam.gserviceaccount.com",
+  "client_email": "crossplane-test@fake-project.iam.gserviceaccount.com",
   "client_id": "123456789",
   "auth_uri": "https://accounts.google.com/o/oauth2/auth",
   "token_uri": "https://oauth2.googleapis.com/token",
@@ -65,10 +63,6 @@ const testGCPCredentialsJSON = `
 }
 
 `
-
-var fakeGoogleCredentials = google.Credentials{
-	TokenSource: oauth2.StaticTokenSource(&oauth2.Token{}),
-}
 
 func TestNetworkConnector_Connect(t *testing.T) {
 	type args struct {
@@ -347,7 +341,7 @@ func TestNetworkExternal_Observe(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
-			s, _ := compute.NewService(context.Background(), option.WithEndpoint(server.URL), option.WithCredentials(&fakeGoogleCredentials))
+			s, _ := compute.NewService(context.Background(), option.WithEndpoint(server.URL), option.WithoutAuthentication())
 			e := networkExternal{
 				projectID: testGoogleProjectID,
 				Service:   s,
@@ -437,7 +431,7 @@ func TestNetworkExternal_Create(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
-			s, _ := compute.NewService(context.Background(), option.WithEndpoint(server.URL), option.WithCredentials(&fakeGoogleCredentials))
+			s, _ := compute.NewService(context.Background(), option.WithEndpoint(server.URL), option.WithoutAuthentication())
 			e := networkExternal{
 				projectID: testGoogleProjectID,
 				Service:   s,
@@ -569,7 +563,7 @@ func TestNetworkExternal_Update(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
-			s, _ := compute.NewService(context.Background(), option.WithEndpoint(server.URL), option.WithCredentials(&fakeGoogleCredentials))
+			s, _ := compute.NewService(context.Background(), option.WithEndpoint(server.URL), option.WithoutAuthentication())
 			e := networkExternal{
 				projectID: testGoogleProjectID,
 				Service:   s,
@@ -656,7 +650,7 @@ func TestNetworkExternal_Delete(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
-			s, _ := compute.NewService(context.Background(), option.WithEndpoint(server.URL), option.WithCredentials(&fakeGoogleCredentials))
+			s, _ := compute.NewService(context.Background(), option.WithEndpoint(server.URL), option.WithoutAuthentication())
 			e := networkExternal{
 				projectID: testGoogleProjectID,
 				Service:   s,

--- a/pkg/controller/gcp/compute/subnetwork_test.go
+++ b/pkg/controller/gcp/compute/subnetwork_test.go
@@ -346,7 +346,7 @@ func TestSubsubnetworkExternal_Observe(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
-			s, _ := compute.NewService(context.Background(), option.WithEndpoint(server.URL), option.WithCredentials(&fakeGoogleCredentials))
+			s, _ := compute.NewService(context.Background(), option.WithEndpoint(server.URL), option.WithoutAuthentication())
 			e := subnetworkExternal{
 				projectID: testGoogleProjectID,
 				Service:   s,
@@ -431,7 +431,7 @@ func TestSubsubnetworkExternal_Create(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
-			s, _ := compute.NewService(context.Background(), option.WithEndpoint(server.URL), option.WithCredentials(&fakeGoogleCredentials))
+			s, _ := compute.NewService(context.Background(), option.WithEndpoint(server.URL), option.WithoutAuthentication())
 			e := subnetworkExternal{
 				projectID: testGoogleProjectID,
 				Service:   s,
@@ -513,7 +513,7 @@ func TestSubsubnetworkExternal_Update(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
-			s, _ := compute.NewService(context.Background(), option.WithEndpoint(server.URL), option.WithCredentials(&fakeGoogleCredentials))
+			s, _ := compute.NewService(context.Background(), option.WithEndpoint(server.URL), option.WithoutAuthentication())
 			e := subnetworkExternal{
 				projectID: testGoogleProjectID,
 				Service:   s,
@@ -601,7 +601,7 @@ func TestSubsubnetworkExternal_Delete(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			server := httptest.NewServer(tc.handler)
 			defer server.Close()
-			s, _ := compute.NewService(context.Background(), option.WithEndpoint(server.URL), option.WithCredentials(&fakeGoogleCredentials))
+			s, _ := compute.NewService(context.Background(), option.WithEndpoint(server.URL), option.WithoutAuthentication())
 			e := subnetworkExternal{
 				projectID: testGoogleProjectID,
 				Service:   s,

--- a/pkg/controller/gcp/servicenetworking/connection_test.go
+++ b/pkg/controller/gcp/servicenetworking/connection_test.go
@@ -547,7 +547,9 @@ func (s FakeComputeService) Serve(t *testing.T) *compute.Service {
 		_ = json.NewEncoder(w).Encode(&compute.Operation{})
 	}))
 
-	c, err := compute.NewService(context.Background(), option.WithEndpoint(srv.URL))
+	c, err := compute.NewService(context.Background(),
+		option.WithEndpoint(srv.URL),
+		option.WithoutAuthentication())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -590,7 +592,9 @@ func (s FakeServiceNetworkingService) Serve(t *testing.T) *servicenetworking.API
 		_ = json.NewEncoder(w).Encode(s.Return)
 	}))
 
-	c, err := servicenetworking.NewService(context.Background(), option.WithEndpoint(srv.URL))
+	c, err := servicenetworking.NewService(context.Background(),
+		option.WithEndpoint(srv.URL),
+		option.WithoutAuthentication())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Previously we were either providing fake credentials, or falling back to using
the test environment's Application Default Credentials if they were set.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml