### PR TITLE
design: add design doc for template stacks experience

### DIFF
--- a/design/design-doc-template-stacks-experience.md
+++ b/design/design-doc-template-stacks-experience.md
@@ -185,16 +185,21 @@ At a high level, the steps would be as follows:
 2. In the project directory, `kubectl crossplane stack init --template
    myorg/mystack` to create the boilerplate of the stack layout.
 3. Relative to the project directory, put the yamls in
-   `config/stack/manifests/resources/templates` .
+   `config/stack/manifests/resources/templates`, or a different
+   directory if desired.
 4. Add CRD definitions; this could be done by putting CRD yaml
    definitions in `config/stack/manifests/resources` or in
-   `config/crd/bases`.
+   `config/crd/bases`. We plan to make this simpler for the user by
+   adding a crossplane-cli command for it.
 5. Add configuration to `stack.yaml` to
    specify how configurations are rendered.
 6. Edit `config/stack/manifests/resources/app.yaml` to specify that the
    stack will be working with all of the kinds that it will be working
    with (using the `dependsOn` field).
 7. Edit `config/stack/manifests/resources/app.yaml` as appropriate.
+
+In the future, we expect that we will combine `app.yaml` and
+`stack.yaml`.
 
 #### Adding a CRD
 
@@ -331,7 +336,7 @@ behaviors:
   crds:
     # This is a particular CRD which is being configured. When the
     # controller sees an object of this type, it will do something.
-    wordpressinstance.wordpress.samples.stacks.crossplane.io/v1alpha1:
+    wordpressinstance.wordpress.samples.stacks.crossplane.io:
       # These are the templates which should be rendered when an object
       # of the type above is seen.
       #
@@ -339,15 +344,18 @@ behaviors:
       # for the CRD fields, using the standard Kubernetes mechanism for
       # specifying CRD field default values.
       resources:
-        # These are individual files which will be rendered.
-        - templates/kubernetescluster.yaml
-        - templates/mysqlinstance.yaml
-        - tempaltes/kubernetesapplication.yaml
+        # Each list item is a folder of files which will be rendered.
+        - wordpress
 EOF
 ```
 
 The `stack.yaml` should be in the build root of the repository. For most
 single-stack repositories, this means the root of the repository.
+
+For some realistic samples, see the [helm engine
+example][helm-engine-example] or the [quick start
+example][quick-start-example] in the template stack experience
+repository.
 
 ### Specifying default values
 
@@ -424,9 +432,10 @@ implementation](https://github.com/crossplaneio/crossplane/blob/master/design/on
 See the [Template Stack
 Experience](https://github.com/suskin/template-stack-experience) code
 examples for some realistic examples of how different use-cases work
-with a realistic workload.
+with a realistic workload. For a coherent user scenario, see the [quick
+start example](https://github.com/suskin/template-stack-experience/tree/master/wordpress-workload/quick-start).
 
-Examples covered by the repository all currently use go templates as the
+Examples covered by the repository mostly use go templates as the
 templating engine. The following cases are covered by the examples:
 
 * No variables at all in a set of configurations.
@@ -437,11 +446,13 @@ templating engine. The following cases are covered by the examples:
 * Multiple CRDs defined in a single Stack.
 * Multiple rendered variants of a given configuration.
 * Composing configuration using multiple Stacks.
+* A user scenario of setting up cloud provider resources and deploying
+  an application bundled as a stack.
 
 ### Helm charts
 
-To author a template stack from a simple helm chart, these steps could
-be followed:
+To author a [template stack from a simple helm
+chart][helm-engine-example], these steps could be followed:
 
 1. Create and initialize a template stack project, with a helm flag:
    `kubectl crossplane stack init --template`.
@@ -459,11 +470,15 @@ When consuming the stack, the default template values can be overridden
 by specifying fields on the render request object.
 
 This use-case will probably need additional thought if we want to
-support all permutations of helm chart.
+support all permutations of helm chart. For more realistic and complete
+examples, see the [helm engine example][helm-engine-example] and the
+[quick start example][quick-start-example] in the template stack
+experience repository.
 
 ## Further reading
 
 * [Template Stack Experience](https://github.com/suskin/template-stack-experience) examples
+* [Template Stack Experience - Quick Start Example](https://github.com/suskin/template-stack-experience/tree/master/wordpress-workload/quick-start)
 * [Declarative Application Management in Kubernetes](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/declarative-application-management.md)
 * [Template Stacks internals design doc](https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-template-stacks.md)
 * [Stacks CLI design](https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-stack-cli.md)
@@ -471,3 +486,5 @@ support all permutations of helm chart.
 
 <!-- Reference-style links -->
 [kubernetes-default-values]: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#defaulting
+[helm-engine-example]: https://github.com/suskin/template-stack-experience/tree/master/wordpress-workload/go-templates/helm-engine
+[quick-start-example]: https://github.com/suskin/template-stack-experience/tree/master/wordpress-workload/quick-start

--- a/design/design-doc-template-stacks-experience.md
+++ b/design/design-doc-template-stacks-experience.md
@@ -350,9 +350,8 @@ behaviors:
 The `stack.yaml` should be in the build root of the repository. For most
 single-stack repositories, this means the root of the repository.
 
-For some realistic samples, see the [helm engine
-example][helm-engine-example] or the [quick start
-example][quick-start-example] in the template stack experience
+For a realistic sample for a complete user scenario, see the [quick
+start example][quick-start-example] in the template stack experience
 repository.
 
 ### Specifying default values
@@ -398,28 +397,67 @@ For the full example, see the sample in the
 
 The imagined implementation for how objects sent to the stack for
 rendering become resources is that the object's fields become the input
-for the template rendered by the controller. For more details, see the
-[detailed examples](https://github.com/suskin/template-stack-experience)
-or the [design document about the
+for the template rendered by the controller.
+
+For example, given this object as input:
+
+```yaml
+apiVersion: wordpress.samples.stacks.crossplane.io/v1alpha1
+kind: WordpressInstance
+metadata:
+  name: "my-wordpress-app-from-helm2"
+  namespace: dev
+spec:
+  engineVersion: "8.0"
+```
+
+The `engineVersion` field would be available to the templating engine
+which was being used, and would have a value of `8.0`. This means that
+if the engine being used were helm, the behavior would be equivalent to
+if there were a `values.yaml` passed in which looked like this:
+
+```yaml
+engineVersion: "8.0"
+```
+
+For the complete example, see the [quick start
+example][quick-start-example] in the template stack experience
+repository. The snippet was taken from the part of the example where the
+app stack is used.
+
+For more details, see the [design document about the
 internals](https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-template-stacks.md).
 
 ### Templating/configuration engine
 
 Template stacks will not be opinionated about which templating engine is
 used. We plan to support multiple configuration engines. The engine will
-be configurable by setting values in the `stack.yaml`.
+be configurable by setting values in the `stack.yaml`. Here's an example
+of a snippet from a `stack.yaml` which specifies a particular engine:
 
-For some realistic examples of what a stack would look like when it uses
-different engines, see the [quick start example][quick-start-example].
-There are also some more details in the [stack yaml
-section](#the-stackyaml), and in the [helm charts
-section](#helm-charts).
+```yaml
+behaviors:
+  engine:
+    type: kustomize
+```
+
+In some cases, the engine configuration line may be optional; the system
+may be able to infer the engine based on the structure of the stack. For
+example, if no engine is specified, and a `kustomization.yaml` is found,
+the engine could be inferred to be kustomize.
+
+For a more complete example of a user scenario, including usage of
+multiple different engines, see the [quick start
+example][quick-start-example]. There are also some more details in the
+[stack yaml section of this document](#the-stackyaml), and in the [helm
+charts section](#helm-charts).
 
 ### Lifecycle hooks
 
 We expect to eventually support lifecycle hooks. See the [speculative
 design in the template stacks experience repo](https://github.com/suskin/template-stack-experience/tree/master/wordpress-workload/go-templates/lifecycle-hook)
-for more details about what that could look like.
+for more details about what that could look like. Lifecycle hooks are
+out of the scope of this document, and will be revisited in the future.
 
 ### Internal representation of templates
 
@@ -433,25 +471,12 @@ implementation](https://github.com/crossplaneio/crossplane/blob/master/design/on
 
 ## Example use-cases
 
-See the [Template Stack
-Experience](https://github.com/suskin/template-stack-experience) code
-examples for some realistic examples of how different use-cases work
-with a realistic workload. For a coherent user scenario, see the [quick
-start example](https://github.com/suskin/template-stack-experience/tree/master/wordpress-workload/quick-start).
+For a coherent user scenario, see the [quick start
+example][quick-start-example].
 
-Examples covered by the repository mostly use go templates as the
-templating engine. The following cases are covered by the examples:
-
-* No variables at all in a set of configurations.
-* Variables in configurations with default variable values.
-* Variables in configurations, with values specified by users when a
-  render is requested.
-* Resource packs.
-* Multiple CRDs defined in a single Stack.
-* Multiple rendered variants of a given configuration.
-* Composing configuration using multiple Stacks.
-* A user scenario of setting up cloud provider resources and deploying
-  an application bundled as a stack.
+The scenario shows what it might look like for a user to set up an
+application and its infrastructure from scratch using Crossplane and
+Template Stacks. Multiple configuration engines are shown.
 
 ### Helm charts
 
@@ -461,7 +486,7 @@ chart][helm-engine-example], these steps could be followed:
 1. Create and initialize a template stack project, with a helm flag:
    `kubectl crossplane stack init --template`.
 2. Create a CRD: `kubectl crossplane stack crd init WordpressInstance
-   wordpressinstances wordpress.samples.stacks.crossplane.io`
+   wordpress.samples.stacks.crossplane.io`
 3. Put the chart's contents into the templates folder.
 4. Create a `stack.yaml` in the root of the repostory, and configure it
    to use the templates for the created CRD.
@@ -475,8 +500,7 @@ by specifying fields on the render request object.
 
 This use-case will probably need additional thought if we want to
 support all permutations of helm chart. For more realistic and complete
-examples, see the [helm engine example][helm-engine-example] and the
-helm variation of the app stack in the [quick start
+examples, see the helm variation of the app stack in the [quick start
 example][quick-start-example] in the template stack experience
 repository.
 
@@ -491,5 +515,5 @@ repository.
 
 <!-- Reference-style links -->
 [kubernetes-default-values]: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#defaulting
-[helm-engine-example]: https://github.com/suskin/template-stack-experience/tree/master/wordpress-workload/go-templates/helm-engine
+[helm-engine-example]: https://github.com/suskin/template-stack-experience/tree/master/wordpress-workload/quick-start/app-stack/helm2
 [quick-start-example]: https://github.com/suskin/template-stack-experience/tree/master/wordpress-workload/quick-start

--- a/design/design-doc-template-stacks-experience.md
+++ b/design/design-doc-template-stacks-experience.md
@@ -154,10 +154,10 @@ for those details.
 
 ## How to read this document
 
-This document is intended to be read alongside the [template stacks
-experience repository](https://github.com/suskin/template-stack-experience),
-which contains realistic code samples for different pieces of the
-functionality.
+This document is intended to be read alongside the quick start example
+in the [template stacks experience repository][quick-start-example],
+which contains an example of a complete user scenario of installing an
+application and its infrastructure using Crossplane and template stacks.
 
 Additionally, for more detail about the internals of template stacks on
 the stack manager and Crossplane side, see the [design doc focused on
@@ -170,9 +170,6 @@ very similar for all scenarios. It is expected that template stacks will
 support a wide variety of scenarios, so this section will show some
 examples to help explain them.
 
-For a more complete treatment of example scenarios, see the [template
-stack experience repository](https://github.com/suskin/template-stack-experience).
-
 ### Writing
 
 Creating a template stack from scratch involves only a couple steps. The
@@ -184,7 +181,7 @@ At a high level, the steps would be as follows:
 1. Create a project directory.
 2. In the project directory, `kubectl crossplane stack init --template
    myorg/mystack` to create the boilerplate of the stack layout.
-3. Relative to the project directory, put the yamls in
+3. Relative to the project directory, put the configuration yamls in
    `config/stack/manifests/resources`, or a different
    directory if desired, so long as the directory is in the right
    location in the stack artifact.
@@ -202,6 +199,16 @@ At a high level, the steps would be as follows:
 Note that we plan to merge `app.yaml` and `stack.yaml` into a single
 document (`stack.yaml`) in the future, so this set of steps is written
 as though that has already happened.
+
+#### Specifying configuration and templates
+
+Because we plan to support multiple engines, this document won't get
+into the specifics of what templates look like. That said, if a helm
+chart were being used (for example), then the helm chart could be placed
+in a folder (such as `wordpress`) in the resources directory, and the
+stack would be configured to use that directory. Using the folder
+structure described above, that would mean that root of the helm chart
+would exist at `configu/stack/manifests/resources/wordpress`.
 
 #### Adding a CRD
 
@@ -324,6 +331,15 @@ example, with comments explaining the directives:
 # to a given object type. An instance of the object type is
 # considered to be a "render request".
 behaviors:
+  # An engine configuration here will apply to the rest of the
+  # configuration, but it could also be specified at a per-crd
+  # level, or as low as a per-hook level. Engine configurations
+  # nested deeper in the configuration hierarchy will override
+  # ones which are higher up in the hierarchy, so a hook-level
+  # configuration would override this one.
+  engine:
+    type: kustomize
+
   crds:
     # This is a particular CRD which is being configured. When the
     # controller sees an object of this type, it will do something.
@@ -420,6 +436,11 @@ if there were a `values.yaml` passed in which looked like this:
 engineVersion: "8.0"
 ```
 
+We expect the configuration to support the same things as the underlying
+engine. So, for example, nested configuration values would be supported
+just as well as they would be with a regular `values.yaml` for a helm
+chart.
+
 For the complete example, see the [quick start
 example][quick-start-example] in the template stack experience
 repository. The snippet was taken from the part of the example where the
@@ -445,6 +466,10 @@ In some cases, the engine configuration line may be optional; the system
 may be able to infer the engine based on the structure of the stack. For
 example, if no engine is specified, and a `kustomization.yaml` is found,
 the engine could be inferred to be kustomize.
+
+The engine can be specified at multiple levels; setting it under
+`behaviors` will set a default, but setting it lower down will override
+a value set at a higher level. It can be configured per hook.
 
 For a more complete example of a user scenario, including usage of
 multiple different engines, see the [quick start
@@ -506,7 +531,6 @@ repository.
 
 ## Further reading
 
-* [Template Stack Experience](https://github.com/suskin/template-stack-experience) examples
 * [Template Stack Experience - Quick Start Example](https://github.com/suskin/template-stack-experience/tree/master/wordpress-workload/quick-start)
 * [Declarative Application Management in Kubernetes](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/declarative-application-management.md)
 * [Template Stacks internals design doc](https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-template-stacks.md)

--- a/design/design-doc-template-stacks-experience.md
+++ b/design/design-doc-template-stacks-experience.md
@@ -337,15 +337,23 @@ behaviors:
     # This is a particular CRD which is being configured. When the
     # controller sees an object of this type, it will do something.
     wordpressinstance.wordpress.samples.stacks.crossplane.io:
-      # These are the templates which should be rendered when an object
-      # of the type above is seen.
-      #
-      # Defaults for the variables can be defined in the default values
-      # for the CRD fields, using the standard Kubernetes mechanism for
-      # specifying CRD field default values.
-      resources:
-        # Each list item is a folder of files which will be rendered.
-        - wordpress
+      # This is a top-level object to namespace hook configurations.
+      # There can be hooks for multiple different types of events.
+      hooks:
+        # Post create is triggered after an instance is created
+        postCreate:
+          # These are the templates which should be rendered when an object
+          # of the type above is seen.
+          #
+          # Defaults for the variables can be defined in the default values
+          # for the CRD fields, using the standard Kubernetes mechanism for
+          # specifying CRD field default values.
+          # Note that this is a list of objects, so multiple can be
+          # specified.
+          - directory: wordpress
+        # Post create is triggered after an instance is changed
+        postUpdate:
+          - directory: wordpress
 EOF
 ```
 

--- a/design/design-doc-template-stacks-experience.md
+++ b/design/design-doc-template-stacks-experience.md
@@ -4,6 +4,35 @@
 * Reviewers: Crossplane Maintainers
 * Status: Draft, revision 1.0
 
+## Outline
+
+* [Background](#background)
+* [Goals](#goals)
+* [Non-goals](#non-goals)
+* [Terms](#terms)
+* [How to read this document](#how-to-read-this-document)
+* [Design](#design)
+  * [Writing](#writing)
+    * [Adding a CRD](#adding-a-crd)
+  * [Building and publishing](#building-and-publishing)
+  * [Consuming](#consuming)
+    * [Install](#install)
+    * [Create](#create)
+    * [Delete](#delete)
+    * [Uninstall](#uninstall)
+    * [Upgrade and update](#upgrade-and-update)
+  * [The stack.yaml](#the-stackyaml)
+    * [Specifying how to process render requests](#specifying-how-to-process-render-requests)
+  * [Specifying default values](#specifying-default-values)
+  * [How processing objects works under the covers](#how-processing-objects-works-under-the-covers)
+  * [Templating/configuration engine](#templatingconfiguration-engine)
+  * [Lifecycle hooks](#lifecycle-hooks)
+  * [Internal representation of templates](#internal-representation-of-templates)
+  * [The template stack controller](#the-template-stack-controller)
+* [Example use-cases](#example-use-cases)
+  * [Helm charts](#helm-charts)
+* [Further reading](#further-reading)
+
 ## Background
 
 Managing configuration of bespoke Kubernetes applications has been a

--- a/design/design-doc-template-stacks-experience.md
+++ b/design/design-doc-template-stacks-experience.md
@@ -328,7 +328,7 @@ behaviors:
     # This is a particular CRD which is being configured. When the
     # controller sees an object of this type, it will do something.
     wordpressinstance.wordpress.samples.stacks.crossplane.io:
-      # This is a top-level object to namespace hook configurations.
+      # This is a top-level object to group hook configurations.
       # There can be hooks for multiple different types of events.
       hooks:
         # Post create is triggered after an instance is created
@@ -342,7 +342,7 @@ behaviors:
           # Note that this is a list of objects, so multiple can be
           # specified.
           - directory: wordpress
-        # Post create is triggered after an instance is changed
+        # Post update is triggered after an instance is changed
         postUpdate:
           - directory: wordpress
 ```

--- a/design/design-doc-template-stacks-experience.md
+++ b/design/design-doc-template-stacks-experience.md
@@ -185,21 +185,23 @@ At a high level, the steps would be as follows:
 2. In the project directory, `kubectl crossplane stack init --template
    myorg/mystack` to create the boilerplate of the stack layout.
 3. Relative to the project directory, put the yamls in
-   `config/stack/manifests/resources/templates`, or a different
-   directory if desired.
+   `config/stack/manifests/resources`, or a different
+   directory if desired, so long as the directory is in the right
+   location in the stack artifact.
 4. Add CRD definitions; this could be done by putting CRD yaml
    definitions in `config/stack/manifests/resources` or in
    `config/crd/bases`. We plan to make this simpler for the user by
    adding a crossplane-cli command for it.
 5. Add configuration to `stack.yaml` to
    specify how configurations are rendered.
-6. Edit `config/stack/manifests/resources/app.yaml` to specify that the
-   stack will be working with all of the kinds that it will be working
-   with (using the `dependsOn` field).
-7. Edit `config/stack/manifests/resources/app.yaml` as appropriate.
+6. Edit `stack.yaml` to specify that the stack will be working with all
+   of the kinds that it will be working with (using the `dependsOn`
+   field).
+7. Edit `stack.yaml` as appropriate.
 
-In the future, we expect that we will combine `app.yaml` and
-`stack.yaml`.
+Note that we plan to merge `app.yaml` and `stack.yaml` into a single
+document (`stack.yaml`) in the future, so this set of steps is written
+as though that has already happened.
 
 #### Adding a CRD
 

--- a/design/design-doc-template-stacks-experience.md
+++ b/design/design-doc-template-stacks-experience.md
@@ -115,14 +115,13 @@ Experience, there are many things which are out of scope. These include:
   evolve over time as people use it and gain insights about how to
   improve it.
 * Dynamic name prefixing or suffixing.
-* Support for Kustomize / overlays.
 * Automatically wrapping application configurations as Crossplane
   workloads.
 * Automatically creating resources (other than CRDs) when a stack is
   installed.
 * Updating output; the high-level idea of re-rendering and letting the
   other stacks take care of the updates seems close enough for now.
-* Updating stack. This should happen as part of the other thinking
+* Updating a stack. This should happen as part of the other thinking
   about versioning and how to update a stack's version.
 * Updating the stack manager / shared controller. Eventually we'll
   need a controller version, and knowing that seems good enough for

--- a/design/design-doc-template-stacks-experience.md
+++ b/design/design-doc-template-stacks-experience.md
@@ -7,9 +7,9 @@
 ## Outline
 
 * [Background](#background)
+* [Terms](#terms)
 * [Goals](#goals)
 * [Non-goals](#non-goals)
-* [Terms](#terms)
 * [How to read this document](#how-to-read-this-document)
 * [Design](#design)
   * [Writing](#writing)
@@ -83,6 +83,22 @@ examples](https://github.com/suskin/template-stack-experience) of what
 writing and interacting with a Template Stack may look like for
 different use-cases.
 
+## Terms
+
+* A **render request** is an instance of a resource Kind recognized by
+  the Template Stack (such as a Kind defined by a custom resource). It
+  tells the stack that some configuration is desired.
+* A **template** is a chunk of configuration which will be reused by
+  the Template Stack to create configuration.
+* A **render** is the configuration which is the output of the stack's
+  controller in response to a render request. The configuration is
+  created by processing the stack's input templates using the desired
+  engine, and using the render request for context.
+* **Behaviors** are the configuration settings for a Template Stack.
+  For example, so that its controller knows how to respond to a render
+  request of a known type.
+
+
 ## Goals
 
 The goal of this document is to propose and discuss what the developer
@@ -126,30 +142,15 @@ Experience, there are many things which are out of scope. These include:
 * Updating the stack manager / shared controller. Eventually we'll
   need a controller version, and knowing that seems good enough for
   now.
-* Setting status in the CRD. This would be nice to have, but it seems
-  independent from the other stuff we're working on. It duplicates
-  information already in the system, so it's not a topmost priority at
-  this time.
+* Setting status in the render request. This would be nice to have, but
+  it seems independent from the other stuff we're working on. It
+  duplicates information already in the system, so it's not a topmost
+  priority at this time.
 
 Also out of scope is the internal representation of configuration, and
 the implementation of the stack manager. See the [complementary
 internals-oriented Template Stack design doc](https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-template-stacks.md)
 for those details.
-
-## Terms
-
-* A **render request** is an instance of a CRD recognized by the
-  Template Stack. It tells the stack that some configuration is
-  desired.
-* A **template** is a chunk of configuration which will be reused by
-  the Template Stack to create configuration.
-* A **render** is the configuration which is the output of the stack's
-  controller in response to a render request. The configuration is
-  created by processing the stack's input templates using the desired
-  engine, and using the render request for context.
-* **Behaviors** are the configuration settings for a Template Stack.
-  For example, so that its controller knows how to respond to a render
-  request of a known type.
 
 ## How to read this document
 

--- a/design/design-doc-template-stacks-experience.md
+++ b/design/design-doc-template-stacks-experience.md
@@ -411,6 +411,12 @@ Template stacks will not be opinionated about which templating engine is
 used. We plan to support multiple configuration engines. The engine will
 be configurable by setting values in the `stack.yaml`.
 
+For some realistic examples of what a stack would look like when it uses
+different engines, see the [quick start example][quick-start-example].
+There are also some more details in the [stack yaml
+section](#the-stackyaml), and in the [helm charts
+section](#helm-charts).
+
 ### Lifecycle hooks
 
 We expect to eventually support lifecycle hooks. See the [speculative
@@ -472,8 +478,9 @@ by specifying fields on the render request object.
 This use-case will probably need additional thought if we want to
 support all permutations of helm chart. For more realistic and complete
 examples, see the [helm engine example][helm-engine-example] and the
-[quick start example][quick-start-example] in the template stack
-experience repository.
+helm variation of the app stack in the [quick start
+example][quick-start-example] in the template stack experience
+repository.
 
 ## Further reading
 

--- a/design/design-doc-template-stacks-experience.md
+++ b/design/design-doc-template-stacks-experience.md
@@ -1,0 +1,360 @@
+# Template Stacks Experience
+
+* Owner: Daniel Suskin (@suskin)
+* Reviewers: Crossplane Maintainers
+* Status: Draft
+
+## Background
+
+Managing configuration of bespoke Kubernetes applications has been a
+topic of much interest and discussion in the Kubernetes community. A
+[design document written by Brian
+Grant](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/declarative-application-management.md)
+gives a nice overview of the space, and proposes some of the properties
+and techniques that a unified solution would have.
+
+A summary of the properties would be:
+
+* Usage of Kubernetes APIs and patterns without going outside of them,
+  so that existing and future tooling can easily integrate with what
+  is built.
+* Support for overlay-style configuration overrides, for their
+  maintainability and expressiveness.
+* Support for template-style configuration, for its ease of use for
+  simple cases.
+  * Alternatively, simple cases may be handled individually instead
+    of via a general templating mechanism.
+
+Users could choose an overlay-oriented approach or a template-style
+approach. In general, overlay-oriented configuration is considered
+better when the user has a large and complex configuration codebase, or
+when extending a third-party configuration is needed. Template-oriented
+configuration is considered easier to use for simple cases, especially
+for people who are not accustomed to overlay-oriented configuration.
+
+The most prominent overlay-oriented configuration tool is
+[kustomize](https://github.com/kubernetes-sigs/kustomize), which
+recently became part of the mainline kubectl tool. The most prominent
+template-oriented configuration tool is [helm](https://helm.sh/), which
+is the de-facto standard tool for managing resource configuration
+bundles in Kubernetes.
+
+On the Crossplane side, the extensibility model is still relatively new.
+In the most recent release, the concept of
+[Stacks](https://github.com/crossplaneio/crossplane/blob/master/design/design-doc-stacks.md)
+was introduced, and the first version of some [tooling to help write
+Stacks](https://github.com/crossplaneio/crossplane-cli) was also
+introduced. The Crossplane project has been working toward making Stacks
+[easier to
+write](https://github.com/crossplaneio/crossplane/issues/853), ideally
+to the point where an author doesn't need to write a full controller.
+The easier version of Stacks is being called "Template Stacks". There is
+now [a repository with some
+examples](https://github.com/suskin/template-stack-experience) of what
+writing and interacting with a Template Stack may look like for
+different use-cases.
+
+## Goals
+
+The goal of this document is to propose and discuss what the developer
+and user experience would look like for Template Stacks. This
+encompasses the complete lifecycle of a Template Stack: project setup,
+development, testing, publishing, and consuming.
+
+Some of the design goals include:
+
+* Reuse existing Kubernetes APIs and patterns wherever possible.
+* Support overlays, for their maintainability and extensibility.
+* Support templates, for their ease of use for simple use-cases, or a
+  solution of equivalent simplicity for simple use-cases.
+* Allow developers to avoid writing a controller if their Stack fits
+  the pattern of provisioning some set of resources.
+
+We plan to support overlays in the long run, but plan to start with
+templates, because they are easier for users to get into when they're
+not familiar with overlays.
+
+## Non-goals
+
+Because this is the first iteration of the Template-style Stacks
+Experience, there are many things which are out of scope. These include:
+
+* Injecting values into stacks from outside of the stack (such as
+  external resources or other stacks); also known as live value
+  referencing.
+* Creating the final form of template stacks; this is expected to
+  evolve over time as people use it and gain insights about how to
+  improve it.
+* Dynamic name prefixing or suffixing.
+* Support for Kustomize / overlays.
+* Automatically wrapping application configurations as Crossplane
+  workloads.
+* Automatically creating resources (other than CRDs) when a stack is
+  installed.
+* Updating output; the high-level idea of re-rendering and letting the
+  other stacks take care of the updates seems close enough for now.
+* Updating stack. This should happen as part of the other thinking
+  about versioning and how to update a stack's version.
+* Updating the stack manager / shared controller. Eventually we'll
+  need a controller version, and knowing that seems good enough for
+  now.
+* Setting status in the CRD. This would be nice to have, but it seems
+  independent from the other stuff we're working on. It duplicates
+  information already in the system, so it's not a topmost priority at
+  this time.
+
+Also out of scope is the internal representation of configuration, and
+the implementation of the stack manager. See the [complementary
+internals-oriented Template Stack design doc](https://github.com/crossplaneio/crossplane/pull/928)
+for those details.
+
+## Terms
+
+* A **render request** is an instance of a CRD recognized by the
+  Template Stack. It tells the stack that some configuration is
+  desired.
+* A **template** is a chunk of configuration which will be reused by
+  the Template Stack to create configuration.
+* A **render** is the configuration which is the output of the stack's
+  controller in response to a render request. The configuration is
+  created by processing the stack's input templates using the desired
+  engine, and using the render request for context.
+* **Behaviors** are the configuration settings for a Template Stack.
+  For example, so that its controller knows how to respond to a render
+  request of a known type.
+
+## Design
+
+The overall flow of authoring and consuming a template stack will be
+very similar for all scenarios. It is expected that template stacks will
+support a wide variety of scenarios, so this section will show some
+examples to help explain them.
+
+For a more complete treatment of example scenarios, see the [template
+stack experience repository](https://github.com/suskin/template-stack-experience).
+### Writing
+
+Creating a template stack from scratch involves only a couple steps. The
+project must first be initialized, and then the yamls must be put in a
+particular directory. The rbac requirements for the stack must also be
+configured, though some of that is done by the stack manager at runtime.
+At a high level, the steps would be as follows:
+
+1. Create a project directory.
+2. In the project directory, `kubectl crossplane stack init --template
+   myorg/mystack` to create the boilerplate of the stack layout.
+3. Relative to the project directory, put the yamls in
+   `config/stack/manifests/resources/templates` .
+4. Add CRD definitions; this could be done by putting CRD yaml
+   definitions in `config/stack/manifests/resources` or in
+   `config/crd/bases`.
+5. Add configuration to `config/stack/manifests/behaviors.yaml` to
+   specify how configurations are rendered.
+6. Edit `config/stack/manifests/resources/app.yaml` to specify that the
+   stack will be working with all of the kinds that it will be working
+   with (using the `dependsOn` field).
+7. Edit `config/stack/manifests/resources/app.yaml` as appropriate.
+
+#### Adding a CRD
+
+The tooling will make it simpler to add a CRD from scratch. For example,
+the following would create a basic CRD in the appropriate folder, and
+would update the `dependsOn` field of the stack's `app.yaml`:
+
+```
+kubectl crossplane stack crd init WordpressInstance wordpressinstances wordpress.samples.stacks.crossplane.io
+```
+
+### Building and publishing
+
+To build and publish a stack, the standard steps for building and
+publishing a stack are used.
+
+Building:
+
+```
+kubectl crossplane stack build
+```
+
+Publishing:
+
+```
+kubectl crossplane stack publish
+```
+
+### Consuming
+
+Consuming has two steps: installation and creation. Installation is
+installing the stack into the Crossplane control cluster. Creation is
+creating a Kubernetes resource which the stack recognizes, so that the
+stack will do something in response to it. In the case of template
+stacks, that usually will look something like rendering a set of yamls
+and applying the rendered output to the cluster.
+
+#### Install
+
+Installation is much the same as installing any stack:
+
+```
+kubectl crossplane stack install myorg/mystack mystack
+```
+
+This installs the stack from the `myorg/mystack` image, using the name `mystack`.
+
+#### Create
+
+Instantiation is also very similar to any stack:
+
+```
+cat > my-instance.yaml <<EOF
+apiVersion: thing.samples.stacks.crossplane.io/v1alpha1
+kind: ThingInstance
+metadata:
+  name: thinginstance-sample
+spec:
+  myfield: myvalue
+EOF
+
+kubectl apply -f my-instance.yaml
+```
+
+The difference is that underneath, the ThingInstance will be used as the
+input for rendering a template.
+
+#### Delete
+
+When the ThingInstance is deleted, the corresponding resources will also
+be deleted. This is the same behavior as in any stack.
+
+```
+cat > my-instance.yaml <<EOF
+apiVersion: thing.samples.stacks.crossplane.io/v1alpha1
+kind: ThingInstance
+metadata:
+  name: thinginstance-sample
+spec:
+  myfield: myvalue
+EOF
+
+kubectl delete -f my-instance.yaml
+```
+
+The instance is also deleted if the stack is uninstalled.
+
+#### Uninstall
+
+Uninstall looks the same as any other stack:
+
+```
+kubectl crossplane stack uninstall mystack
+```
+
+#### Upgrade and update
+
+Upgrading a stack version, and updating an instance of an object managed
+by the stack, are out of scope of this document. However, one could
+imagine that the process of upgrading a stack version would change a
+version number on object instances which go with the stack, and that the
+version number change would underneath cause the template to be rendered
+again and applied to the cluster.
+
+### Specifying how to process render requests
+
+A Stack author must create a `behaviors.yaml` in order to configure how
+templates are rendered in response to a render request. Here's an
+example, with comments explaining the directives:
+
+```
+cat > config/stack/manifests/behaviors.yaml <<EOF
+# This field configures which templates are rendered in response
+# to a given object type. An instance of the object type is
+# considered to be a "render request".
+crdOutputs:
+  # This is a particular CRD which is being configured. When the
+  # controller sees an object of this type, it will do something.
+  wordpressinstance.wordpress.samples.stacks.crossplane.io/v1alpha1:
+    # These are the templates which should be rendered when an object
+    # of the type above is seen.
+    resources:
+      # These are individual files which will be rendered.
+      - kubernetescluster.yaml
+      - mysqlinstance.yaml
+      - kubernetesapplication.yaml
+    # This configures default values for the variables in the
+    # templates being rendered.
+    defaults:
+      # This is a list of files to use for default values. They
+      # will be merged together in the specified order to create
+      # the default template variables in the context.
+      - defaults.yaml
+EOF
+```
+
+### How processing objects works under the covers
+
+The imagined implementation for how objects sent to the stack for
+rendering become resources is that the object's fields become the input
+for the template rendered by the controller. For more details, see the
+[detailed examples](https://github.com/suskin/template-stack-experience)
+or the [design document about the
+internals](https://github.com/crossplaneio/crossplane/pull/928).
+
+### Internal representation of templates
+
+See the [design doc on the internals of the Template Stack
+implementation](https://github.com/crossplaneio/crossplane/pull/928).
+
+### The template stack controller
+
+See the [design doc on the internals of the Template Stack
+implementation](https://github.com/crossplaneio/crossplane/pull/928).
+
+## Example use-cases
+
+See the [Template Stack
+Experience](https://github.com/suskin/template-stack-experience) code
+examples for some realistic examples of how different use-cases work
+with a realistic workload.
+
+Examples covered by the repository all currently use go templates as the
+templating engine. The following cases are covered by the examples:
+
+* No variables at all in a set of configurations.
+* Variables in configurations with default variable values.
+* Variables in configurations, with values specified by users when a
+  render is requested.
+* Resource packs.
+* Multiple CRDs defined in a single Stack.
+* Multiple rendered variants of a given configuration.
+* Composing configuration using multiple Stacks.
+
+### Helm charts
+
+To author a template stack from a simple helm chart, these steps could
+be followed:
+
+1. Create and initialize a template stack project, with a helm flag:
+   `kubectl crossplane stack init --template`.
+2. Create a CRD: `kubectl crossplane stack crd init WordpressInstance
+   wordpressinstances wordpress.samples.stacks.crossplane.io`
+3. Put the chart's contents into the templates folder.
+4. Create a `behaviors.yaml` and configure it to use the templates for
+   the created CRD.
+5. To set up default values:
+    1. Put the contents of the chart's `values.yaml` in the templates
+       folder, and configure `behaviors.yaml` to use it as the file with
+       the default values in it.
+6. Bundle and publish the stack.
+
+When consuming the stack, the default template values can be overridden
+by specifying fields on the render request object.
+
+This use-case will probably need additional thought if we want to
+support all permutations of helm chart.
+
+## Further reading
+
+* [Template Stack Experience](https://github.com/suskin/template-stack-experience) examples
+* [Declarative Application Management in Kubernetes](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/declarative-application-management.md)
+* [Template Stacks internals design doc](https://github.com/crossplaneio/crossplane/pull/928)
+* [Stacks CLI design](https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-stack-cli.md)

--- a/design/design-doc-template-stacks-experience.md
+++ b/design/design-doc-template-stacks-experience.md
@@ -204,8 +204,8 @@ In the future, we expect that we will combine `app.yaml` and
 #### Adding a CRD
 
 The tooling will make it simpler to add a CRD from scratch. For example,
-the following would create a basic CRD in the appropriate folder, and
-would update the `dependsOn` field of the stack's `app.yaml`:
+the following would create a basic CRD in the appropriate folder, so
+that it becomes part of the stack:
 
 ```
 kubectl crossplane stack crd init WordpressInstance wordpressinstances wordpress.samples.stacks.crossplane.io

--- a/design/design-doc-template-stacks-experience.md
+++ b/design/design-doc-template-stacks-experience.md
@@ -268,19 +268,16 @@ This installs the stack from the `myorg/mystack` image, using the name `mystack`
 
 #### Create
 
-Instantiation is also very similar to any stack:
+Instantiation is also very similar to creating any object. Here is some
+sample yaml:
 
-```
-cat > my-instance.yaml <<EOF
+```yaml
 apiVersion: thing.samples.stacks.crossplane.io/v1alpha1
 kind: ThingInstance
 metadata:
   name: thinginstance-sample
 spec:
   myfield: myvalue
-EOF
-
-kubectl apply -f my-instance.yaml
 ```
 
 The difference is that underneath, the ThingInstance will be used as the
@@ -290,19 +287,6 @@ input for rendering a template.
 
 When the ThingInstance is deleted, the corresponding resources will also
 be deleted. This is the same behavior as in any stack.
-
-```
-cat > my-instance.yaml <<EOF
-apiVersion: thing.samples.stacks.crossplane.io/v1alpha1
-kind: ThingInstance
-metadata:
-  name: thinginstance-sample
-spec:
-  myfield: myvalue
-EOF
-
-kubectl delete -f my-instance.yaml
-```
 
 The instance is also deleted if the stack is uninstalled.
 
@@ -335,8 +319,7 @@ A Stack author must create a `stack.yaml` in order to configure how
 templates are rendered in response to a render request. Here's an
 example, with comments explaining the directives:
 
-```
-cat > stack.yaml <<EOF
+```yaml
 # This field configures which templates are rendered in response
 # to a given object type. An instance of the object type is
 # considered to be a "render request".
@@ -362,7 +345,6 @@ behaviors:
         # Post create is triggered after an instance is changed
         postUpdate:
           - directory: wordpress
-EOF
 ```
 
 The `stack.yaml` should be in the build root of the repository. For most

--- a/design/design-doc-template-stacks-experience.md
+++ b/design/design-doc-template-stacks-experience.md
@@ -210,8 +210,12 @@ the following would create a basic CRD in the appropriate folder, so
 that it becomes part of the stack:
 
 ```
-kubectl crossplane stack crd init WordpressInstance wordpressinstances wordpress.samples.stacks.crossplane.io
+kubectl crossplane stack crd init WordpressInstance wordpress.samples.stacks.crossplane.io
 ```
+
+The command will generate a reasonable version (such as `v1alpha1`), and
+sensible list, plural, and singular names from the input; the generated
+values can be adjusted by the user in the CRD file.
 
 There will also be a convenience flag in the `stack init` command so
 that people starting from scratch can initialize the stack and the first
@@ -220,9 +224,11 @@ CRD with a single command:
 ```
 $ kubectl crossplane stack init --template mygroup/mystackname --init-crd
 > CRD name: WordpressInstance
-> CRD plural: wordpressinstances
-> CRD subdomain: wordpress.samples.stacks.crossplane.io
+> CRD api group: wordpress.samples.stacks.crossplane.io
 ```
+
+In the future, we will likely do more work in the are of making CRDs and
+their schemas simpler to write.
 
 ### Building and publishing
 


### PR DESCRIPTION
## Overview

As part of creating template stacks, we want to explore what the
experience looks like at the beginning, and then work backwards from
there. This helps us focus on the user experience early, and helps us
iron out **some** kinks before we even begin. This design doc and the
code which it links to are an attempt at that.

This document is intended to be consumed alongside these code examples: https://github.com/suskin/template-stack-experience

[skip ci]