### PR TITLE
fix typo in stacks design doc, correct permissionScope value is Namespaced

### DIFF
--- a/design/design-doc-stacks.md
+++ b/design/design-doc-stacks.md
@@ -307,7 +307,7 @@ license: Apache-2.0
 # current supported values are:
 #
 # - Cluster
-# - Namespace
+# - Namespaced
 permissionScope: Cluster
 
 # Dependent CRDs will be coupled with Owned CRDs and core resources to produce


### PR DESCRIPTION
### Description of your changes

Small typo fix to clarify the stacks design doc that `Namespaced` is the correct allowed value for `permissionScope`

Fixes #797 

### Checklist
I have:
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml

[skip ci]