### PR TITLE
Maintainer team updates

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -10,11 +10,11 @@ This page lists all active maintainers and their areas of expertise. This can be
 Here's the current list of senior maintainers:
 
 * Bassam Tabbara <bassam@upbound.io> ([bassam](https://github.com/bassam))
-  * Catch-all, architecture, strategy, build and packaging
-* Illya Chekrygin <illya@upbound.io> ([ichekrygin](https://github.com/ichekrygin))
-  * Core, Controllers, GCP, AWS, Azure
+  * Catch-all, architecture, strategy
 * Jared Watts <jared@upbound.io> ([jbw976](https://github.com/jbw976))
-  * Core, Controllers, GCP, AWS, Azure
+  * Stacks architecture, release engineering
+* Nic Cope <negz@upbound.io> ([negz](https://github.com/negz))
+  * Services architecture
 
 ## Maintainers
 
@@ -22,7 +22,7 @@ There are currently no maintainers. Maintainers will be added according to the [
 
 ## Emeritus maintainers
 
-There are currently no emeritus maintainers.  This list will be updated according to the [process for removing a maintainer](GOVERNANCE.md#removing-a-maintainer) in the [governance](GOVERNANCE.md).
+* Illya Chekrygin <illya.chekrygin@gmail.com> ([ichekrygin](https://github.com/ichekrygin))
 
 ## Friends of Crossplane
 


### PR DESCRIPTION
### Description of your changes

This PR is a formal proposal to update the maintainer team as per the [Crossplane governance](https://github.com/crossplaneio/crossplane/blob/master/GOVERNANCE.md).  The following changes are included:

* Add @negz to senior maintainers
* Move @ichekrygin to emeritus maintainers

Thank you @ichekrygin and @negz both for all of your amazing contributions to the Crossplane project! 🚀 

@bassam and @ichekrygin please "approve" this PR as an indication of your formal vote on this proposed change to the maintainer team.

### Checklist

I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml

[skip ci]