### PR TITLE
api patterns: sensitive input field handling and external resource labelling

### DIFF
--- a/design/one-pager-managed-resource-api-design.md
+++ b/design/one-pager-managed-resource-api-design.md
@@ -12,6 +12,7 @@
   * Added [how to handle sensitive input fields](#sensitive-input-fields).
   * Added [external resource labelling](#external-resource-labeling).
   * Added [cross-resource reference edge case](#pointer-types-and-markers) for types.
+  * Added a condition to enforce the status fields to be reproducible in section [High Fidelity](#high-fidelity).
 
 ## Terminology
 
@@ -189,6 +190,14 @@ For both `Status` and `Spec`:
   
   What if the sub-resource is not yet supported as managed resource in Crossplane? In that case, you should first
   consider implementing that managed resource, if not suitable, only then include it in the CR.
+
+* Can the value of this field be reproduced when the whole `Status` is deleted? Do not include if the answer is no.
+  `Status` sub-resource is the _representation_ of the current state, so, the
+  controller should be able to reproduce it as long as the state that's represented
+  is still there. In practice, this means the controller should not rely on any
+  field that is present in the `Status`.
+
+For details, see [Kubernetes API Conventions - Spec and Status].
 
 #### Embedded Structs with Mixed Fields
 
@@ -571,3 +580,4 @@ and reconciler can mark the sync status in one of the `Condition`s we already ha
 
 [glossary]: https://github.com/crossplaneio/crossplane/blob/master/docs/concepts.md#glossary
 [from crossplane-runtime]: https://github.com/crossplaneio/crossplane-runtime/blob/ca4b6b4/apis/core/v1alpha1/resource.go#L77
+[Kubernetes API Conventions - Spec and Status]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

Currently, Crossplane does not support supplying sensitive data over the custom resource. This PR suggests a plan although it's useful only in static provisioning currently since _any_ input for dynamic provisioning has to be implemented in claim level.

It's easy to identify what external resources correspond to what managed resource by looking at your managed resource but the other way around is not really trivial, in some cases not possible. For example, AWS VPCs have random generated name and when you look at it in the console you can't even differentiate whether it was provisioned by Crossplane or not. This PR suggests that we label (if possible) the resource with the manage resource CR name.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [x] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplaneio/crossplane/tree/master/design/one-pager-definition-of-done.md
