### PR TITLE
fix for timeout setting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,12 +3,12 @@ pipeline {
 
     parameters {
         booleanParam(defaultValue: true, description: 'Execute pipeline?', name: 'shouldBuild')
-        timeout(time: 30, unit: 'MINUTES')
     }
 
     options {
         disableConcurrentBuilds()
         timestamps()
+        timeout(time: 30, unit: 'MINUTES')
     }
 
     environment {


### PR DESCRIPTION
### Description of  changes
Fix for pull/941 that broke build
```
timeout(time: 30, unit: 'MINUTES')
```
-->

### Checklist

I have:
- [ x] Run `make reviewable` to ensure this PR is ready for review.
- [ x] Ensured this PR contains a neat, self documenting set of commits.
- [ x] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml