### PR TITLE
stackinstall: fix panic logging about updates being unsupported

### DIFF
--- a/pkg/controller/stacks/install/stackinstall.go
+++ b/pkg/controller/stacks/install/stackinstall.go
@@ -19,6 +19,7 @@ package install
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -231,7 +232,8 @@ func (h *stackInstallHandler) update(ctx context.Context) (reconcile.Result, err
 	// TODO: should updates of the StackInstall be supported? what would that even mean, they
 	// changed the package they wanted installed? Shouldn't they delete the StackInstall and
 	// create a new one?
-	log.V(logging.Debug).Info("updating not supported yet", h.ext.GroupVersionKind(), fmt.Sprintf("%s/%s", h.ext.GetNamespace(), h.ext.GetName()))
+	groupversion, kind := h.ext.GroupVersionKind().ToAPIVersionAndKind()
+	log.V(logging.Debug).Info("updating not supported yet", strings.ToLower(kind)+"."+groupversion, fmt.Sprintf("%s/%s", h.ext.GetNamespace(), h.ext.GetName()))
 	return reconcile.Result{}, nil
 }
 


### PR DESCRIPTION
Fix a panic logging about `StackInstall`/`ClusterStackInstall` updates being unsupported.

Before:
```
2019-09-13T19:49:23.364Z        DPANIC  crossplane.stackinstall.stacks.crossplane.io    non-string key argument passed to logging, ignoring all later arguments {"invalid key": "stacks.crossplane.io/v1alpha1, Kind=ClusterStackInstall"}
￼
```

After:
```
2019-09-13T20:25:36.464Z        DEBUG   crossplane.stackinstall.stacks.crossplane.io    updating not supported yet      {"clusterstackinstall.stacks.crossplane.io/v1alpha1": "gcp/stack-gcp"}
```
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml