### PR TITLE
stacks: RBAC policy rules should not have any version information

### DIFF
--- a/pkg/stacks/unpack_test.go
+++ b/pkg/stacks/unpack_test.go
@@ -200,19 +200,19 @@ spec:
       verbs:
       - '*'
     - apiGroups:
-      - samples.upbound.io/v1alpha1
+      - samples.upbound.io
       resources:
       - mytypes
       verbs:
       - '*'
     - apiGroups:
-      - mystack.example.org/v1alpha1
+      - mystack.example.org
       resources:
       - foo
       verbs:
       - '*'
     - apiGroups:
-      - yourstack.example.org/v1alpha2
+      - yourstack.example.org
       resources:
       - '*'
       verbs:
@@ -454,37 +454,37 @@ spec:
       verbs:
       - '*'
     - apiGroups:
-      - samples.upbound.io/v1alpha1
+      - samples.upbound.io
       resources:
       - siblings
       verbs:
       - '*'
     - apiGroups:
-      - samples.upbound.io/v1alpha1
+      - samples.upbound.io
       resources:
       - secondcousins
       verbs:
       - '*'
     - apiGroups:
-      - samples.upbound.io/v1alpha1
+      - samples.upbound.io
       resources:
       - mytypes
       verbs:
       - '*'
     - apiGroups:
-      - samples.upbound.io/v1alpha1
+      - samples.upbound.io
       resources:
       - cousins
       verbs:
       - '*'
     - apiGroups:
-      - mystack.example.org/v1alpha1
+      - mystack.example.org
       resources:
       - foo
       verbs:
       - '*'
     - apiGroups:
-      - yourstack.example.org/v1alpha2
+      - yourstack.example.org
       resources:
       - '*'
       verbs:
@@ -726,37 +726,37 @@ spec:
       verbs:
       - '*'
     - apiGroups:
-      - samples.upbound.io/v1alpha1
+      - samples.upbound.io
       resources:
       - siblings
       verbs:
       - '*'
     - apiGroups:
-      - samples.upbound.io/v1alpha1
+      - samples.upbound.io
       resources:
       - secondcousins
       verbs:
       - '*'
     - apiGroups:
-      - samples.upbound.io/v1alpha1
+      - samples.upbound.io
       resources:
       - mytypes
       verbs:
       - '*'
     - apiGroups:
-      - samples.upbound.io/v1alpha1
+      - samples.upbound.io
       resources:
       - cousins
       verbs:
       - '*'
     - apiGroups:
-      - mystack.example.org/v1alpha1
+      - mystack.example.org
       resources:
       - foo
       verbs:
       - '*'
     - apiGroups:
-      - yourstack.example.org/v1alpha2
+      - yourstack.example.org
       resources:
       - '*'
       verbs:
@@ -865,19 +865,19 @@ spec:
       verbs:
       - '*'
     - apiGroups:
-      - samples.upbound.io/v1alpha1
+      - samples.upbound.io
       resources:
       - mytypes
       verbs:
       - '*'
     - apiGroups:
-      - mystack.example.org/v1alpha1
+      - mystack.example.org
       resources:
       - foo
       verbs:
       - '*'
     - apiGroups:
-      - yourstack.example.org/v1alpha2
+      - yourstack.example.org
       resources:
       - '*'
       verbs:


### PR DESCRIPTION
### Description of your changes
This PR ensures that no version information goes into the RBAC policy rules that the Stack Manager creates.  Those rules should not have any version information and will not work if versions are included.

This was tested end to end with the Wordpress stack (with updates from https://github.com/crossplaneio/sample-stack-wordpress/pull/12).

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml