### PR TITLE
bump all cloud provider stack package references to their v0.1.0 release

### DIFF
--- a/cluster/examples/stacks/stack-aws.yaml
+++ b/cluster/examples/stacks/stack-aws.yaml
@@ -9,4 +9,4 @@ metadata:
   name: stack-aws
   namespace: aws
 spec:
-  package: "crossplane/stack-aws:master"
+  package: "crossplane/stack-aws:v0.1.0"

--- a/cluster/examples/stacks/stack-azure.yaml
+++ b/cluster/examples/stacks/stack-azure.yaml
@@ -9,4 +9,4 @@ metadata:
   name: stack-azure
   namespace: azure
 spec:
-  package: "crossplane/stack-azure:master"
+  package: "crossplane/stack-azure:v0.1.0"

--- a/cluster/examples/stacks/stack-gcp.yaml
+++ b/cluster/examples/stacks/stack-gcp.yaml
@@ -9,4 +9,4 @@ metadata:
   name: stack-gcp
   namespace: gcp
 spec:
-  package: "crossplane/stack-gcp:master"
+  package: "crossplane/stack-gcp:v0.1.0"

--- a/docs/install-crossplane.md
+++ b/docs/install-crossplane.md
@@ -72,7 +72,7 @@ metadata:
   name: stack-gcp
   namespace: gcp
 spec:
-  package: "crossplane/stack-gcp:master"
+  package: "crossplane/stack-gcp:v0.1.0"
 ```
 
 Then you can install the GCP stack into Crossplane in the `gcp` namespace with the following command:
@@ -97,7 +97,7 @@ metadata:
   name: stack-aws
   namespace: aws
 spec:
-  package: "crossplane/stack-aws:master"
+  package: "crossplane/stack-aws:v0.1.0"
 ```
 
 Then you can install the AWS stack into Crossplane in the `aws` namespace with the following command:
@@ -122,7 +122,7 @@ metadata:
   name: stack-azure
   namespace: azure
 spec:
-  package: "crossplane/stack-azure:master"
+  package: "crossplane/stack-azure:v0.1.0"
 ```
 
 Then you can install the Azure stack into Crossplane in the `azure` namespace with the following command:

--- a/docs/services/aws-services-guide.md
+++ b/docs/services/aws-services-guide.md
@@ -421,7 +421,7 @@ metadata:
   name: stack-aws
   namespace: crossplane-system
 spec:
-  package: "crossplane/stack-aws:master"
+  package: "crossplane/stack-aws:v0.1.0"
 EOF
 
 kubectl apply -f stack-aws.yaml
@@ -838,7 +838,7 @@ kubectl delete -f app-project1-dev-namespace.yaml
 kubectl delete -f aws-infra-dev-namespace.yaml
 ```
 
-### AWS Resources 
+### AWS Resources
 We will also need to delete the resources that we created for the RDS database
 and EKS cluster:
 

--- a/docs/services/azure-services-guide.md
+++ b/docs/services/azure-services-guide.md
@@ -119,7 +119,7 @@ metadata:
   name: stack-azure
   namespace: crossplane-system
 spec:
-  package: "crossplane/stack-azure:master"
+  package: "crossplane/stack-azure:v0.1.0"
 EOF
 
 kubectl apply -f stack-azure.yaml

--- a/docs/stacks-guide-aws.md
+++ b/docs/stacks-guide-aws.md
@@ -68,7 +68,7 @@ infrastructure stack, we need to specify that it's cluster-scoped by
 passing the `--cluster` flag.
 
 ```bash
-kubectl crossplane stack generate-install --cluster 'crossplane/stack-aws:master' stack-aws | kubectl apply --namespace ${INFRA_NAMESPACE} -f -
+kubectl crossplane stack generate-install --cluster 'crossplane/stack-aws:v0.1.0' stack-aws | kubectl apply --namespace ${INFRA_NAMESPACE} -f -
 ```
 
 The rest of the steps assume that you installed the AWS stack into the

--- a/docs/stacks-guide-azure.md
+++ b/docs/stacks-guide-azure.md
@@ -63,7 +63,7 @@ control over how the stack's installation is handled. Everything is
 a Kubernetes object!
 
 ```
-kubectl crossplane stack generate-install --cluster 'crossplane/stack-azure:master' stack-azure | kubectl apply --namespace crossplane-system -f -
+kubectl crossplane stack generate-install --cluster 'crossplane/stack-azure:v0.1.0' stack-azure | kubectl apply --namespace crossplane-system -f -
 ```
 
 If we wanted to use whatever the current namespace is, we could have

--- a/docs/stacks-guide-gcp.md
+++ b/docs/stacks-guide-gcp.md
@@ -63,7 +63,7 @@ a Kubernetes object!
 
 ```
 kubectl create namespace gcp
-kubectl crossplane stack generate-install --cluster 'crossplane/stack-gcp:master' stack-gcp | kubectl apply --namespace gcp -f -
+kubectl crossplane stack generate-install --cluster 'crossplane/stack-gcp:v0.1.0' stack-gcp | kubectl apply --namespace gcp -f -
 ```
 
 If we wanted to use whatever the current namespace is, we could have


### PR DESCRIPTION
### Description of your changes

This PR updates the cloud provider stack package references to their v0.1.0 release in both the user guides and the examples.

Note that this change is only going into the release branch, not into master.

We definitely have some improvements we can make to this release process going forward, so we should think through that.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml