### PR TITLE
examples: portable redis classes unintentionally updated to v1alpha2

### DIFF
--- a/cluster/examples/cache/rediscluster/aws/resource-class-default.yaml
+++ b/cluster/examples/cache/rediscluster/aws/resource-class-default.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cache.crossplane.io/v1alpha2
+apiVersion: cache.crossplane.io/v1alpha1
 kind: RedisClusterClass
 metadata:
   name: redis-standard

--- a/cluster/examples/cache/rediscluster/aws/resource-class.yaml
+++ b/cluster/examples/cache/rediscluster/aws/resource-class.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cache.crossplane.io/v1alpha2
+apiVersion: cache.crossplane.io/v1alpha1
 kind: RedisClusterClass
 metadata:
   name: redis-standard

--- a/cluster/examples/cache/rediscluster/azure/resource-class-default.yaml
+++ b/cluster/examples/cache/rediscluster/azure/resource-class-default.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cache.crossplane.io/v1alpha2
+apiVersion: cache.crossplane.io/v1alpha1
 kind: RedisClusterClass
 metadata:
   name: redis-standard

--- a/cluster/examples/cache/rediscluster/azure/resource-class.yaml
+++ b/cluster/examples/cache/rediscluster/azure/resource-class.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cache.crossplane.io/v1alpha2
+apiVersion: cache.crossplane.io/v1alpha1
 kind: RedisClusterClass
 metadata:
   name: redis-standard

--- a/cluster/examples/cache/rediscluster/gcp/resource-class-default.yaml
+++ b/cluster/examples/cache/rediscluster/gcp/resource-class-default.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cache.crossplane.io/v1alpha2
+apiVersion: cache.crossplane.io/v1alpha1
 kind: RedisClusterClass
 metadata:
   name: redis-standard

--- a/cluster/examples/cache/rediscluster/gcp/resource-class.yaml
+++ b/cluster/examples/cache/rediscluster/gcp/resource-class.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cache.crossplane.io/v1alpha2
+apiVersion: cache.crossplane.io/v1alpha1
 kind: RedisClusterClass
 metadata:
   name: redis-standard


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

Portable `RedisClusterClass` examples were unintentionally updated to `v1alpha2`. This PR reverts them back to `v1alpha1`.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml