### PR TITLE
bump all examples and stack references to latest release versions

### DIFF
--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -15,14 +15,14 @@ imagePullSecrets:
 
 clusterStacks:
   aws:
-    version: v0.2.0
+    version: v0.2.1
     deploy: false
   gcp:
-    version: v0.2.0
+    version: v0.2.1
     deploy: false
   azure:
-    version: v0.2.0
+    version: v0.2.1
     deploy: false
   rook:
-    version: v0.1.0
+    version: v0.1.1
     deploy: false

--- a/cluster/examples/stacks/stack-aws.yaml
+++ b/cluster/examples/stacks/stack-aws.yaml
@@ -5,4 +5,4 @@ metadata:
   name: stack-aws
   namespace: crossplane-system
 spec:
-  package: "crossplane/stack-aws:v0.2.0"
+  package: "crossplane/stack-aws:v0.2.1"

--- a/cluster/examples/stacks/stack-azure.yaml
+++ b/cluster/examples/stacks/stack-azure.yaml
@@ -5,4 +5,4 @@ metadata:
   name: stack-azure
   namespace: crossplane-system
 spec:
-  package: "crossplane/stack-azure:v0.2.0"
+  package: "crossplane/stack-azure:v0.2.1"

--- a/cluster/examples/stacks/stack-gcp.yaml
+++ b/cluster/examples/stacks/stack-gcp.yaml
@@ -5,4 +5,4 @@ metadata:
   name: stack-gcp
   namespace: crossplane-system
 spec:
-  package: "crossplane/stack-gcp:v0.2.0"
+  package: "crossplane/stack-gcp:v0.2.1"

--- a/docs/install-crossplane.md
+++ b/docs/install-crossplane.md
@@ -94,7 +94,7 @@ metadata:
   name: stack-gcp
   namespace: gcp
 spec:
-  package: "crossplane/stack-gcp:v0.2.0"
+  package: "crossplane/stack-gcp:v0.2.1"
 ```
 
 Then you can install the GCP stack into Crossplane in the `gcp` namespace with the following command:
@@ -119,7 +119,7 @@ metadata:
   name: stack-aws
   namespace: aws
 spec:
-  package: "crossplane/stack-aws:v0.2.0"
+  package: "crossplane/stack-aws:v0.2.1"
 ```
 
 Then you can install the AWS stack into Crossplane in the `aws` namespace with the following command:
@@ -144,7 +144,7 @@ metadata:
   name: stack-azure
   namespace: azure
 spec:
-  package: "crossplane/stack-azure:v0.2.0"
+  package: "crossplane/stack-azure:v0.2.1"
 ```
 
 Then you can install the Azure stack into Crossplane in the `azure` namespace with the following command:
@@ -169,7 +169,7 @@ metadata:
   name: stack-rook
   namespace: rook
 spec:
-  package: "crossplane/stack-rook:v0.1.0"
+  package: "crossplane/stack-rook:v0.1.1"
 ```
 
 Then you can install the Rook stack into Crossplane in the `rook` namespace with the following command:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -42,7 +42,7 @@ metadata:
   name: stack-gcp
   namespace: crossplane-system
 spec:
-  package: "crossplane/stack-gcp:v0.2.0"
+  package: "crossplane/stack-gcp:v0.2.1"
 ```
 
 Save the above as `stack.yaml`, and apply it by running:

--- a/docs/services/aws-services-guide.md
+++ b/docs/services/aws-services-guide.md
@@ -88,7 +88,7 @@ metadata:
   name: stack-aws
   namespace: crossplane-system
 spec:
-  package: "crossplane/stack-aws:v0.2.0"
+  package: "crossplane/stack-aws:v0.2.1"
 EOF
 
 kubectl apply -f stack-aws.yaml

--- a/docs/services/azure-services-guide.md
+++ b/docs/services/azure-services-guide.md
@@ -81,7 +81,7 @@ metadata:
   name: stack-azure
   namespace: crossplane-system
 spec:
-  package: "crossplane/stack-azure:v0.2.0"
+  package: "crossplane/stack-azure:v0.2.1"
 EOF
 
 kubectl apply -f stack-azure.yaml

--- a/docs/stacks-guide-aws.md
+++ b/docs/stacks-guide-aws.md
@@ -73,7 +73,7 @@ infrastructure stack, we need to specify that it's cluster-scoped by passing the
 `--cluster` flag.
 
 ```bash
-kubectl crossplane stack generate-install --cluster 'crossplane/stack-aws:v0.2.0' stack-aws | kubectl apply --namespace crossplane-system -f -
+kubectl crossplane stack generate-install --cluster 'crossplane/stack-aws:v0.2.1' stack-aws | kubectl apply --namespace crossplane-system -f -
 ```
 
 The rest of this guide assumes that the AWS stack is installed within

--- a/docs/stacks-guide-azure.md
+++ b/docs/stacks-guide-azure.md
@@ -74,7 +74,7 @@ infrastructure stack, we need to specify that it's cluster-scoped by passing the
 `--cluster` flag.
 
 ```bash
-kubectl crossplane stack generate-install --cluster 'crossplane/stack-azure:v0.2.0' stack-azure | kubectl apply --namespace crossplane-system -f -
+kubectl crossplane stack generate-install --cluster 'crossplane/stack-azure:v0.2.1' stack-azure | kubectl apply --namespace crossplane-system -f -
 ```
 
 The rest of this guide assumes that the Azure stack is installed within

--- a/docs/stacks-guide-gcp.md
+++ b/docs/stacks-guide-gcp.md
@@ -74,7 +74,7 @@ infrastructure stack, we need to specify that it's cluster-scoped by passing the
 `--cluster` flag.
 
 ```bash
-kubectl crossplane stack generate-install --cluster 'crossplane/stack-gcp:v0.2.0' stack-gcp | kubectl apply --namespace crossplane-system -f -
+kubectl crossplane stack generate-install --cluster 'crossplane/stack-gcp:v0.2.1' stack-gcp | kubectl apply --namespace crossplane-system -f -
 ```
 
 The rest of this guide assumes that the GCP stack is installed within

--- a/docs/stacks-guide-rook.md
+++ b/docs/stacks-guide-rook.md
@@ -93,7 +93,7 @@ metadata:
   name: stack-gcp
   namespace: crossplane-system
 spec:
-  package: "crossplane/stack-gcp:v0.2.0"
+  package: "crossplane/stack-gcp:v0.2.1"
 EOF
 
 kubectl apply -f stack-gcp.yaml
@@ -110,7 +110,7 @@ metadata:
   name: stack-rook
   namespace: crossplane-system
 spec:
-  package: "crossplane/stack-rook:v0.1.0"
+  package: "crossplane/stack-rook:v0.1.1"
 EOF
 
 kubectl apply -f stack-rook.yaml


### PR DESCRIPTION
### Description of your changes

This PR bumps all the examples and stack references to their latest release versions.  AWS/GCP/Azure are at `v0.2.1` now, and `stack-rook` is at `v0.1.1`.

This will be included in the `v0.4.1` patch release.

### Checklist
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml