### PR TITLE
rook stacks guide: fix bugs in rook operator config

### DIFF
--- a/cluster/examples/rook/yugastore/rook-operator.yaml
+++ b/cluster/examples/rook/yugastore/rook-operator.yaml
@@ -114,7 +114,7 @@ spec:
           name: rook-yugabytedb-operator
           namespace: rook-yugabytedb-system
   - metadata:
-      name: rook-serviceaccount
+      name: rook-clusterrolebinding
       labels:
         operator: rook-yugabyte
     spec:
@@ -133,7 +133,7 @@ spec:
           name: rook-yugabytedb-operator
           namespace: rook-yugabytedb-system
   - metadata:
-      name: rook-serviceaccount
+      name: rook-deployment
       labels:
         operator: rook-yugabyte
     spec:

--- a/docs/stacks-guide-rook.md
+++ b/docs/stacks-guide-rook.md
@@ -524,7 +524,7 @@ spec:
           name: rook-yugabytedb-operator
           namespace: rook-yugabytedb-system
   - metadata:
-      name: rook-serviceaccount
+      name: rook-clusterrolebinding
       labels:
         operator: rook-yugabyte
     spec:
@@ -543,7 +543,7 @@ spec:
           name: rook-yugabytedb-operator
           namespace: rook-yugabytedb-system
   - metadata:
-      name: rook-serviceaccount
+      name: rook-deployment
       labels:
         operator: rook-yugabyte
     spec:


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

During docs updates the Rook Yugastore config became invalid (i.e. I made typos, `git blame = hasheddan`). This updates the guide and config to be accurate. I have tested successfully.

Note: This PR will be followed by a backport to `release-0.4` branch.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml