### PR TITLE
Requeue a speculative reconcile of KubernetesApplicationResources

### DIFF
--- a/pkg/controller/workload/kubernetes/resource/resource.go
+++ b/pkg/controller/workload/kubernetes/resource/resource.go
@@ -49,6 +49,9 @@ const (
 	controllerName   = "kubernetesapplicationresource." + v1alpha1.Group
 	finalizerName    = "finalizer." + controllerName
 	reconcileTimeout = 1 * time.Minute
+
+	// The time we wait before requeueing a speculative reconcile.
+	aLongWait = 1 * time.Minute
 )
 
 var errMissingTemplate = errors.New(v1alpha1.KubernetesApplicationResourceKind + " must include a template")
@@ -200,7 +203,7 @@ func (c *remoteCluster) sync(ctx context.Context, ar *v1alpha1.KubernetesApplica
 
 	ar.Status.SetConditions(runtimev1alpha1.ReconcileSuccess())
 	ar.Status.State = v1alpha1.KubernetesApplicationResourceStateSubmitted
-	return reconcile.Result{Requeue: false}
+	return reconcile.Result{RequeueAfter: aLongWait}
 }
 
 func (c *remoteCluster) delete(ctx context.Context, ar *v1alpha1.KubernetesApplicationResource, secrets []corev1.Secret) reconcile.Result {

--- a/pkg/controller/workload/kubernetes/resource/resource_test.go
+++ b/pkg/controller/workload/kubernetes/resource/resource_test.go
@@ -421,7 +421,7 @@ func TestSync(t *testing.T) {
 				withState(v1alpha1.KubernetesApplicationResourceStateSubmitted),
 				withRemoteStatus(remoteStatus),
 			),
-			wantResult: reconcile.Result{Requeue: false},
+			wantResult: reconcile.Result{RequeueAfter: aLongWait},
 		},
 		{
 			name:   "MissingTemplate",
@@ -469,7 +469,7 @@ func TestSync(t *testing.T) {
 				withState(v1alpha1.KubernetesApplicationResourceStateSubmitted),
 				withRemoteStatus(remoteStatus),
 			),
-			wantResult: reconcile.Result{Requeue: false},
+			wantResult: reconcile.Result{RequeueAfter: aLongWait},
 		},
 		{
 			name: "SecretSyncFailed",


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #810

Previously we never requeued, which means we'd never reflect the remote status of our external resources once submitted unless the KAR was changed.


### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml