### PR TITLE
Stacks guides: Fix and polish pass

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -156,10 +156,10 @@ Use [stack-gcp][stack-gcp], [stack-aws][stack-aws], and [stack-azure][stack-azur
 [services-user-guide]: services-guide.md
 [stack-user-guide]: stacks-guide.md
 [stack-developer-guide]: developer-guide.md
-[stack-manager]: https://github.com/crossplaneio/crossplane/blob/master/design/design-doc-stacks.md#terminology
+[stacks-manager]: https://github.com/crossplaneio/crossplane/blob/master/design/design-doc-stacks.md#terminology
 [crossplane-cli]: https://github.com/crossplaneio/crossplane-cli
 [crossplane-cli-usage]: https://github.com/crossplaneio/crossplane-cli#usage
-[stack-sercurity-design]: https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-stacks-security-isolation.md
+[stack-security-design]: https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-stacks-security-isolation.md
 
 [stack-wordpress-registry]: https://hub.docker.com/r/crossplane/sample-stack-wordpress
 [stack-wordpress]: https://github.com/crossplaneio/sample-stack-wordpress

--- a/docs/stacks-guide-aws.md
+++ b/docs/stacks-guide-aws.md
@@ -17,6 +17,7 @@ indent: true
   1. [Set Up Network Configuration](#set-up-network-configuration)
   1. [Configure Provider Resources](#configure-provider-resources)
   1. [Recap](#recap)
+  1. [Next Steps](#next-steps)
 
 ## Introduction
 
@@ -31,6 +32,7 @@ Before we begin, you will need:
   - A `kubectl` pointing to a Crossplane control cluster
   - The [Crossplane CLI][crossplane-cli] installed
 * An account on [AWS][aws]
+* The [aws cli][installed]
 
 At the end, we will have:
 
@@ -80,16 +82,16 @@ namespace.
 
 ## Configure the AWS account
 
-An [aws user] with `Administrative` privileges is needed to enable Crossplane to
-create the required resources. Once the user is provisioned, an [Access Key]
+An [aws user][] with `Administrative` privileges is needed to enable Crossplane to
+create the required resources. Once the user is provisioned, an [Access Key][]
 needs to be created to enable the user to have API access. Next, using these set
-of access key credentials, one needs to have [`aws` command line tool]
-[installed] and [configured]. Then, the credentials and configuration will
+of access key credentials, one needs to have [`aws` command line tool][]
+[installed][] and [configured][]. Then, the credentials and configuration will
 reside in `~/.aws/credentials` and `~/.aws/config` respectively, which will be
 consumed in the next step.
 
 When configuring aws CLI, it is recommended that the user credentials are
-configured under a specific [aws named profile] other than `default`. In this
+configured under a specific [aws named profile][] other than `default`. In this
 guide we are assuming that the credentials are configured under
 `crossplane-user` profile, but you can use other profiles as well. Let's store
 the profile name in `aws_profile` variable to use later:
@@ -102,7 +104,7 @@ aws_profile=crossplane-user
 
 Crossplane uses the aws user credentials that was configured in the previous
 step, to create resources in AWS. These credentials will be stored as a
-[secret], and is managed them by an  [`aws provider`] instance. In addition to
+[secret][], and is managed them by an  [`aws provider`][] instance. In addition to
 the credentials, the AWS region is also read from the configuration to target a
 specific region.
 
@@ -117,7 +119,7 @@ AWS_REGION=$(awk '/["$aws_profile"]/ {getline; print $3}' ${HOME}/.aws/config)
 ```
 
 At this point, the region and the encoded credentials are stored in respective
- variables. Next, we'll need to create an instance of [`aws provider`]:
+ variables. Next, we'll need to create an instance of [`aws provider`][]:
 
 ```bash
 cat > provider.yaml <<EOF
@@ -162,7 +164,7 @@ they both need to live within the same VPC. However VPC is not the only AWS
 resource that needs to be created to enable inter-resource connectivity. In
 general, a **Network Configuration**, which is built of a set of VPCs, Subnets,
 Security Groups, Route Tables, IAM Roles and other resources, is required for
-this purpose. For more information, see [AWS resource connectivity] design
+this purpose. For more information, see [AWS resource connectivity][] design
 document.
 
 In this section we will build a simple network configuration, by creating AWS
@@ -201,8 +203,7 @@ creating these resources:
   dependent resources that require those attribute.
 
 The rest of this section creates the resources for a configuration described in
-[the EKS user
-guide](https://docs.aws.amazon.com/eks/latest/userguide/create-public-private-vpc.html).
+[the EKS user guide][eks-user-guide].
 For grouping all these resources together we will use a `CONFIG_NAME` variable,
 which will be prepended to the names of these resources in Crossplane, and their
 corresponding external resources in AWS. Keep in mind that if you create
@@ -217,7 +218,7 @@ CONFIG_NAME=aws-network-config
 
 ### VPC
 
-A [Virtual Private Network] or VPC is a virtual network in AWS.
+A [Virtual Private Network][] or VPC is a virtual network in AWS.
 
 ```bash
 # build vpc yaml
@@ -379,7 +380,7 @@ SUBNET3_ID=$(kubectl get -f "subnets.yaml" -o=jsonpath='{.items[2].status.subnet
 
 ### Internet Gateway
 
-An [Internet Gateway] enables the resources in the VPC to have access to the
+An [Internet Gateway][] enables the resources in the VPC to have access to the
 Internet. Since the WordPress application will be addressed from the internet,
 this resource is required in the network configuration.
 
@@ -419,7 +420,7 @@ IG_ID=$(kubectl get -f "internetgateway.yaml" -o=jsonpath='{.status.internetGate
 
 ### Route Table
 
-A [Route Table] sets rules to direct traffic in a virtual network. We use a
+A [Route Table][] sets rules to direct traffic in a virtual network. We use a
 Route Table to redirect internet traffic from all Subnets to the Internet
 Gateway instance that we created in previous step.
 
@@ -460,7 +461,7 @@ routetable.network.aws.crossplane.io/aws-network-config-routetable condition met
 
 ### Cluster Security Group
 
-A [Security Group] is created to later to be assigned to the EKS cluster. This
+A [Security Group][] is created to later to be assigned to the EKS cluster. This
 security group enables the cluster to communicate with the worker nodes
 
 ```bash
@@ -501,7 +502,7 @@ CLUSTER_SECURITY_GROUP_ID=$(kubectl get -f "cluster_sg.yaml" -o=jsonpath='{.stat
 
 ### Database Security Group
 
-A [Security Group] is created to later to be assigned to the RDS database
+A [Security Group][] is created to later to be assigned to the RDS database
 instance. This security group enables the database instance to accept traffic
 from the internet in a certain port.
 
@@ -550,7 +551,7 @@ RDS_SECURITY_GROUP_ID=$(kubectl get -f "rds_sg.yaml" -o=jsonpath='{.status.secur
 
 ### Database Subnet Group
 
-A [Database Subnet Group] creates a group of Subnets which can communicate with
+A [Database Subnet Group][] creates a group of Subnets which can communicate with
 an RDS database instance.
 
 ```bash
@@ -597,7 +598,7 @@ RDS_SUBNET_GROUP_NAME=$(kubectl get -f "dbsubnetgroup.yaml" -o=jsonpath='{.spec.
 
 ### Cluster IAM Role
 
-An [IAM Role] gives permissions to the principal that assumes that role. We
+An [IAM Role][] gives permissions to the principal that assumes that role. We
 Create a role to be assumed by the cluster, which later is granted the required
 permissions to talk to required resources in AWS.
 
@@ -651,7 +652,7 @@ EKS_ROLE_ARN=$(kubectl get -f "iamrole.yaml" -o=jsonpath='{.status.arn}')
 
 ### Cluster IAM Role Policies
 
-An [IAM Role Policy] grants a role a certain permission. We add two policies to
+An [IAM Role Policy][] grants a role a certain permission. We add two policies to
 the Cluster IAM Role that we created above. These policies are needed for the
 cluster to communicate with other aws resources.
 
@@ -871,3 +872,4 @@ off.
 [portable-classes-docs]: https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-default-resource-class.md
 [stacks-guide-continue]: stacks-guide.html#install-support-for-our-application-into-crossplane
 [resource-claims-docs]: concepts.md#resource-claims-and-resource-classes
+[eks-user-guide]: https://docs.aws.amazon.com/eks/latest/userguide/create-public-private-vpc.html

--- a/docs/stacks-guide-aws.md
+++ b/docs/stacks-guide-aws.md
@@ -1,16 +1,14 @@
 ---
-title: "AWS Stack Setup"
+title: "Stacks Guide: AWS Setup"
 toc: true
 weight: 530
 indent: true
 ---
 
-# Crossplane Stacks Guide: AWS Setup
+# Stacks Guide: AWS Setup
 
 ## Table of Contents
 
-  1. [Crossplane Stacks Guide: AWS Setup](#crossplane-stacks-guide-aws-setup)
-  1. [Table of Contents](#table-of-contents)
   1. [Introduction](#introduction)
   1. [Before you begin](#before-you-begin)
   1. [Install AWS stack](#install-aws-stack)

--- a/docs/stacks-guide-aws.md
+++ b/docs/stacks-guide-aws.md
@@ -21,7 +21,7 @@ indent: true
 
 ## Introduction
 
-In this guide, we will set up a GCP provider in Crossplane so that we
+In this guide, we will set up an AWS provider in Crossplane so that we
 can install and use the [WordPress sample
 stack][sample-wordpress-stack], which depends on MySQL and Kubernetes!
 

--- a/docs/stacks-guide-aws.md
+++ b/docs/stacks-guide-aws.md
@@ -885,6 +885,6 @@ off.
 [portable-classes-docs]: https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-default-resource-class.md
 [resource-classes-docs]: concepts.md#resource-claims-and-resource-classes
 
-[stacks-guide-continue]: stacks-guide.html#install-support-for-our-application-into-crossplane
+[stacks-guide-continue]: stacks-guide.md#install-support-for-our-application-into-crossplane
 [resource-claims-docs]: concepts.md#resource-claims-and-resource-classes
 [eks-user-guide]: https://docs.aws.amazon.com/eks/latest/userguide/create-public-private-vpc.html

--- a/docs/stacks-guide-aws.md
+++ b/docs/stacks-guide-aws.md
@@ -10,8 +10,7 @@ indent: true
 ## Table of Contents
 
   1. [Introduction](#introduction)
-  1. [Before you begin](#before-you-begin)
-  1. [Install AWS stack](#install-aws-stack)
+  1. [Install the AWS stack](#install-the-aws-stack)
   1. [Configure the AWS account](#configure-the-aws-account)
   1. [Configure Crossplane Provider for
     AWS](#configure-crossplane-provider-for-aws)
@@ -21,32 +20,35 @@ indent: true
 
 ## Introduction
 
-In this guide we are focusing on WordPress stack, and will show how it could be
-deployed using AWS resources. WordPress stack uses a generic Kubernetes cluster
-and a MySQL database as its resource, which are not tied to a specific provider
-(also known as **resource claims**). Instead, these resource claims could be
-configured to use a be satisfied by a specific cloud provider.
+In this guide, we will set up a GCP provider in Crossplane so that we
+can install and use the [WordPress sample
+stack][sample-wordpress-stack], which depends on MySQL and Kubernetes!
 
-We will walk you through installing the AWS stack, configuring an aws account,
-and setting up cloud-specific resources in order to create and configure a
-network configuration in which these cloud resources can communicate with each
-other. Once the network configuration is done, we will specify a resource class
-for each resource claim type. Then we will install WordPress stack, which will
-create related external resources for each claim in AWS.
+Before we begin, you will need:
 
-## Before you begin
+* Everything from the [Crossplane Stacks Guide][stacks-guide] before the
+  cloud provider setup
+  - A `kubectl` pointing to a Crossplane control cluster
+  - The [Crossplane CLI][crossplane-cli] installed
+* An account on [AWS][aws]
 
-Before continuing in this guide, make sure that all the following are true:
+At the end, we will have:
 
-- Crossplane is installed
-- [crossplane-cli] is installed
-- `kubectl` is configured to target the Crossplane cluster
-- An aws account is available
+* A Crossplane control cluster configured to use AWS
+* The boilerplate of an AWS-based project spun up
+* Support in the control cluster for managing MySQL and Kubernetes
+  cluster dependencies
+* A slightly better understanding of:
+  - The way cloud providers are configured in Crossplane
+  - The way dependencies for cloud-portable workloads are configured in
+    Crossplane
 
-## Install AWS stack
+## Install the AWS stack
 
-Once Crossplane is installed, it can be extended to support AWS by installing
-AWS **stack**.
+After Crossplane has been installed, it can be extended with more
+functionality by installing a [Crossplane Stack][stack-docs]! Let's
+install the [stack for Amazon Web Services][stack-aws] (AWS) to add
+support for that cloud provider.
 
 The namespace where we install the stack, is also the one that our managed AWS
 resources will reside. Let's call this namespace `infra-aws`, and go ahead and
@@ -836,11 +838,21 @@ Next we'll set up a Crossplane App Stack and use it! Head [back over to the
 Stacks Guide document][stacks-guide-continue] so we can pick up where we left
 off.
 
+<!-- Links -->
+[stacks-guide]: stacks-guide.md
+
+[aws]: https://aws.amazon.com
+[stack-aws]: https://github.com/crossplaneio/stack-aws
+[sample-wordpress-stack]: https://github.com/crossplaneio/sample-stack-wordpress
+
+[stack-docs]: https://github.com/crossplaneio/crossplane/blob/master/design/design-doc-stacks.md#crossplane-stacks
+
 [aws user]: https://docs.aws.amazon.com/mediapackage/latest/ug/setting-up-create-iam-user.html
 [Access Key]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
 [`aws provider`]: https://github.com/crossplaneio/stack-aws/blob/master/aws/apis/v1alpha2/types.go#L43
 [`aws` command line tool]: https://aws.amazon.com/cli/
 [AWS SDK for GO]: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/setting-up.html
+
 [installed]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html
 [configured]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html
 [AWS security credentials]: https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html

--- a/docs/stacks-guide-azure.md
+++ b/docs/stacks-guide-azure.md
@@ -390,7 +390,7 @@ while kubectl -n azure-infra-dev get mysqlservers -o yaml | grep -q  'items: \[\
 done
 echo "done" >&2
 
-export MYSQL_NAME=$(kubectl -n azure-infra-dev get mysqlservers -o json | jq -j '.items[0].metadata.name')
+export MYSQL_NAME=$(kubectl -n azure-infra-dev get mysqlservers -o=jsonpath='{.items[0].metadata.name}')
 
 sed "s/MYSQL_NAME/$MYSQL_NAME/g" vnet-rule.yaml | kubectl apply -f -
 

--- a/docs/stacks-guide-azure.md
+++ b/docs/stacks-guide-azure.md
@@ -20,9 +20,9 @@ indent: true
 
 ## Introduction
 
-In this guide, we will set up an Azure provider in Crossplane so that we can
-install and use the WordPress sample stack, which depends on MySQL and
-Kubernetes!
+In this guide, we will set up a GCP provider in Crossplane so that we
+can install and use the [WordPress sample
+stack][sample-wordpress-stack], which depends on MySQL and Kubernetes!
 
 Before you begin, you will need:
 
@@ -426,6 +426,8 @@ Stacks Guide document][stacks-guide-continue] so we can pick up where we left
 off.
 
 <!-- Links -->
+[sample-wordpress-stack]: https://github.com/crossplaneio/sample-stack-wordpress
+
 [crossplane-cli]: https://github.com/crossplaneio/crossplane-cli/tree/release-0.1
 [crossplane-azure-networking-docs]: https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-resource-connectivity-mvp.md#microsoft-azure
 [stacks-guide]: stacks-guide.html

--- a/docs/stacks-guide-azure.md
+++ b/docs/stacks-guide-azure.md
@@ -1,11 +1,11 @@
 ---
-title: "Azure Stack Setup"
+title: "Stacks Guide: Azure Setup"
 toc: true
 weight: 540
 indent: true
 ---
 
-# Crossplane Stacks Guide: Azure Setup
+# Stacks Guide: Azure Setup
 
 ## Table of Contents
 

--- a/docs/stacks-guide-azure.md
+++ b/docs/stacks-guide-azure.md
@@ -20,7 +20,7 @@ indent: true
 
 ## Introduction
 
-In this guide, we will set up a GCP provider in Crossplane so that we
+In this guide, we will set up an Azure provider in Crossplane so that we
 can install and use the [WordPress sample
 stack][sample-wordpress-stack], which depends on MySQL and Kubernetes!
 

--- a/docs/stacks-guide-azure.md
+++ b/docs/stacks-guide-azure.md
@@ -430,7 +430,7 @@ off.
 
 [crossplane-cli]: https://github.com/crossplaneio/crossplane-cli/tree/release-0.1
 [crossplane-azure-networking-docs]: https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-resource-connectivity-mvp.md#microsoft-azure
-[stacks-guide]: stacks-guide.html
+[stacks-guide]: stacks-guide.md
 [provider-azure-guide]: cloud-providers/azure/azure-provider.md
 
 [stack-docs]: https://github.com/crossplaneio/crossplane/blob/master/design/design-doc-stacks.md#crossplane-stacks
@@ -443,5 +443,5 @@ off.
 [azure-vnet-rule]: https://docs.microsoft.com/en-us/azure/mysql/concepts-data-access-and-security-vnet
 [azure-resource-group-docs]: https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview
 
-[stacks-guide-continue]: stacks-guide.html#install-support-for-our-application-into-crossplane
+[stacks-guide-continue]: stacks-guide.md#install-support-for-our-application-into-crossplane
 [jq]: https://stedolan.github.io/jq/

--- a/docs/stacks-guide-azure.md
+++ b/docs/stacks-guide-azure.md
@@ -415,7 +415,7 @@ Stacks Guide document][stacks-guide-continue] so we can pick up where we left
 off.
 
 <!-- Links -->
-[crossplane-cli]: https://github.com/crossplaneio/crossplane-cli
+[crossplane-cli]: https://github.com/crossplaneio/crossplane-cli/tree/release-0.1
 [crossplane-azure-networking-docs]: TODO
 [stacks-guide]: stacks-guide.html
 [provider-azure-guide]: cloud-providers/azure/azure-provider.md

--- a/docs/stacks-guide-gcp.md
+++ b/docs/stacks-guide-gcp.md
@@ -1,11 +1,11 @@
 ---
-title: "GCP Stack Setup"
+title: "Stacks Guide: GCP Setup"
 toc: true
 weight: 520
 indent: true
 ---
 
-# Crossplane Stacks Guide: GCP Setup
+# Stacks Guide: GCP Setup
 
 ## Table of Contents
 

--- a/docs/stacks-guide-gcp.md
+++ b/docs/stacks-guide-gcp.md
@@ -83,6 +83,22 @@ resource claims][resource-claims-docs].
 For convenience, the next steps assume that you installed GCP stack into
 the `gcp` namespace.
 
+### Validate the installation
+
+To check to see whether our stack installed correctly, we can look at
+the status of our stack:
+
+```
+kubectl -n gcp get stack
+```
+
+It should look something like this:
+
+```
+NAME        READY   VERSION   AGE
+stack-gcp   True    0.0.1     5m19s
+```
+
 ## Configure GCP Account
 
 We will make use of the following services on GCP:
@@ -176,6 +192,21 @@ The example YAML also exists in [the Crossplane repository][crossplane-sample-gc
 The name of the `Provider` resource in the file above is `gcp-provider`;
 we'll use the name `gcp-provider` to refer to this provider when we
 configure and set up other Crossplane resources.
+
+### Validate
+
+To check on our newly created provider, we can run:
+
+```
+kubectl -n gcp get provider.gcp.crossplane.io
+```
+
+The output should look something like:
+
+```
+NAME           PROJECT-ID              AGE
+gcp-provider   crossplane-playground   37s
+```
 
 ## Set Up Network Resources
 
@@ -278,6 +309,17 @@ assumes the GCP stack is installed in `gcp` namespace:
 kubectl -n gcp get connection.servicenetworking.gcp.crossplane.io/example-connection -o custom-columns='NAME:.metadata.name,FIRST_CONDITION:.status.conditions[0].status,SECOND_CONDITION:.status.conditions[1].status'
 ```
 
+The output should look something like:
+
+```
+NAME                 FIRST_CONDITION   SECOND_CONDITION
+example-connection   True              True
+```
+
+The conditions we're checking for are `Ready` and `Synced`. The reason
+we are using `FIRST_CONDITION` and `SECOND_CONDITION` is because we
+don't know what order they'll be in when we run the command.
+
 ## Configure Provider Resources
 
 Once we have the network set up, we also need to tell Crossplane how to
@@ -331,8 +373,12 @@ EOF
 
 kubectl apply -f environment.yaml
 ```
+
 The example YAML also exists in [the Crossplane
 repository][crossplane-sample-gcp-environment].
+
+We don't need to validate that these are ready, because they don't
+require any reconciliation.
 
 The steps that we have taken so far have been related to things that can
 be shared by all resources in all namespaces of the Crossplane control
@@ -396,6 +442,9 @@ kubectl apply -f namespace.yaml
 
 The example YAML also exists in [the Crossplane
 repository][crossplane-sample-gcp-namespace].
+
+We don't need to validate that these are ready, because they don't need
+to reconcile for them to be ready.
 
 ## Recap
 

--- a/docs/stacks-guide-gcp.md
+++ b/docs/stacks-guide-gcp.md
@@ -421,7 +421,7 @@ the Stacks Guide document][stacks-guide-continue] so we can pick up
 where we left off.
 
 <!-- Links -->
-[crossplane-cli]: https://github.com/crossplaneio/crossplane-cli
+[crossplane-cli]: https://github.com/crossplaneio/crossplane-cli/tree/release-0.1
 [crossplane-gcp-networking-docs]: https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-resource-connectivity-mvp.md#google-cloud-platform
 [stacks-guide]: stacks-guide.md
 

--- a/docs/stacks-guide-gcp.md
+++ b/docs/stacks-guide-gcp.md
@@ -56,7 +56,6 @@ CLI][crossplane-cli] for this operation. Since this is an infrastructure
 stack, we need to specify that it's cluster-scoped by passing the
 `--cluster` flag.
 
-
 To install to a specific namespace, we can use the `generate-install`
 command and pipe it to `kubectl apply` instead, which gives us more
 control over how the stack's installation is handled. Everything is

--- a/docs/stacks-guide-gcp.md
+++ b/docs/stacks-guide-gcp.md
@@ -127,14 +127,15 @@ assigned][gcp-assign-roles]:
 *   Kubernetes Engine Admin
 *   Service Account User
 
-You need to get JSON file of the service account you’ll use. In the next
-sections, this file will be referred to as
-`crossplane-gcp-provider-key.json`
+### Set up cloud provider credentials
 
-You can create the JSON file by using the [gcloud
-command][gcp-create-keys] and specifying a file name of
-`crossplane-gcp-provider-key.json`. If you use Crossplane's [GCP
-credentials script][gcp-credentials], this is taken care of for you.
+This guide assumes that you have created a JSON file which contains the
+credentials for the cloud provider. In later sections, this file will be
+referred to as `crossplane-gcp-provider-key.json`. There are quite a few
+steps involved, so the steps are in [a different document which you
+should take a look at][cloud-provider-setup-gcp] before moving to the
+next section. Or, there is also [a script in the Crossplane
+repo][gcp-credentials] which helps with creating the file.
 
 ## Configure Crossplane GCP Provider
 
@@ -497,3 +498,5 @@ where we left off.
 [crossplane-sample-gcp-network]: https://github.com/crossplaneio/crossplane/blob/master/cluster/examples/workloads/kubernetes/wordpress/gcp/network.yaml
 [crossplane-sample-gcp-environment]: https://github.com/crossplaneio/crossplane/blob/master/cluster/examples/workloads/kubernetes/wordpress/gcp/environment.yaml
 [crossplane-sample-gcp-namespace]: https://github.com/crossplaneio/crossplane/blob/master/cluster/examples/workloads/kubernetes/wordpress/gcp/namespace.yaml
+
+[cloud-provider-setup-gcp]: cloud-providers/gcp/gcp-provider.md

--- a/docs/stacks-guide.md
+++ b/docs/stacks-guide.md
@@ -217,9 +217,8 @@ kubectl get -n app-project1-dev kubernetesapplicationresource
 
 For validation that these resources are spinning up, you can check in
 the usual way for your cloud provider, or you can ask for the
-statuses of some of the [cloud-specific resource
-classes][cloud-specific-resource-classes-docs] in your Crossplane control
-cluster using `kubectl`.
+statuses of some of the cloud-specific Kubernetes resources provided by
+the infrastructure stack that we installed.
 
 For more information about how Crossplane manages databases and
 Kubernetes clusters for us, see the more complete documentation about
@@ -304,8 +303,8 @@ guide][stack-developer-guide].
 *   [Crossplane Install Guide][crossplane-install-docs]
 *   [The Crossplane CLI][crossplane-cli]
 *   [Stacks Quick Start][stack-quick-start]
-*   [Stack Registry][stack-registry]
 *   [Stacks Developer Guide][stack-developer-guide]
+*   [Stack Registry][stack-registry]
 *   [Provider Stack Developer Guide][provider-stack-developer-guide]
 *   [AWS documentation][aws-docs]
 *   [GCP documentation][gcp-docs]
@@ -317,9 +316,9 @@ guide][stack-developer-guide].
 [crossplane-cli-docs]: https://github.com/crossplaneio/crossplane-cli/blob/release-0.1/README.md
 [crossplane-concepts]: concepts.md
 [crossplane-install-docs]: install-crossplane.md
-[crossplane-api-reference]: TODO
+[crossplane-api-reference]: api.md
 
-[kubernetesapplicationresource-docs]: TODO
+[kubernetesapplicationresource-docs]: https://github.com/crossplaneio/crossplane/blob/master/design/design-doc-complex-workloads.md
 [claims-docs]: concepts.md#resource-claims-and-resource-classes
 [resource-classes-docs]: concepts.md#resource-claims-and-resource-classes
 [portable-classes-docs]: https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-default-resource-class.md
@@ -336,16 +335,15 @@ guide][stack-developer-guide].
 [gcp-docs]: https://cloud.google.com/docs/
 [azure-docs]: https://docs.microsoft.com/azure/
 
-[aws-setup]: TODO
+[aws-setup]: stacks-guide-aws.md
 [gcp-setup]: stacks-guide-gcp.md
 [azure-setup]: stacks-guide-azure.md
 
 [stack-docs]: https://github.com/crossplaneio/crossplane/blob/master/design/design-doc-stacks.md#crossplane-stacks
 [stack-quick-start]: https://github.com/crossplaneio/crossplane-cli/tree/release-0.1#quick-start-stacks
 [stack-concepts]: https://github.com/crossplaneio/crossplane/blob/master/design/design-doc-stacks.md#crossplane-stacks
+[stack-registry]: https://hub.docker.com/search?q=crossplane&type=image
 [stack-manager-docs]: https://github.com/crossplaneio/crossplane/blob/master/design/design-doc-stacks.md#installation-flow
 [stack-format-docs]: https://github.com/crossplaneio/crossplane/blob/master/design/design-doc-stacks.md#stack-package-format
-[stack-registry]: TODO
-[stack-developer-guide]: TODO
-[provider-stack-developer-guide]: TODO
-[cloud-specific-resource-classes-docs]: TODO
+[stack-developer-guide]: developer-guide.md
+[provider-stack-developer-guide]: developer-guide.md

--- a/docs/stacks-guide.md
+++ b/docs/stacks-guide.md
@@ -73,7 +73,7 @@ CLI][crossplane-cli], because it's more convenient. To install it, we
 can use the one-line curl bash:
 
 ```
-RELEASE=0.0.1
+RELEASE=release-0.1
 curl -sL https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bootstrap.sh | bash
 ```
 
@@ -295,8 +295,8 @@ guide][stack-developer-guide].
 *   [Kubernetes documentation][kubernetes-docs]
 
 <!-- Named links -->
-[crossplane-cli]: https://github.com/crossplaneio/crossplane-cli
-[crossplane-cli-docs]: https://github.com/crossplaneio/crossplane-cli/blob/master/README.md
+[crossplane-cli]: https://github.com/crossplaneio/crossplane-cli/tree/release-0.1
+[crossplane-cli-docs]: https://github.com/crossplaneio/crossplane-cli/blob/release-0.1/README.md
 [crossplane-concepts]: concepts.md
 [crossplane-install-docs]: install-crossplane.md
 
@@ -322,7 +322,7 @@ guide][stack-developer-guide].
 [azure-setup]: TODO
 
 [stack-docs]: https://github.com/crossplaneio/crossplane/blob/master/design/design-doc-stacks.md#crossplane-stacks
-[stack-quick-start]: https://github.com/crossplaneio/crossplane-cli#quick-start-stacks
+[stack-quick-start]: https://github.com/crossplaneio/crossplane-cli/tree/release-0.1#quick-start-stacks
 [stack-concepts]: https://github.com/crossplaneio/crossplane/blob/master/design/design-doc-stacks.md#crossplane-stacks
 [stack-manager-docs]: https://github.com/crossplaneio/crossplane/blob/master/design/design-doc-stacks.md#installation-flow
 [stack-format-docs]: https://github.com/crossplaneio/crossplane/blob/master/design/design-doc-stacks.md#stack-package-format

--- a/docs/stacks-guide.md
+++ b/docs/stacks-guide.md
@@ -43,14 +43,17 @@ Let's go!
 
 ## Concepts
 
-There are a bunch of things you might want to know to fully understand what's happening in this document. This guide won't cover them, but there are other ones that do. Here are some links!
+There are a bunch of things you might want to know to fully understand
+what's happening in this document. This guide won't cover them, but
+there are other ones that do. Here are some links!
 
 * [Crossplane concepts][crossplane-concepts]
 * [Kubernetes concepts][kubernetes-concepts]
 
 ## Before you get started
 
-This guide assumes you are using a *nix-like environment. It also assumes you have a basic working familiarity with the following:
+This guide assumes you are using a *nix-like environment. It also
+assumes you have a basic working familiarity with the following:
 
 * The terminal environment
 * Setting up cloud provider accounts for the cloud provider you want to

--- a/docs/stacks-guide.md
+++ b/docs/stacks-guide.md
@@ -102,7 +102,7 @@ documentation][crossplane-install-docs].
 
 ### Create the application namespace
 
-[Kubernetes namespaces][kubernetes-namespace-docs] are used to isolate
+[Kubernetes namespaces][kubernetes-namespaces-docs] are used to isolate
 resources in the same cluster, and we'll use them in our Crossplane
 control cluster too. Let's create a namespace for our application's
 resources. We'll call it `app-project1-dev` for the purposes of this
@@ -179,6 +179,19 @@ EOF
 kubectl apply --namespace app-project1-dev -f my-wordpress.yaml
 ```
 
+To validate that it has been set up correctly, we can run:
+
+```
+kubectl -n app-project1-dev get stack
+```
+
+The output should look something like:
+
+```
+NAME                     READY   VERSION   AGE
+sample-stack-wordpress   True    0.0.1     48s
+```
+
 If the control cluster doesn't recognize the Wordpress instance type, it
 could be because the stack is still being installed. Wait a few seconds,
 and try creating the Wordpress instance again.
@@ -202,6 +215,12 @@ kubectl get -n app-project1-dev kubernetesapplication
 kubectl get -n app-project1-dev kubernetesapplicationresource
 ```
 
+For validation that these resources are spinning up, you can check in
+the usual way for your cloud provider, or you can ask for the
+statuses of some of the [cloud-specific resource
+classes][cloud-specific-resource-classes-docs] in your Crossplane control
+cluster using `kubectl`.
+
 For more information about how Crossplane manages databases and
 Kubernetes clusters for us, see the more complete documentation about
 [claims][claims-docs], [resource classes][resource-classes-docs], and
@@ -216,7 +235,7 @@ which represents the workload's service. Here's a way to watch for the
 ip:
 
 ```
-kubectl get kubernetesapplicationresource -n app-project1-dev -o custom-columns='NAME:.metadata.name,NAMESPACE:.spec.template.metadata.namespace,KIND:.spec.template.kind,SERVICE-EXTERNAL-IP:.status.remote.loadBalancer.ingress[0].ip' --watch
+kubectl get --watch kubernetesapplicationresource -n app-project1-dev -o custom-columns='NAME:.metadata.name,NAMESPACE:.spec.template.metadata.namespace,KIND:.spec.template.kind,SERVICE-EXTERNAL-IP:.status.remote.loadBalancer.ingress[0].ip'
 ```
 
 The ip will show up on the one which has a `Service` kind.
@@ -242,8 +261,7 @@ kubectl delete -n app-project1-dev wordpressinstance my-wordpressinstance
 We can also remove the stack, using the Crossplane CLI:
 
 ```
-kubectl crossplane stack uninstall sample-stack-wordpress -n
-app-project1-dev
+kubectl crossplane stack uninstall sample-stack-wordpress -n app-project1-dev
 ```
 
 Removing the stack removes any Wordpress instances that were created.
@@ -281,6 +299,7 @@ guide][stack-developer-guide].
 ## References
 
 *   [The Crossplane Concepts guide][crossplane-concepts]
+*   [Crossplane API Reference][crossplane-api-reference]
 *   [The Stacks Concepts guide][stack-concepts]
 *   [Crossplane Install Guide][crossplane-install-docs]
 *   [The Crossplane CLI][crossplane-cli]
@@ -298,6 +317,7 @@ guide][stack-developer-guide].
 [crossplane-cli-docs]: https://github.com/crossplaneio/crossplane-cli/blob/release-0.1/README.md
 [crossplane-concepts]: concepts.md
 [crossplane-install-docs]: install-crossplane.md
+[crossplane-api-reference]: TODO
 
 [kubernetesapplicationresource-docs]: TODO
 [claims-docs]: concepts.md#resource-claims-and-resource-classes
@@ -328,3 +348,4 @@ guide][stack-developer-guide].
 [stack-registry]: TODO
 [stack-developer-guide]: TODO
 [provider-stack-developer-guide]: TODO
+[cloud-specific-resource-classes-docs]: TODO

--- a/docs/stacks-guide.md
+++ b/docs/stacks-guide.md
@@ -5,7 +5,7 @@ weight: 510
 indent: false
 ---
 
-# Crossplane Stacks Guide
+# Stacks Guide
 
 
 ## Table of Contents

--- a/docs/stacks-guide.md
+++ b/docs/stacks-guide.md
@@ -319,7 +319,7 @@ guide][stack-developer-guide].
 
 [aws-setup]: TODO
 [gcp-setup]: stacks-guide-gcp.md
-[azure-setup]: TODO
+[azure-setup]: stacks-guide-azure.md
 
 [stack-docs]: https://github.com/crossplaneio/crossplane/blob/master/design/design-doc-stacks.md#crossplane-stacks
 [stack-quick-start]: https://github.com/crossplaneio/crossplane-cli/tree/release-0.1#quick-start-stacks

--- a/docs/stacks-guide.md
+++ b/docs/stacks-guide.md
@@ -73,8 +73,7 @@ CLI][crossplane-cli], because it's more convenient. To install it, we
 can use the one-line curl bash:
 
 ```
-RELEASE=release-0.1
-curl -sL https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bootstrap.sh | bash
+RELEASE=release-0.1 && curl -sL https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bootstrap.sh | RELEASE=${RELEASE} bash
 ```
 
 To use the latest release, you can use `master` as the `RELEASE` instead


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

This is a collection of changes to polish the various stack guides. There are a few categories of change:

* Updates to keep the guides consistent
* Clarifications and rewordings to improve readability
* Fixes of bugs found during testing

The Most Tested path is the end-to-end path for GCP, though the credentials generation has not been tested as part of this test pass. I could use help with testing the following:

- [ ] Test the Stacks guide with AWS, including pulling down the AWS credentials and installing dependencies
- [x] Test the Stacks guide with Azure, including pulling down the Azure credentials and installing dependencies
  - [x] Also make sure to test the wait script now that `jq` has been removed
- [ ] Test pulling down GCP credentials

These are ordered from highest to lowest priority. I have already mentioned this list to @muvaf , and we agreed it would make sense to also get help from @hasheddan for the Azure parts.

Ideally the testing would be done with a local render of the site, as described in [this pull request](https://github.com/crossplaneio/crossplaneio.github.io/pull/25)

### Testing done

@jbw976 and I ran through the guide end-to-end using GCP, except for the credentials setup.