### PR TITLE
helm: add a Chart.yaml icon

### DIFF
--- a/cluster/charts/crossplane/Chart.yaml
+++ b/cluster/charts/crossplane/Chart.yaml
@@ -3,3 +3,4 @@ appVersion: 0.0.1
 description: Crossplane - Managed Cloud Resources Operator
 name: crossplane
 version: 0.0.1
+icon: https://crossplane.io/images/favicon_192x192.png


### PR DESCRIPTION
### Description of your changes

This removes the build notice:

```console
[INFO] Chart.yaml: icon is recommended
```

The Chart.yaml will use the popsicle logo included on the Crossplane website, ![Crossplane Logo](https://crossplane.io/images/favicon_192x192.png)

Having the chart meet [best practices](https://github.com/helm/hub/blob/master/Repositories.md#repository-best-practices) allows this chart to be used broadly, including Helm Hub.

I was tempted to update the version and appVersion in the Chart.yaml, to match the Crossplane version per [this Codefresh recommendation](https://codefresh.io/docs/docs/new-helm/helm-best-practices/#chart-versions-and-appversions), but I believe the build/ process already sets the version of the built and published charts without this modification.  In the future, there may be a benefit to setting the version via a Chart.yaml.tmpl file, similar to what is done for values.yaml.tmpl.

A future PR should seek to add an instructional [NOTES.txt](https://helm.sh/docs/topics/chart_template_guide/notes_files/) file.

### How has this code been tested?

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

