### PR TITLE
docs: store gcp provider project id in variable

### DIFF
--- a/docs/cloud-providers/gcp/gcp-provider.md
+++ b/docs/cloud-providers/gcp/gcp-provider.md
@@ -160,6 +160,14 @@ First, let's encode the credential file contents and put it in a variable:
 BASE64ENCODED_GCP_ACCOUNT_CREDS=$(base64 crossplane-gcp-provider-key.json | tr -d "\n")
 ```
 
+Next, store the project ID of the GCP project in which you would like to
+provision infrastructure as a variable:
+
+```bash
+# replace this with your own gcp project id
+PROJECT_ID: my-cool-gcp-project
+```
+
 Now we’ll create the `Secret` resource that contains the credential, and
  `Provider` resource which refers to that secret:
 
@@ -181,7 +189,7 @@ metadata:
   name: gcp-provider
 spec:
   # replace this with your own gcp project id
-  projectID: my-cool-gcp-project
+  projectID: ${PROJECT_ID}
   credentialsSecretRef:
     namespace: crossplane-system
     name: gcp-account-creds
@@ -191,8 +199,9 @@ EOF
 # apply it to the cluster:
 kubectl apply -f "provider.yaml"
 
-# delete the credentials variable
+# delete the credentials and project id variables
 unset BASE64ENCODED_GCP_ACCOUNT_CREDS
+unset PROJECT_ID
 ```
 
 The output will look like the following:


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

Fixes #1044 

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml