### PR TITLE
Fix owner kind of stack install job

### DIFF
--- a/pkg/controller/stacks/install/installjob.go
+++ b/pkg/controller/stacks/install/installjob.go
@@ -58,7 +58,7 @@ type stackInstallJobCompleter struct {
 }
 
 func createInstallJob(i v1alpha1.StackInstaller, executorInfo *stacks.ExecutorInfo) *batchv1.Job {
-	ref := meta.AsOwner(meta.ReferenceTo(i, v1alpha1.StackGroupVersionKind))
+	ref := meta.AsOwner(meta.ReferenceTo(i, i.GroupVersionKind()))
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            i.GetName(),


### PR DESCRIPTION
Signed-off-by: Hasan Turken <turkenh@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

There is a wrong object reference in stack install jobs. It contains the uid of ClusterStackInstall object but kind/name of Stack object. This commit changes kind as ClusterStackInstall.

Fixes #895

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml