### PR TITLE
optionally install stack-rook during Crossplane helm chart install

### DIFF
--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -23,3 +23,6 @@ clusterStacks:
   azure:
     version: v0.1.0
     deploy: false
+  rook:
+    version: master
+    deploy: false


### PR DESCRIPTION
### Description of your changes

This PR adds `stack-rook` to the set of optional stacks that can be installed through the Crossplane helm chart.  Very similar to the existing options for the AWS/GCP/Azure stacks, it will be installed at Helm chart install time with the following value set:

```
--set clusterStacks.rook.deploy=true
```

Note there wasn't documentation added for the original 3 cloud provider stacks, so it would be useful to add docs for how to use this general feature to install stacks along with the helm chart, but that should not block this PR since this docs gap already exists.

Fixes #982 

### Checklist
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml