### PR TITLE
Helm chart: fix crd issues when stacks enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,11 @@ go.test.unit: $(KUBEBUILDER)
 manifests: vendor kubebuilder.manifests
 	@$(INFO) Generating CRD manifests
 	$(CONTROLLERGEN) crd:maxDescLen=0,trivialVersions=true paths=./apis/stacks/... output:dir=$(CRD_DIR)
+# Add "helm.sh/hook: crd-install" and "helm.sh/hook-delete-policy: before-hook-creation" annotations for clusterstackinstalls and stackinstalls CRDs
+	$(eval TMPDIR := $(shell mktemp -d))
+	kustomize build cluster/charts -o $(TMPDIR)
+	mv $(TMPDIR)/apiextensions.k8s.io_v1beta1_customresourcedefinition_clusterstackinstalls.stacks.crossplane.io.yaml $(CRD_DIR)/stacks.crossplane.io_clusterstackinstalls.yaml
+	mv $(TMPDIR)/apiextensions.k8s.io_v1beta1_customresourcedefinition_stackinstalls.stacks.crossplane.io.yaml $(CRD_DIR)/stacks.crossplane.io_stackinstalls.yaml
 	@$(OK) Generating CRD manifests
 
 # Generate a coverage report for cobertura applying exclusions on

--- a/Makefile
+++ b/Makefile
@@ -90,12 +90,20 @@ go.test.unit: $(KUBEBUILDER)
 
 # Generate manifests e.g. CRD, RBAC etc. locally for Stacks API types
 # as it needs the custom "maxDescLen=0" option
-manifests: vendor kubebuilder.manifests
+manifests: vendor kubebuilder.manifests $(KUSTOMIZE)
 	@$(INFO) Generating CRD manifests
 	$(CONTROLLERGEN) crd:maxDescLen=0,trivialVersions=true paths=./apis/stacks/... output:dir=$(CRD_DIR)
-# Add "helm.sh/hook: crd-install" and "helm.sh/hook-delete-policy: before-hook-creation" annotations for clusterstackinstalls and stackinstalls CRDs
+# Add "helm.sh/hook: crd-install" and "helm.sh/hook-delete-policy: before-hook-creation" annotations for
+# clusterstackinstalls and stackinstalls CRDs.
+# Since Crossplane helm chart contains both CRD and ClusterStackInstall CRs, helm fails to install both together.
+# One option was to use `post-install,post-update` hooks in CR to deploy it after CRDs are installed, but this didn't
+# work reliably with "helm upgrade --install" command. Using "crd-install" hook is already suggested in helm best
+# practices doc: https://helm.sh/docs/chart_best_practices/#method-2-crd-install-hooks and we verified that it works
+# reliably for all use cases. The other hook for deletion policy is necessary to be able to redeploy helm chart after
+# it is deleted since CRDs with "crd-install" hooks will not be deleted with "helm delete" and cause next
+# "helm install" to fail.
 	$(eval TMPDIR := $(shell mktemp -d))
-	kustomize build cluster/charts -o $(TMPDIR)
+	$(KUSTOMIZE) build cluster/charts -o $(TMPDIR)
 	mv $(TMPDIR)/apiextensions.k8s.io_v1beta1_customresourcedefinition_clusterstackinstalls.stacks.crossplane.io.yaml $(CRD_DIR)/stacks.crossplane.io_clusterstackinstalls.yaml
 	mv $(TMPDIR)/apiextensions.k8s.io_v1beta1_customresourcedefinition_stackinstalls.stacks.crossplane.io.yaml $(CRD_DIR)/stacks.crossplane.io_stackinstalls.yaml
 	@$(OK) Generating CRD manifests

--- a/cluster/charts/crossplane/templates/clusterstackinstalls.yaml
+++ b/cluster/charts/crossplane/templates/clusterstackinstalls.yaml
@@ -4,8 +4,6 @@ apiVersion: stacks.crossplane.io/v1alpha1
 kind: ClusterStackInstall
 metadata:
   name: "stack-{{ $key }}"
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
 spec:
   package: "crossplane/stack-{{ $key }}:{{ $val.version }}"
 ---

--- a/cluster/charts/crossplane/templates/crds/stacks.crossplane.io_clusterstackinstalls.yaml
+++ b/cluster/charts/crossplane/templates/crds/stacks.crossplane.io_clusterstackinstalls.yaml
@@ -1,8 +1,9 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    helm.sh/hook: crd-install
+    helm.sh/hook-delete-policy: before-hook-creation
   creationTimestamp: null
   name: clusterstackinstalls.stacks.crossplane.io
 spec:

--- a/cluster/charts/crossplane/templates/crds/stacks.crossplane.io_stackinstalls.yaml
+++ b/cluster/charts/crossplane/templates/crds/stacks.crossplane.io_stackinstalls.yaml
@@ -1,8 +1,9 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    helm.sh/hook: crd-install
+    helm.sh/hook-delete-policy: before-hook-creation
   creationTimestamp: null
   name: stackinstalls.stacks.crossplane.io
 spec:

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -15,13 +15,13 @@ imagePullSecrets:
 
 clusterStacks:
   aws:
-    version: v0.1.0
+    version: master
     deploy: false
   gcp:
-    version: v0.1.0
+    version: master
     deploy: false
   azure:
-    version: v0.1.0
+    version: master
     deploy: false
   rook:
     version: master

--- a/cluster/charts/kustomization.yaml
+++ b/cluster/charts/kustomization.yaml
@@ -1,0 +1,7 @@
+commonAnnotations:
+  helm.sh/hook: crd-install
+  helm.sh/hook-delete-policy: before-hook-creation
+
+resources:
+  - crossplane/templates/crds/stacks.crossplane.io_clusterstackinstalls.yaml
+  - crossplane/templates/crds/stacks.crossplane.io_stackinstalls.yaml


### PR DESCRIPTION
Fixes #1026 

Currently helm chart installation fails when stacks deployment enabled and installed with `helm upgrade --install`

`helm install --name crossplane crossplane-alpha/crossplane --namespace crossplane-system  --version 0.4.0 --set 'clusterStacks.gcp.deploy=true'` ==> Works

`helm upgrade --install crossplane crossplane-alpha/crossplane --namespace crossplane-system  --version 0.4.0 --set 'clusterStacks.gcp.deploy=true'` ==> Fails

The root cause is `post-install` and `post-update` hooks do not work reliably (i.e. work differently for helm install vs helm upgrade —install even it is first time install both). 

This PR removes `post-install` and `post-update` hooks from `ClusterStackInstall` resources and adds `crd-install` hooks to CRD.

Our CRDs are auto generated by kubebuilder tools, thus this PR also updates makefile so that generated CRDs contain the annotations. Since kubebuilder does not provide a mechanism to add annotations to CRDs, I used `kustomize` in Makefile as suggested [in this comment.](https://github.com/kubernetes-sigs/kubebuilder/issues/387#issuecomment-428380728)


### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml