### PR TITLE
Check for dirty go modules in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,6 +46,7 @@ pipeline {
                 }
             }
             steps {
+                sh './build/run make check-diff'
                 sh './build/run make vendor.check'
                 sh './build/run make -j\$(nproc) build.all'
             }

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,13 @@ cobertura:
 
 # Ensure a PR is ready for review.
 reviewable: generate lint
+	@go mod tidy
+
+# Ensure branch is clean.
+check-diff: reviewable
+	@$(INFO) checking that branch is clean
+	@git diff --quiet || $(FAIL)
+	@$(OK) branch is clean
 
 # integration tests
 e2e.run: test-integration


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

Causes CI to check for dirty go modules and fail if so.

Same as:
https://github.com/crossplaneio/stack-gcp/pull/90
https://github.com/crossplaneio/stack-aws/pull/75
https://github.com/crossplaneio/stack-azure/pull/63
https://github.com/crossplaneio/stack-rook/pull/22
https://github.com/crossplaneio/crossplane-runtime/pull/77

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml