### PR TITLE
docs: correct error in dbsubnetgroup group

### DIFF
--- a/docs/services/aws-services-guide.md
+++ b/docs/services/aws-services-guide.md
@@ -113,7 +113,7 @@ accessed
 
 ```bash
 cat > aws-dbsubnet.yaml <<EOF
-apiVersion: storage.aws.crossplane.io/v1alpha3
+apiVersion: database.aws.crossplane.io/v1alpha3
 kind: DBSubnetGroup
 metadata:
   name: sample-dbsubnetgroup


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

This update was missed in the `v0.4.0` docs cut. The `DBSubnetGroup` type was moved from `storage` to `database` right before the cut of the `v0.2.0` release of `stack-aws`.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml