### PR TITLE
One pager on Stacks Status spec and related changes/additions

### DIFF
--- a/design/design-doc-stacks.md
+++ b/design/design-doc-stacks.md
@@ -468,10 +468,8 @@ metadata:
           validation:
           - minimum: 1
           - maximum: 3
-      resourceConditionedStatusTypes:
-      - Ready
-      stackConditionedStatusTypes:
-      - Ready
+      resourceConditionPaths:
+      - .status.conditionedStatus.conditions[?(@.type=='Ready')]
       ---
       additionalSpec: example
       stillYaml: true

--- a/design/design-doc-stacks.md
+++ b/design/design-doc-stacks.md
@@ -453,7 +453,7 @@ metadata:
     stacks.crossplane.io/resource-readme: "Readme of the Resource"
     stacks.crossplane.io/icon-data-uri: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciLz4K
     stacks.crossplane.io/ui-schema: |
-      version: 0.3
+      version: 0.4
       configSections:
       - title: Configuration
         description: Enter information specific to the configuration you wish to create.
@@ -468,6 +468,10 @@ metadata:
           validation:
           - minimum: 1
           - maximum: 3
+      resourceConditionedStatusTypes:
+      - Ready
+      stackConditionedStatusTypes:
+      - Ready
       ---
       additionalSpec: example
       stillYaml: true

--- a/design/one-pager-stack-status-spec.md
+++ b/design/one-pager-stack-status-spec.md
@@ -1,0 +1,82 @@
+# Stack UI Schema Status Spec
+
+- Owner: Steven Rathbauer (@rathpc)
+- Reviewers: Crossplane Maintainers
+- Status: Draft
+
+## Proposal
+
+[crossplaneio/crossplane#929](https://github.com/crossplaneio/crossplane/issues/929)
+
+## Problem
+
+As of right now there is no defined spec to be able to drive status information for a given stack or resource from a GUI perspective. It would be useful to add keys to the existing `ui-schema.yaml` file that can be used for this purpose.
+
+We can leverage the types from the array of **conditions** within the **conditionedStatus** key defined in **status**.
+
+This 1-pager will identify the keys that should be added and what that structure looks like.
+
+## Design
+
+#### Add two new keys to the `ui-schema.yaml` file:
+
+- `resourceConditionedStatusTypes` _(this is an array of condition types as strings)_
+- `stackConditionedStatusTypes` _(this is an array of condition types as strings)_
+
+#### The arrays could potentially look like this inside of the `ui-schema.yaml` file:
+
+```yaml
+version: 0.4
+configSections: 
+- title: Title
+  description: Description
+resourceConditionedStatusTypes:
+- Ready
+stackConditionedStatusTypes:
+- Ready
+```
+
+- You can use that key to get the various values you want for a GUI related to that type.
+
+- For example if you wanted a status title, status value and additional details for the 'Ready' status type you could build an object like this for example (_Using JS for example purposes_):
+
+```js
+import { JSONPath } from 'jsonpath-plus';
+
+// ...
+
+const statusTypesFromUISchema = resourceConditionedStatusTypes;
+
+const statusInfo = statusTypesFromUISchema.map(statusType => ({
+    title: JSONPath({
+        path: `$.status.conditionedStatus.conditions[?(@.type=='${statusType}')].type`,
+        json: crdReturnedFromK8SAsJSON,
+    }),
+    value: JSONPath({
+        path: `$.status.conditionedStatus.conditions[?(@.type=='${statusType}')].status`,
+        json: crdReturnedFromK8SAsJSON,
+    }),
+    details: JSONPath({
+        path: `$.status.conditionedStatus.conditions[?(@.type=='${statusType}')].reason`,
+        json: crdReturnedFromK8SAsJSON,
+    }),
+}));
+
+// ...
+```
+
+- You can use a javascript implementation of JSONPath ([jsonpath-plus](https://github.com/s3u/JSONPath)) as shown above to leverage these keys and "_look up_" the status values and additional info if present.
+
+-----
+
+## Fallback Option
+
+If a package author does not include these additional keys in the `ui-schema.yaml` file **OR** if there is no `ui-schema.yaml` file included at all, you can try to leverage the **additionalPrinterColumns** values if they exist within the spec.
+
+```yaml
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.conditionedStatus.conditions[?(@.type=='Ready')].status
+      name: READY
+      type: string
+```

--- a/design/one-pager-stack-status-spec.md
+++ b/design/one-pager-stack-status-spec.md
@@ -10,18 +10,39 @@
 
 ## Problem
 
-As of right now there is no defined spec to be able to drive status information for a given stack or resource from a GUI perspective. It would be useful to add keys to the existing `ui-schema.yaml` file that can be used for this purpose.
+For a given CRD I want to be able to expose various statuses to a frontend GUI. Initially it makes
+sense to at least have the Ready state available. In addition to the value of the Ready state it
+would also be helpful to have some additional details about that state if applicable.
 
-We can leverage the types from the array of **conditions** within the **conditionedStatus** key defined in **status**.
+This also assumes that statuses are following a particular condition convention, similar to that of a
+[podcondition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#podcondition-v1-core)
 
-This 1-pager will identify the keys that should be added and what that structure looks like.
+The conditions should contain at least the following keys:
+- type
+- status
+- reason
+- message
+
+#### For example:
+
+If a CRD has the condition type 'Ready' defined but has a status of that type of
+_"False"_, I could show some visual indication to a user through a GUI that the CRD is **NOT Ready**.
+
+When that status changes to _"True"_ then I can adjust that visual cue to now reflect that the CRD is
+in fact **Ready**.
+
+As of right now there is no defined spec to be able to drive status information for a given resource from a GUI perspective. It would be useful to add a key to the existing `ui-schema.yaml`
+file that can be used for this purpose.
+
+This key would contain an array of JSONPath's that point directly to conditions following the convention described above.
+
+This 1-pager will identify the key that should be added and what that structure looks like.
 
 ## Design
 
 #### Add two new keys to the `ui-schema.yaml` file:
 
-- `resourceConditionedStatusTypes` _(this is an array of condition types as strings)_
-- `stackConditionedStatusTypes` _(this is an array of condition types as strings)_
+- `resourceConditionPaths` _(this is an array of JSONPaths)_
 
 #### The arrays could potentially look like this inside of the `ui-schema.yaml` file:
 
@@ -30,48 +51,41 @@ version: 0.4
 configSections: 
 - title: Title
   description: Description
-resourceConditionedStatusTypes:
-- Ready
-stackConditionedStatusTypes:
-- Ready
+resourceConditionPaths:
+- .status.conditionedStatus.conditions[?(@.type=='Ready')]
 ```
 
 - You can use that key to get the various values you want for a GUI related to that type.
 
-- For example if you wanted a status title, status value and additional details for the 'Ready' status type you could build an object like this for example (_Using JS for example purposes_):
+- For example if you wanted a status title, status value and additional details for the 'Ready'
+status type you could build an object like this for example (_Using JS for example purposes_):
 
 ```js
 import { JSONPath } from 'jsonpath-plus';
 
 // ...
 
-const statusTypesFromUISchema = resourceConditionedStatusTypes;
+const resourceConditionPathsFromUISchema = resourceConditionPaths;
 
-const statusInfo = statusTypesFromUISchema.map(statusType => ({
-    title: JSONPath({
-        path: `$.status.conditionedStatus.conditions[?(@.type=='${statusType}')].type`,
-        json: crdReturnedFromK8SAsJSON,
-    }),
-    value: JSONPath({
-        path: `$.status.conditionedStatus.conditions[?(@.type=='${statusType}')].status`,
-        json: crdReturnedFromK8SAsJSON,
-    }),
-    details: JSONPath({
-        path: `$.status.conditionedStatus.conditions[?(@.type=='${statusType}')].reason`,
-        json: crdReturnedFromK8SAsJSON,
-    }),
+const resourceStatusInfo = resourceConditionPathsFromUISchema.map(statusType => ({
+    title: JSONPath({ path: `$${statusType}.type`, json: crdReturnedFromK8SAsJSON }),
+    value: JSONPath({ path: `$${statusType}.status`, json: crdReturnedFromK8SAsJSON }),
+    details: JSONPath({ path: `$${statusType}.reason`, json: crdReturnedFromK8SAsJSON }),
 }));
 
 // ...
 ```
 
-- You can use a javascript implementation of JSONPath ([jsonpath-plus](https://github.com/s3u/JSONPath)) as shown above to leverage these keys and "_look up_" the status values and additional info if present.
+- You can use a javascript implementation of JSONPath ([jsonpath-plus](https://github.com/s3u/JSONPath))
+as shown above to leverage these keys and "_look up_" the status values and additional info if present.
 
 -----
 
 ## Fallback Option
 
-If a package author does not include these additional keys in the `ui-schema.yaml` file **OR** if there is no `ui-schema.yaml` file included at all, you can try to leverage the **additionalPrinterColumns** values if they exist within the spec.
+If a package author does not include these additional keys in the `ui-schema.yaml` file **OR** if
+there is no `ui-schema.yaml` file included at all, you can try to leverage the
+**additionalPrinterColumns** values if they exist within the spec.
 
 ```yaml
 spec:

--- a/design/one-pager-stack-ui-metadata.md
+++ b/design/one-pager-stack-ui-metadata.md
@@ -83,7 +83,7 @@ A root `ui-schema.yaml` file may be used to set global UI metadata.  This may be
 This file contains multiple sections and a variety of different input types with validation overrides, extended validation and custom error messages.
 
 ```yaml
-version: 0.3
+version: 0.4
 configSections:
 - title: Configuration
   description: Enter information specific to the configuration you wish to create.
@@ -125,6 +125,10 @@ configSections:
     validation:
     - required: true
       customError: You must select an instance size for your configuration!
+resourceConditionedStatusTypes:
+- Ready
+stackConditionedStatusTypes:
+- Ready
 ```
 
 ### CRD Annotation Example
@@ -132,6 +136,7 @@ configSections:
 An example injection of the `ui-schema.yaml` as a CRD annotation follows.  Keep in mind that Kubernetes annotations are limited to 256kb (less in older versions).
 
 ```yaml
+version: 0.4
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -139,7 +144,6 @@ metadata:
   annotations:
     stacks.crossplane.io/ui-schema: |-
       ---
-      version: 0.3
       configSections:
       - title: Configuration
         description: Enter information specific to the configuration you wish to create.
@@ -182,11 +186,19 @@ metadata:
           validation:
           - required: true
             customError: You must select an instance size for your configuration!
+      resourceConditionedStatusTypes:
+      - Ready
+      stackConditionedStatusTypes:
+      - Ready
       ---
-      version: 0.3
+      version: 0.4
       configSections:
       - title: Supplementary
         description: A supplementary UI annotation
+      resourceConditionedStatusTypes:
+      - Ready
+      stackConditionedStatusTypes:
+      - Ready
   labels:
     controller-tools.k8s.io: "1.0"
 ```

--- a/design/one-pager-stack-ui-metadata.md
+++ b/design/one-pager-stack-ui-metadata.md
@@ -125,10 +125,8 @@ configSections:
     validation:
     - required: true
       customError: You must select an instance size for your configuration!
-resourceConditionedStatusTypes:
-- Ready
-stackConditionedStatusTypes:
-- Ready
+resourceConditionPaths:
+- .status.conditionedStatus.conditions[?(@.type=='Ready')]
 ```
 
 ### CRD Annotation Example
@@ -186,19 +184,15 @@ metadata:
           validation:
           - required: true
             customError: You must select an instance size for your configuration!
-      resourceConditionedStatusTypes:
-      - Ready
-      stackConditionedStatusTypes:
-      - Ready
+      resourceConditionPaths:
+      - .status.conditionedStatus.conditions[?(@.type=='Ready')]
       ---
       version: 0.4
       configSections:
       - title: Supplementary
         description: A supplementary UI annotation
-      resourceConditionedStatusTypes:
-      - Ready
-      stackConditionedStatusTypes:
-      - Ready
+      resourceConditionPaths:
+      - .status.conditionedStatus.conditions[?(@.type=='Ready')]
   labels:
     controller-tools.k8s.io: "1.0"
 ```

--- a/pkg/stacks/unpack_test.go
+++ b/pkg/stacks/unpack_test.go
@@ -246,15 +246,23 @@ metadata:
     stacks.crossplane.io/icon-data-uri: data:image/svg+xml;base64,bW9jay1pY29uLWRhdGEtc3Zn
     stacks.crossplane.io/stack-title: Sample Crossplane Stack
     stacks.crossplane.io/ui-schema: |-
-      version: 0.3
+      version: 0.4
       configSections:
       - title: group Title
         description: group Description
+      resourceConditionedStatusTypes:
+      - Ready
+      stackConditionedStatusTypes:
+      - Ready
       ---
-      version: 0.3
+      version: 0.4
       configSections:
       - title: sibling Title
         description: sibling Description
+      resourceConditionedStatusTypes:
+      - Ready
+      stackConditionedStatusTypes:
+      - Ready
   creationTimestamp: null
   name: siblings.samples.upbound.io
 spec:
@@ -324,20 +332,32 @@ metadata:
     stacks.crossplane.io/resource-title-plural: Resources Title
     stacks.crossplane.io/stack-title: Sample Crossplane Stack
     stacks.crossplane.io/ui-schema: |-
-      version: 0.3
+      version: 0.4
       configSections:
       - title: group Title
         description: group Description
+      resourceConditionedStatusTypes:
+      - Ready
+      stackConditionedStatusTypes:
+      - Ready
       ---
-      version: 0.3
+      version: 0.4
       configSections:
       - title: sibling Title
         description: sibling Description
+      resourceConditionedStatusTypes:
+      - Ready
+      stackConditionedStatusTypes:
+      - Ready
       ---
-      version: 0.3
+      version: 0.4
       configSections:
       - title: kind Title
         description: kind Description
+      resourceConditionedStatusTypes:
+      - Ready
+      stackConditionedStatusTypes:
+      - Ready
   creationTimestamp: null
   name: mytypes.samples.upbound.io
 spec:
@@ -370,10 +390,14 @@ metadata:
     stacks.crossplane.io/icon-data-uri: data:image/jpeg;base64,bW9jay1pY29uLWRhdGE=
     stacks.crossplane.io/stack-title: Sample Crossplane Stack
     stacks.crossplane.io/ui-schema: |-
-      version: 0.3
+      version: 0.4
       configSections:
       - title: group Title
         description: group Description
+      resourceConditionedStatusTypes:
+      - Ready
+      stackConditionedStatusTypes:
+      - Ready
   creationTimestamp: null
   name: cousins.samples.upbound.io
 spec:
@@ -531,15 +555,23 @@ metadata:
     stacks.crossplane.io/icon-data-uri: data:image/svg+xml;base64,bW9jay1pY29uLWRhdGEtc3Zn
     stacks.crossplane.io/stack-title: Sample Crossplane Stack
     stacks.crossplane.io/ui-schema: |-
-      version: 0.3
+      version: 0.4
       configSections:
       - title: group Title
         description: group Description
+      resourceConditionedStatusTypes:
+      - Ready
+      stackConditionedStatusTypes:
+      - Ready
       ---
-      version: 0.3
+      version: 0.4
       configSections:
       - title: sibling Title
         description: sibling Description
+      resourceConditionedStatusTypes:
+      - Ready
+      stackConditionedStatusTypes:
+      - Ready
   creationTimestamp: null
   name: siblings.samples.upbound.io
 spec:
@@ -609,20 +641,32 @@ metadata:
     stacks.crossplane.io/resource-title-plural: Resources Title
     stacks.crossplane.io/stack-title: Sample Crossplane Stack
     stacks.crossplane.io/ui-schema: |-
-      version: 0.3
+      version: 0.4
       configSections:
       - title: group Title
         description: group Description
+      resourceConditionedStatusTypes:
+      - Ready
+      stackConditionedStatusTypes:
+      - Ready
       ---
-      version: 0.3
+      version: 0.4
       configSections:
       - title: sibling Title
         description: sibling Description
+      resourceConditionedStatusTypes:
+      - Ready
+      stackConditionedStatusTypes:
+      - Ready
       ---
-      version: 0.3
+      version: 0.4
       configSections:
       - title: kind Title
         description: kind Description
+      resourceConditionedStatusTypes:
+      - Ready
+      stackConditionedStatusTypes:
+      - Ready
   creationTimestamp: null
   name: mytypes.samples.upbound.io
 spec:
@@ -655,10 +699,14 @@ metadata:
     stacks.crossplane.io/icon-data-uri: data:image/jpeg;base64,bW9jay1pY29uLWRhdGE=
     stacks.crossplane.io/stack-title: Sample Crossplane Stack
     stacks.crossplane.io/ui-schema: |-
-      version: 0.3
+      version: 0.4
       configSections:
       - title: group Title
         description: group Description
+      resourceConditionedStatusTypes:
+      - Ready
+      stackConditionedStatusTypes:
+      - Ready
   creationTimestamp: null
   name: cousins.samples.upbound.io
 spec:
@@ -1025,10 +1073,14 @@ spec:
 }
 
 func simpleUIFile(name string) string {
-	return fmt.Sprintf(`version: 0.3
+	return fmt.Sprintf(`version: 0.4
 configSections:
 - title: %s Title
   description: %s Description
+resourceConditionedStatusTypes:
+- Ready
+stackConditionedStatusTypes:
+- Ready
 `, name, name)
 }
 

--- a/pkg/stacks/unpack_test.go
+++ b/pkg/stacks/unpack_test.go
@@ -250,19 +250,15 @@ metadata:
       configSections:
       - title: group Title
         description: group Description
-      resourceConditionedStatusTypes:
-      - Ready
-      stackConditionedStatusTypes:
-      - Ready
+      resourceConditionPaths:
+      - .status.conditionedStatus.conditions[?(@.type=='Ready')]
       ---
       version: 0.4
       configSections:
       - title: sibling Title
         description: sibling Description
-      resourceConditionedStatusTypes:
-      - Ready
-      stackConditionedStatusTypes:
-      - Ready
+      resourceConditionPaths:
+      - .status.conditionedStatus.conditions[?(@.type=='Ready')]
   creationTimestamp: null
   name: siblings.samples.upbound.io
 spec:
@@ -336,28 +332,22 @@ metadata:
       configSections:
       - title: group Title
         description: group Description
-      resourceConditionedStatusTypes:
-      - Ready
-      stackConditionedStatusTypes:
-      - Ready
+      resourceConditionPaths:
+      - .status.conditionedStatus.conditions[?(@.type=='Ready')]
       ---
       version: 0.4
       configSections:
       - title: sibling Title
         description: sibling Description
-      resourceConditionedStatusTypes:
-      - Ready
-      stackConditionedStatusTypes:
-      - Ready
+      resourceConditionPaths:
+      - .status.conditionedStatus.conditions[?(@.type=='Ready')]
       ---
       version: 0.4
       configSections:
       - title: kind Title
         description: kind Description
-      resourceConditionedStatusTypes:
-      - Ready
-      stackConditionedStatusTypes:
-      - Ready
+      resourceConditionPaths:
+      - .status.conditionedStatus.conditions[?(@.type=='Ready')]
   creationTimestamp: null
   name: mytypes.samples.upbound.io
 spec:
@@ -394,10 +384,8 @@ metadata:
       configSections:
       - title: group Title
         description: group Description
-      resourceConditionedStatusTypes:
-      - Ready
-      stackConditionedStatusTypes:
-      - Ready
+      resourceConditionPaths:
+      - .status.conditionedStatus.conditions[?(@.type=='Ready')]
   creationTimestamp: null
   name: cousins.samples.upbound.io
 spec:
@@ -559,19 +547,15 @@ metadata:
       configSections:
       - title: group Title
         description: group Description
-      resourceConditionedStatusTypes:
-      - Ready
-      stackConditionedStatusTypes:
-      - Ready
+      resourceConditionPaths:
+      - .status.conditionedStatus.conditions[?(@.type=='Ready')]
       ---
       version: 0.4
       configSections:
       - title: sibling Title
         description: sibling Description
-      resourceConditionedStatusTypes:
-      - Ready
-      stackConditionedStatusTypes:
-      - Ready
+      resourceConditionPaths:
+      - .status.conditionedStatus.conditions[?(@.type=='Ready')]
   creationTimestamp: null
   name: siblings.samples.upbound.io
 spec:
@@ -645,28 +629,22 @@ metadata:
       configSections:
       - title: group Title
         description: group Description
-      resourceConditionedStatusTypes:
-      - Ready
-      stackConditionedStatusTypes:
-      - Ready
+      resourceConditionPaths:
+      - .status.conditionedStatus.conditions[?(@.type=='Ready')]
       ---
       version: 0.4
       configSections:
       - title: sibling Title
         description: sibling Description
-      resourceConditionedStatusTypes:
-      - Ready
-      stackConditionedStatusTypes:
-      - Ready
+      resourceConditionPaths:
+      - .status.conditionedStatus.conditions[?(@.type=='Ready')]
       ---
       version: 0.4
       configSections:
       - title: kind Title
         description: kind Description
-      resourceConditionedStatusTypes:
-      - Ready
-      stackConditionedStatusTypes:
-      - Ready
+      resourceConditionPaths:
+      - .status.conditionedStatus.conditions[?(@.type=='Ready')]
   creationTimestamp: null
   name: mytypes.samples.upbound.io
 spec:
@@ -703,10 +681,8 @@ metadata:
       configSections:
       - title: group Title
         description: group Description
-      resourceConditionedStatusTypes:
-      - Ready
-      stackConditionedStatusTypes:
-      - Ready
+      resourceConditionPaths:
+      - .status.conditionedStatus.conditions[?(@.type=='Ready')]
   creationTimestamp: null
   name: cousins.samples.upbound.io
 spec:
@@ -1077,10 +1053,8 @@ func simpleUIFile(name string) string {
 configSections:
 - title: %s Title
   description: %s Description
-resourceConditionedStatusTypes:
-- Ready
-stackConditionedStatusTypes:
-- Ready
+resourceConditionPaths:
+- .status.conditionedStatus.conditions[?(@.type=='Ready')]
 `, name, name)
 }
 


### PR DESCRIPTION
### Description of your changes

This PR defines the first draft of the one pager that designs the spec around adding keys to drive status information in a GUI.

Addresses: https://github.com/crossplaneio/crossplane/issues/929

Related: https://github.com/crossplaneio/sample-stack/pull/4

I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml