### PR TITLE
stacks: owned subresources should have generated rbac roles

### DIFF
--- a/pkg/stacks/unpack_test.go
+++ b/pkg/stacks/unpack_test.go
@@ -291,6 +291,11 @@ spec:
     plural: secondcousins
     singular: secondcousin
   scope: Namespaced
+  subresources:
+    scale:
+      specReplicasPath: ""
+      statusReplicasPath: ""
+    status: {}
   version: v1alpha1
 status:
   acceptedNames:
@@ -477,6 +482,8 @@ spec:
       - samples.upbound.io
       resources:
       - secondcousins
+      - secondcousins/status
+      - secondcousins/scale
       verbs:
       - '*'
     - apiGroups:
@@ -573,6 +580,11 @@ spec:
     plural: secondcousins
     singular: secondcousin
   scope: Namespaced
+  subresources:
+    scale:
+      specReplicasPath: ""
+      statusReplicasPath: ""
+    status: {}
   version: v1alpha1
 status:
   acceptedNames:
@@ -759,6 +771,8 @@ spec:
       - samples.upbound.io
       resources:
       - secondcousins
+      - secondcousins/status
+      - secondcousins/scale
       verbs:
       - '*'
     - apiGroups:
@@ -996,6 +1010,28 @@ spec:
 `, plural, title, title, plural, singular)
 }
 
+func subresourceCRDFile(singular string) string {
+	title := strings.Title(singular)
+	plural := singular + "s"
+	return fmt.Sprintf(`apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: %s.samples.upbound.io
+spec:
+  group: samples.upbound.io
+  names:
+    kind: %s
+    listKind: %sList
+    plural: %s
+    singular: %s
+  scope: Namespaced
+  subresources:
+    status: {}
+    scale: {}
+  version: v1alpha1
+`, plural, title, title, plural, singular)
+}
+
 func simpleUIFile(name string) string {
 	return fmt.Sprintf(`uiSpecVersion: 0.3
 uiSpec:
@@ -1077,7 +1113,7 @@ func TestUnpack(t *testing.T) {
 				afero.WriteFile(fs, filepath.Join(crdDir, "mytype.v1alpha1.crd.yaml"), []byte(simpleCRDFile("mytype")), 0644)
 				afero.WriteFile(fs, filepath.Join(crdDir, "sibling.v1alpha1.crd.yaml"), []byte(simpleCRDFile("sibling")), 0644)
 				afero.WriteFile(fs, filepath.Join(crdDir2, "cousin.v1alpha1.crd.yaml"), []byte(simpleCRDFile("cousin")), 0644)
-				afero.WriteFile(fs, filepath.Join(crdDir3, "secondcousin.v1alpha1.crd.yaml"), []byte(simpleCRDFile("secondcousin")), 0644)
+				afero.WriteFile(fs, filepath.Join(crdDir3, "secondcousin.v1alpha1.crd.yaml"), []byte(subresourceCRDFile("secondcousin")), 0644)
 				return fs
 			}(),
 			root: "ext-dir",
@@ -1164,7 +1200,7 @@ func TestUnpack_cluster(t *testing.T) {
 				afero.WriteFile(fs, filepath.Join(crdDir, "mytype.v1alpha1.crd.yaml"), []byte(simpleCRDFile("mytype")), 0644)
 				afero.WriteFile(fs, filepath.Join(crdDir, "sibling.v1alpha1.crd.yaml"), []byte(simpleCRDFile("sibling")), 0644)
 				afero.WriteFile(fs, filepath.Join(crdDir2, "cousin.v1alpha1.crd.yaml"), []byte(simpleCRDFile("cousin")), 0644)
-				afero.WriteFile(fs, filepath.Join(crdDir3, "secondcousin.v1alpha1.crd.yaml"), []byte(simpleCRDFile("secondcousin")), 0644)
+				afero.WriteFile(fs, filepath.Join(crdDir3, "secondcousin.v1alpha1.crd.yaml"), []byte(subresourceCRDFile("secondcousin")), 0644)
 				return fs
 			}(),
 			root: "ext-dir",


### PR DESCRIPTION
CRDs may define [two specific sub-resources](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#subresources), `scale` and `status`.

If a CRD owned by a stack includes one of these sub-resources, the
stack-manager processing must create a service account that receives roles
to access those sub-resources.

Closes #799


<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml