### PR TITLE
docs: add definition of done

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,14 +18,12 @@ can uncomment the below line to indicate which issue your PR fixes, for example
 Fixes #
 -->
 
-### Testing done
+### How has this code been tested?
 <!--
-How has this code been tested?
-
-Before reviewers can be confident in the correctness of a changeset,
+Before reviewers can be confident in the correctness of a pull request,
 it needs to be tested. In this section, briefly describe the testing
 that has already done or which is planned. The testing should be enough
-to help people feel comfortable in the changeset's correctness.
+to help people feel comfortable in the pull request's correctness.
 -->
 
 ### Checklist

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,9 +21,8 @@ Fixes #
 ### How has this code been tested?
 <!--
 Before reviewers can be confident in the correctness of a pull request,
-it needs to be tested. In this section, briefly describe the testing
-that has already done or which is planned. The testing should be enough
-to help people feel comfortable in the pull request's correctness.
+it needs to tested and shown to be correct. In this section, briefly
+describe the testing that has already been done or which is planned.
 -->
 
 ### Checklist

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,16 @@ can uncomment the below line to indicate which issue your PR fixes, for example
 Fixes #
 -->
 
+### Testing done
+<!--
+How has this code been tested?
+
+Before reviewers can be confident in the correctness of a changeset,
+it needs to be tested. In this section, briefly describe the testing
+that has already done or which is planned. The testing should be enough
+to help people feel comfortable in the changeset's correctness.
+-->
+
 ### Checklist
 <!--
 Please run through the below readiness checklist. The first two items are
@@ -26,10 +36,13 @@ relevant to every Crossplane pull request.
 I have:
 - [ ] Run `make reviewable` to ensure this PR is ready for review.
 - [ ] Ensured this PR contains a neat, self documenting set of commits.
-- [ ] Updated any relevant [documentation], [examples], or [release notes].
-- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.
+- [ ] Updated any relevant [documentation] and [examples].
+- [ ] Reported all new error conditions into the log or as an event, as
+  appropriate.
+
+For more about what we believe makes a pull request complete, see our
+[definition of done].
 
 [documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
 [examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
-[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
-[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml
+[definition of done]: https://github.com/crossplaneio/crossplane/tree/master/design/one-pager-definition-of-done.md

--- a/design/one-pager-definition-of-done.md
+++ b/design/one-pager-definition-of-done.md
@@ -20,15 +20,21 @@ Work means a contribution to the project, typically code.
 
 ## Definition of done
 
-A chunk of work is considered done when the following criteria have been met:
+The following criteria **MUST** be met for work to be considered done:
 
-* All code is written
 * Code is reviewed and approved
-* New behavior is documented in the documentation that will go onto the
-  crossplane website
+* Code passes linting (use `make reviewable` to lint)
 * All error conditions are reported into the log or as an event, as
   appropriate
-* Code is tested, ideally in an integration test
+* Code is tested
+
+Additionally, the following criteria **SHOULD** be met for the work to
+be considered done, as they are best practices:
+
+* Code is tested with an integration test
+* New behavior is documented in the documentation that will go onto the
+  crossplane website
+* Examples have been updated to reflect any changes
 
 ## Applying definition of done
 

--- a/design/one-pager-definition-of-done.md
+++ b/design/one-pager-definition-of-done.md
@@ -1,0 +1,40 @@
+# Definition of done
+
+* Owner: Daniel Suskin (@suskin)
+* Reviewers: Crossplane Maintainers
+* Status: Draft
+
+## Introduction
+
+*Why does this document exist?*
+
+The goal of this document is to answer the questions:
+
+* As a developer, when should I consider a chunk of work to be complete?
+* As a reviewer, what should I be looking for to verify that a chunk of work is
+  complete?
+
+## Definition of work
+
+Work means a contribution to the project, typically code.
+
+## Definition of done
+
+A chunk of work is considered done when the following criteria have been met:
+
+* All code is written
+* Code is reviewed and approved
+* New behavior is documented in the documentation that will go onto the
+  crossplane website
+* All error conditions are reported into the log or as an event, as
+  appropriate
+* Code is tested, ideally in an integration test
+
+## Applying definition of done
+
+The definition of done can be applied in the following ways:
+
+* Pull requests should not be merged until the work contained in them is
+  done.
+* Issues tracking work should not be closed until the work being tracked
+  is done.

--- a/design/one-pager-definition-of-done.md
+++ b/design/one-pager-definition-of-done.md
@@ -22,25 +22,33 @@ Work means a contribution to the project, typically code.
 
 The following criteria **MUST** be met for work to be considered done:
 
-* Code is reviewed and approved
-* Code passes linting (use `make reviewable` to lint)
-* All error conditions are reported into the log or as an event, as
-  appropriate
-* Code is tested
+* Code is reviewed and approved.
+* Code passes linting (use `make reviewable` to lint).
+* Error conditions are reported as and where appropriate. For more about
+  how to think about error reporting, see our [philosophical
+  guide][error-reporting-philosophy].
+* Code is tested to an extent such that: we are confident in its
+  correctness; and future maintainers will be able to tell if they have
+  introduced a regression.
 
 Additionally, the following criteria **SHOULD** be met for the work to
 be considered done, as they are best practices:
 
-* Code is tested with an integration test
+* Code is exercised with an integration test (existing or new).
 * New behavior is documented in the documentation that will go onto the
-  crossplane website
-* Examples have been updated to reflect any changes
+  crossplane website.
+* Examples have been updated to reflect any changes.
 
 ## Applying definition of done
 
 The definition of done can be applied in the following ways:
 
 * Pull requests should not be merged until the work contained in them is
-  done.
+  done. Generally, the best practice would be to include all relevant
+  changes (such as code, tests, and documentation) in a single pull
+  request, so that it is easier to keep track of.
 * Issues tracking work should not be closed until the work being tracked
   is done.
+
+<!-- Reference links -->
+[error-reporting-philosophy]: https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-error-and-event-reporting.md


### PR DESCRIPTION
### Description of your changes

In the retrospective for the 0.3 release (and in the sig-stacks sprint
retrospective recently), the topic came up of documenting the definition
of done, so that we can all be agreed about it. The difference between
the definition we had previously been using and the definition in this
changeset is that documentation and error reporting are now included.

[skip ci]