### PR TITLE
getting started: change connect your provider page

### DIFF
--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -1,43 +1,18 @@
 ---
-title: Connect Your Cloud Providers
+title: Configure Your Cloud Provider Account
 toc: true
 weight: 230
 indent: true
 ---
 
-# Connect Your Cloud Provider
+# Configure Your Cloud Provider Account
 
-In order for Crossplane to be able to manage resources across all your clouds, you will need to add your cloud provider account credentials to Crossplane.
-Use the links below for specific instructions to add each of the following cloud providers:
+In order for Crossplane to be able to manage resources in a specific cloud
+provider, you will need to create an account for Crossplane to use.
+Use the links below for cloud-specific instructions to create an account
+that can be used throughout the guides:
 
-* [Google Cloud Platform (GCP)](cloud-providers/gcp/gcp-provider.md)
+* [Google Cloud Platform (GCP) Service Account](cloud-providers/gcp/gcp-provider.md)
     * Required for Quick Start
-* [Microsoft Azure](cloud-providers/azure/azure-provider.md)
-* [Amazon Web Services (AWS)](cloud-providers/aws/aws-provider.md)
-
-## Examining Cloud Provider Configuration
-
-When Crossplane is installed, you can list all of the available providers.
-
-```console
-$ kubectl api-resources  | grep providers.*crossplane | awk '{print $2}'
-aws.crossplane.io
-azure.crossplane.io
-gcp.crossplane.io
-```
-
-After credentials have put in place for some of the Cloud providers, you can list those configurations.
-
-```console
-$ kubectl -n crossplane-system get providers.gcp.crossplane.io
-NAME           PROJECT-ID                 AGE
-gcp-provider   crossplane-example-10412   22h
-
-$ kubectl -n crossplane-system get providers.aws.crossplane.io
-NAME           REGION      AGE
-aws-provider   eu-west-1   22h
-
-$ kubectl -n crossplane-system get providers.azure.crossplane.io
-NAME           AGE
-azure-provider 22h
-```
+* [Microsoft Azure Service Principal](cloud-providers/azure/azure-provider.md)
+* [Amazon Web Services (AWS) IAM User](cloud-providers/aws/aws-provider.md)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

Our [_Connect Your Cloud Provider_](https://crossplane.io/docs/v0.3/cloud-providers.html) page assumes that cloud-specific pages create `Provider` resource which only AWS one does.

In the current state, all guides start with assuming that _credentials file_(json for azure and gke) is ready for `Provider` resource creation. Also, `Provider` resource has to live in a namespace that the user decides but here in this page the context is not there yet.

Suggestion:
* Change _Connect Your Cloud Provider_ page to _Configure Your Cloud Provider Account_, both title and the content (this PR does that)
* Change AWS to account creation with needed permissions that can work with all guides we have, just like other cloud-specific pages. 

We can also extend these pages to cover `Provider` creation and remove that part from other guides but having the user make the namespace decision early and without much context concerns me.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml