### PR TITLE
Cluster scoped cluster stacks

### DIFF
--- a/apis/stacks/v1alpha1/types.go
+++ b/apis/stacks/v1alpha1/types.go
@@ -23,6 +23,7 @@ import (
 	batch "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -103,10 +104,10 @@ func (si *StackInstall) Image() string { return si.Spec.Image() }
 func (si *ClusterStackInstall) Image() string { return si.Spec.Image() }
 
 // PermissionScope gets the required app.yaml permissionScope value ("Namespaced") for StackInstall
-func (si *StackInstall) PermissionScope() string { return "Namespaced" }
+func (si *StackInstall) PermissionScope() string { return string(apiextensions.NamespaceScoped) }
 
 // PermissionScope gets the required app.yaml permissionScope value ("Cluster") for ClusterStackInstall
-func (si *ClusterStackInstall) PermissionScope() string { return "Cluster" }
+func (si *ClusterStackInstall) PermissionScope() string { return string(apiextensions.ClusterScoped) }
 
 // SetConditions sets the StackInstall's Status conditions
 func (si *StackInstall) SetConditions(c ...runtimev1alpha1.Condition) {

--- a/design/one-pager-stacks-security-isolation.md
+++ b/design/one-pager-stacks-security-isolation.md
@@ -2,7 +2,14 @@
 
 * Owner: Jared Watts (@jbw976)
 * Reviewers: Crossplane Maintainers
-* Status: Draft, revision 1.0
+* Status: Draft, revision 1.1
+
+## Revisions
+
+* 1.1
+  * Cluster stacks may own Cluster scoped CRDs
+    [#958](https://github.com/crossplaneio/crossplane/pull/958)
+  * Namespaced stacks may depend on Cluster scoped CRDs [#958](https://github.com/crossplaneio/crossplane/pull/958)
 
 ## Background
 
@@ -69,10 +76,12 @@ This is described in greater details in the sections below.
 
 A few notes on the scope of access to CRDs:
 
-* All CRDs the stack owns and depends on are expected to be namespace scoped CRDs. Access to cluster scoped CRDs will not be granted, even for Cluster Stacks.
+* All CRDs a Namespaced stack owns must be namespace scoped CRDs. Cluster scoped Stacks may own cluster scoped CRDs.
+* Namespaced and Cluster scoped Stacks may depend on a combination of namespaced or cluster scoped CRDs.
 * The allowed verbs for the CRDs the stack owns and depends on will be the same. Stacks will likely need full CRUD access, regardless of if the stack owns or depends on the CRD.
 
-In the future, other security modes could be enabled such as a more explicit model, and the allowed set of permissions and scope could be expanded, but we are intentionally starting now with a restrictive scope.
+In the future, other security modes could be enabled such as a more explicit model, and the allowed set of permissions and scope could be expanded.  We are intentionally starting
+with a restrictive scope compatible with Crossplane Managed Resource Infrastructure Stacks and [Resource Class Selection](https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-simple-class-selection.md#proposal).
 We will allow feedback and real use cases from the community to inform any decisions to potentially expand this security model.
 Any future expansions to the model should be accompanied by a thoughtful design.
 

--- a/pkg/stacks/steps.go
+++ b/pkg/stacks/steps.go
@@ -81,7 +81,10 @@ func crdStep(sp StackPackager) walker.Step {
 			return errors.Wrap(err, fmt.Sprintf("invalid crd %q", path))
 		}
 
-		if (crd.Spec.Scope != apiextensions.NamespaceScoped) && (crd.Spec.Scope != "") {
+		stackIsNamespacedScope := sp.IsNamespaced()
+		crdIsNotNamespacedScope := (crd.Spec.Scope != apiextensions.NamespaceScoped) && (crd.Spec.Scope != "")
+
+		if stackIsNamespacedScope && crdIsNotNamespacedScope {
 			return errors.New(fmt.Sprintf("Stack CRD %q must be namespaced scope", path))
 		}
 

--- a/pkg/stacks/unpack.go
+++ b/pkg/stacks/unpack.go
@@ -112,6 +112,7 @@ type StackPackager interface {
 	SetRBAC(v1alpha1.PermissionsSpec)
 
 	GotApp() bool
+	IsNamespaced() bool
 
 	AddGroup(string, StackGroup)
 	AddResource(string, StackResource)
@@ -183,6 +184,11 @@ func (sp *StackPackage) Yaml() (string, error) {
 	}
 
 	return builder.String(), nil
+}
+
+// IsNamespaced reports if the StackPackage is Namespaced (not Cluster Scoped)
+func (sp *StackPackage) IsNamespaced() bool {
+	return sp.Stack.Spec.PermissionScope == string(apiextensions.NamespaceScoped)
 }
 
 // SetApp sets the Stack's App metadata


### PR DESCRIPTION

### Description of your changes

Cluster scoped CRDs are now supported since the [Simple Resource Class
Selection](https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-simple-class-selection.md#proposal) design was adopted.

> Providers, managed resources, and resource classes would be cluster scoped rather than namespaced.

The original Stack Isolation design has also been updated, reversing
this previous stance:

> All CRDs the stack owns and depends on are expected to be namespace scoped CRDs. Access to cluster scoped CRDs will not be granted, even for Cluster Stacks.

Closes #958
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml