### PR TITLE
stacks: fixes for unpacking stacks

### DIFF
--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -109,7 +109,7 @@ func main() {
 
 		// TODO(displague) afero.NewBasePathFs could avoid the need to track Base
 		fs := afero.NewOsFs()
-		rd := &walker.ResourceDir{Base: *extUnpackDir, Walker: afero.Afero{Fs: fs}}
+		rd := &walker.ResourceDir{Base: filepath.Clean(*extUnpackDir), Walker: afero.Afero{Fs: fs}}
 		kingpin.FatalIfError(stacks.Unpack(rd, outFile, rd.Base, *extUnpackPermissionScope), "failed to unpack stacks")
 		return
 	default:

--- a/pkg/controller/stacks/install/installjob.go
+++ b/pkg/controller/stacks/install/installjob.go
@@ -19,7 +19,9 @@ package install
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -88,7 +90,12 @@ func createInstallJob(i v1alpha1.StackInstaller, executorInfo *stacks.ExecutorIn
 							// "--debug" can be added to this list of Args to get debug output from the job,
 							// but note that will be included in the stdout from the pod, which makes it
 							// impossible to create the resources that the job unpacks.
-							Args: []string{"stack", "unpack", "--content-dir=/ext-pkg", "--permission-scope=" + i.PermissionScope()},
+							Args: []string{
+								"stack",
+								"unpack",
+								fmt.Sprintf("--content-dir=%s", filepath.Join("/ext-pkg", registryDirName)),
+								"--permission-scope=" + i.PermissionScope(),
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      packageContentsVolumeName,

--- a/pkg/stacks/unpack.go
+++ b/pkg/stacks/unpack.go
@@ -413,7 +413,7 @@ func NewStackPackage(baseDir string) *StackPackage {
 func Unpack(rw walker.ResourceWalker, out io.StringWriter, baseDir string, permissionScope string) error {
 	log.V(logging.Debug).Info("Unpacking stack")
 
-	sp := NewStackPackage(baseDir)
+	sp := NewStackPackage(filepath.Clean(baseDir))
 
 	rw.AddStep(appFileName, appStep(sp))
 


### PR DESCRIPTION
### Description of your changes

This commit ensures that the unpacking process starts with a base
dir that includes the .registry folder.  This matters now since
we look for top level icons only in the base dir, so knowing the
right base dir is important.

The troubleshooting ability of the stack manager is also increased
by adding the path to error messages when we fail to parse a
resource.

Finally, we also use filepath.Clean() to ensure that the path being
passed in as the base dir is always clean and normalized.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml