### PR TITLE
fix doc welcome image proportions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,8 +14,7 @@ and cloud services to Crossplane with support for out-of-tree extensibility and
 independent release schedules. Crossplane includes Stacks for [GCP][stack-gcp], 
 [AWS][stack-aws], and [Azure][stack-azure] today.
 
-<h4 align="center"><img src="media/crossplane-overview.png" alt="Crossplane"
-height="400"></h4>
+<h4 align="center"><img src="media/crossplane-overview.png" alt="Crossplane"></h4>
 
 Crossplane has four main feature areas that can be used independently:
 1. Crossplane Services - provision managed services from kubectl.


### PR DESCRIPTION
### Description of your changes
Fix docs welcome page image resizing issues for narrow screens (iPhone).

Issue: used to look like this:
![Image from iOS](https://user-images.githubusercontent.com/284840/65211878-0dcb1880-da55-11e9-8e52-498d1f95b74a.png)

Now looks like this:
![Image from iOS-fixed](https://user-images.githubusercontent.com/284840/65212031-787c5400-da55-11e9-8a38-54897ff9852c.png)

Tested on chrome, safari (mac), safari (iOS).

### Checklist
I have:
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[skip ci]
