### PR TITLE
build: new Jenkinsfiles for tag and promote

### DIFF
--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -1,0 +1,37 @@
+pipeline {
+    agent { label 'upbound-gce' }
+
+    parameters {
+        string(name: 'version', defaultValue: '', description: 'The version you are releasing, for example v0.4.0')
+        string(name: 'channel', defaultValue: 'alpha', description: 'Channel you are promoting the given version to, for example alpha.')
+    }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    environment {
+        DOCKER = credentials('dockerhub-upboundci')
+        AWS = credentials('aws-upbound-bot')
+    }
+
+    stages {
+        stage('Promote Release') {
+
+            steps {
+                sh 'docker login -u="${DOCKER_USR}" -p="${DOCKER_PSW}"'
+                sh "./build/run make -j\$(nproc) promote BRANCH_NAME=${BRANCH_NAME} VERSION=${params.version} CHANNEL=${params.channel} AWS_ACCESS_KEY_ID=${AWS_USR} AWS_SECRET_ACCESS_KEY=${AWS_PSW}"
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                sh 'make -j\$(nproc) clean'
+                deleteDir()
+            }
+        }
+    }
+}

--- a/Jenkinsfile.tag
+++ b/Jenkinsfile.tag
@@ -1,0 +1,42 @@
+pipeline {
+    agent { label 'upbound-gce' }
+
+    parameters {
+        string(name: 'version', defaultValue: '', description: 'The version you are releasing, for example v0.4.0')
+        string(name: 'commit', defaultValue: '', description: 'Optional commit hash for this release, for example 56b65dba917e50132b0a540ae6ff4c5bbfda2db6. If empty the latest commit hash will be used.')
+    }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    environment {
+        GITHUB_UPBOUND_BOT = credentials('github-upbound-jenkins')
+    }
+
+    stages {
+
+        stage('Prepare') {
+            steps {
+                 // github credentials are not setup to push over https in jenkins. add the github token to the url
+                sh "git config remote.origin.url https://${GITHUB_UPBOUND_BOT_USR}:${GITHUB_UPBOUND_BOT_PSW}@\$(git config --get remote.origin.url | sed -e 's/https:\\/\\///')"
+                sh 'git config user.name "upbound-bot"'
+                sh 'git config user.email "info@crossplane.io"'
+                sh 'echo "machine github.com login upbound-bot password $GITHUB_UPBOUND_BOT" > ~/.netrc'
+            }
+        }
+
+        stage('Tag Release') {
+            steps {
+                sh "./build/run make -j\$(nproc) tag VERSION=${params.version} COMMIT_HASH=${params.commit}"
+            }
+        }
+    }
+
+    post {
+        always {
+            deleteDir()
+        }
+    }
+}


### PR DESCRIPTION
### Description of your changes

This PR includes two new Jenkinsfiles that will be used for two new Jenkins pipelines related to releasing Crossplane:

* tag: Used to tag a particular commit hash with a specific version, e.g. `v0.4.0`.
* promote: Used to promote a version to a specific channel, e.g. `alpha`.

We have been running these steps manually for all previous Crossplane releases and this automation will make the release process much more simple.

Full documentation/guide on how to use these pipelines and the release process in general will be coming with a fix for #911 

These Jenkinsfiles have been tested with a mock Crossplane repo and pipelines:
* https://github.com/crossplaneio/release-test
* https://jenkinsci.upbound.io/job/crossplane/job/release-test-tag/
* https://jenkinsci.upbound.io/job/crossplane/job/release-test-promote/

You can see that the docker image has been tagged, released, and promoted in https://cloud.docker.com/u/crossplane/repository/docker/crossplane/release-test/tags.

Related to #6 

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml