### PR TITLE
Cleanup CRDs by label, not garbage collection

### DIFF
--- a/cmd/crossplane/main.go
+++ b/cmd/crossplane/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/afero"
 	"gopkg.in/alecthomas/kingpin.v2"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -156,6 +157,10 @@ func stacksControllerSetupWithManager(mgr manager.Manager) error {
 // addToScheme adds all resources to the runtime scheme.
 func addToScheme(scheme *runtime.Scheme) error {
 	if err := apis.AddToScheme(scheme); err != nil {
+		return err
+	}
+
+	if err := apiextensionsv1beta1.AddToScheme(scheme); err != nil {
 		return err
 	}
 

--- a/pkg/controller/stacks/install/installjob_test.go
+++ b/pkg/controller/stacks/install/installjob_test.go
@@ -384,6 +384,7 @@ func TestCreate(t *testing.T) {
 			handler: &stackInstallHandler{
 				kube: &test.MockClient{
 					MockCreate:       func(ctx context.Context, obj runtime.Object, _ ...client.CreateOption) error { return nil },
+					MockUpdate:       func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
 					MockStatusUpdate: func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
 				},
 				executorInfo: &stacks.ExecutorInfo{Image: stackPackageImage},
@@ -393,6 +394,7 @@ func TestCreate(t *testing.T) {
 				result: requeueOnSuccess,
 				err:    nil,
 				ext: resource(
+					withFinalizers(installFinalizer),
 					withConditions(runtimev1alpha1.Creating(), runtimev1alpha1.ReconcileSuccess()),
 					withInstallJob(&corev1.ObjectReference{Name: resourceName, Namespace: namespace}),
 				),
@@ -406,6 +408,7 @@ func TestCreate(t *testing.T) {
 						// GET Job returns an uncompleted job
 						return nil
 					},
+					MockUpdate:       func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
 					MockStatusUpdate: func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
 				},
 				ext: resource(
@@ -415,6 +418,7 @@ func TestCreate(t *testing.T) {
 				result: requeueOnSuccess,
 				err:    nil,
 				ext: resource(
+					withFinalizers(installFinalizer),
 					withConditions(runtimev1alpha1.Creating(), runtimev1alpha1.ReconcileSuccess()),
 					withInstallJob(&corev1.ObjectReference{Name: resourceName, Namespace: namespace}),
 				),
@@ -429,6 +433,7 @@ func TestCreate(t *testing.T) {
 						*obj.(*batchv1.Job) = *(job(withJobConditions(batchv1.JobComplete, "")))
 						return nil
 					},
+					MockUpdate:       func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
 					MockStatusUpdate: func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
 				},
 				jobCompleter: &mockJobCompleter{
@@ -442,6 +447,7 @@ func TestCreate(t *testing.T) {
 				result: requeueOnSuccess,
 				err:    nil,
 				ext: resource(
+					withFinalizers(installFinalizer),
 					withConditions(runtimev1alpha1.Available(), runtimev1alpha1.ReconcileSuccess()),
 					withInstallJob(&corev1.ObjectReference{Name: resourceName, Namespace: namespace}),
 				),
@@ -456,6 +462,7 @@ func TestCreate(t *testing.T) {
 						*obj.(*batchv1.Job) = *(job(withJobConditions(batchv1.JobFailed, "mock job failure message")))
 						return nil
 					},
+					MockUpdate:       func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
 					MockStatusUpdate: func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
 				},
 				jobCompleter: &mockJobCompleter{
@@ -469,6 +476,7 @@ func TestCreate(t *testing.T) {
 				result: resultRequeue,
 				err:    nil,
 				ext: resource(
+					withFinalizers(installFinalizer),
 					withConditions(
 						runtimev1alpha1.Creating(),
 						runtimev1alpha1.ReconcileError(errors.New("mock job failure message")),

--- a/pkg/controller/stacks/install/stackinstall.go
+++ b/pkg/controller/stacks/install/stackinstall.go
@@ -25,6 +25,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -43,6 +44,7 @@ import (
 const (
 	reconcileTimeout      = 1 * time.Minute
 	requeueAfterOnSuccess = 10 * time.Second
+	installFinalizer      = "finalizer.stackinstall.crossplane.io"
 )
 
 var (
@@ -113,6 +115,10 @@ func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 
 	handler := r.factory.newHandler(ctx, stackInstaller, r.kube, r.kubeclient, executorinfo)
 
+	if meta.WasDeleted(stackInstaller) {
+		return handler.delete(ctx)
+	}
+
 	return handler.sync(ctx)
 }
 
@@ -121,6 +127,7 @@ type handler interface {
 	sync(context.Context) (reconcile.Result, error)
 	create(context.Context) (reconcile.Result, error)
 	update(context.Context) (reconcile.Result, error)
+	delete(context.Context) (reconcile.Result, error)
 }
 
 // stackInstallHandler is a concrete implementation of the handler interface
@@ -169,6 +176,12 @@ func (h *stackInstallHandler) sync(ctx context.Context) (reconcile.Result, error
 // that the Stack does not yet exist, so the caller should confirm that before calling.
 func (h *stackInstallHandler) create(ctx context.Context) (reconcile.Result, error) {
 	h.ext.SetConditions(runtimev1alpha1.Creating())
+
+	meta.AddFinalizer(h.ext, installFinalizer)
+	if err := h.kube.Update(ctx, h.ext); err != nil {
+		return fail(ctx, h.kube, h.ext, err)
+	}
+
 	jobRef := h.ext.InstallJob()
 
 	if jobRef == nil {
@@ -234,6 +247,31 @@ func (h *stackInstallHandler) update(ctx context.Context) (reconcile.Result, err
 	// create a new one?
 	groupversion, kind := h.ext.GroupVersionKind().ToAPIVersionAndKind()
 	log.V(logging.Debug).Info("updating not supported yet", strings.ToLower(kind)+"."+groupversion, fmt.Sprintf("%s/%s", h.ext.GetNamespace(), h.ext.GetName()))
+	return reconcile.Result{}, nil
+}
+
+func (h *stackInstallHandler) delete(ctx context.Context) (reconcile.Result, error) {
+	labels := map[string]string{
+		labelInstallNamespace: h.ext.GetNamespace(),
+		labelInstallName:      h.ext.GetName(),
+		labelInstallUID:       string(h.ext.GetUID()),
+	}
+	list := &apiextensionsv1beta1.CustomResourceDefinitionList{}
+	if err := h.kube.List(ctx, list, client.MatchingLabels(labels)); err != nil {
+		return fail(ctx, h.kube, h.ext, err)
+	}
+
+	for i := range list.Items {
+		if err := h.kube.Delete(ctx, &list.Items[i]); err != nil {
+			return fail(ctx, h.kube, h.ext, err)
+		}
+	}
+
+	meta.RemoveFinalizer(h.ext, installFinalizer)
+	if err := h.kube.Update(ctx, h.ext); err != nil {
+		return fail(ctx, h.kube, h.ext, err)
+	}
+
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/controller/stacks/install/stackinstall.go
+++ b/pkg/controller/stacks/install/stackinstall.go
@@ -252,9 +252,10 @@ func (h *stackInstallHandler) update(ctx context.Context) (reconcile.Result, err
 
 func (h *stackInstallHandler) delete(ctx context.Context) (reconcile.Result, error) {
 	labels := map[string]string{
-		labelInstallNamespace: h.ext.GetNamespace(),
-		labelInstallName:      h.ext.GetName(),
-		labelInstallUID:       string(h.ext.GetUID()),
+		labelParentKind:      h.ext.GetObjectKind().GroupVersionKind().Kind,
+		labelParentNamespace: h.ext.GetNamespace(),
+		labelParentName:      h.ext.GetName(),
+		labelParentUID:       string(h.ext.GetUID()),
 	}
 	list := &apiextensionsv1beta1.CustomResourceDefinitionList{}
 	if err := h.kube.List(ctx, list, client.MatchingLabels(labels)); err != nil {
@@ -262,7 +263,7 @@ func (h *stackInstallHandler) delete(ctx context.Context) (reconcile.Result, err
 	}
 
 	for i := range list.Items {
-		if err := h.kube.Delete(ctx, &list.Items[i]); err != nil {
+		if err := h.kube.Delete(ctx, &list.Items[i]); err != nil && !kerrors.IsNotFound(err) {
 			return fail(ctx, h.kube, h.ext, err)
 		}
 	}

--- a/pkg/controller/stacks/install/stackinstall_test.go
+++ b/pkg/controller/stacks/install/stackinstall_test.go
@@ -61,6 +61,9 @@ var _ reconcile.Reconciler = &Reconciler{}
 // Resource modifiers
 type resourceModifier func(v1alpha1.StackInstaller)
 
+func withFinalizers(finalizers ...string) resourceModifier {
+	return func(r v1alpha1.StackInstaller) { r.SetFinalizers(finalizers) }
+}
 func withConditions(c ...runtimev1alpha1.Condition) resourceModifier {
 	return func(r v1alpha1.StackInstaller) { r.SetConditions(c...) }
 }
@@ -123,6 +126,7 @@ type mockHandler struct {
 	MockSync   func(context.Context) (reconcile.Result, error)
 	MockCreate func(context.Context) (reconcile.Result, error)
 	MockUpdate func(context.Context) (reconcile.Result, error)
+	MockDelete func(context.Context) (reconcile.Result, error)
 }
 
 func (m *mockHandler) sync(ctx context.Context) (reconcile.Result, error) {
@@ -135,6 +139,10 @@ func (m *mockHandler) create(ctx context.Context) (reconcile.Result, error) {
 
 func (m *mockHandler) update(ctx context.Context) (reconcile.Result, error) {
 	return m.MockUpdate(ctx)
+}
+
+func (m *mockHandler) delete(ctx context.Context) (reconcile.Result, error) {
+	return m.MockDelete(ctx)
 }
 
 type mockExecutorInfoDiscoverer struct {


### PR DESCRIPTION
### Description of your changes

Fixes https://github.com/crossplaneio/crossplane/issues/895

(Cluster)StackInstall is namespaced, and CRDs are cluster scoped. Namespaced resources cannot own cluster scoped resources, so we can't rely on garbage collection to cleanup CRDs that were installed by a StackInstall. This uses labels instead.

I have removed the draft qualifier on this PR now so it is ready for full review.  The approach here uses the labels that are defined in the [stack relationship labels design doc](https://github.com/negz/crossplane/blob/refrace/design/one-pager-stack-relationship-labels.md), which has been updated by this PR also to be in alignment with the current implementation.

I think that this is a good approach for a `v0.5.1` patch release, but @displague is thinking about the longer term approach and how it aligns with ownership, garbage collection, multiple stack installs and versions, parent / child relationships, etc. 

Below is an example of a labeled CRD after stack-gcp has been installed:

```yaml
> kubectl get crd gkeclusters.compute.gcp.crossplane.io -o yaml
...
labels:
    app.kubernetes.io/managed-by: stack-manager
    core.crossplane.io/parent-group: stacks.crossplane.io
    core.crossplane.io/parent-kind: ClusterStackInstall
    core.crossplane.io/parent-name: stack-gcp
    core.crossplane.io/parent-namespace: gcp
    core.crossplane.io/parent-uid: 858ab465-ff60-49d8-a3e7-624ce841f339
    core.crossplane.io/parent-version: v1alpha1
name: gkeclusters.compute.gcp.crossplane.io
...
```

### Checklist
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml