### PR TITLE
stacks: distinguish crossplane-admin from actual environment roles

### DIFF
--- a/cluster/charts/crossplane/templates/crossplane-admin-clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/crossplane-admin-clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     chart: {{ template "chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    crossplane.io/scope: "environment"
+    crossplane.io/scope: "system"
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:

--- a/design/one-pager-stacks-security-isolation.md
+++ b/design/one-pager-stacks-security-isolation.md
@@ -358,6 +358,9 @@ Example running a command as crossplane-admin
 kubectl {any crossplane-admin operation} --as-group=crossplane:masters
 ```
 
+For discoverability of the system role (`crossplane-admin`) we will add the following labels:
+ * `crossplane.io/scope: "system"`
+
 For discoverability of the roles for the environment we will add the following labels:
  * `crossplane.io/scope: "environment"`
 
@@ -467,11 +470,27 @@ kind: ClusterRole
 metadata:
   name: crossplane-admin
   labels:
-    crossplane.io/scope: "environment" # For discoverability for tools
+    crossplane.io/scope: "system" # For discoverability for tools
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.crossplane.io/aggregate-to-crossplane-admin: "true"
+rules: [] # Rules are automatically filled in by the controller manager.
+```
+
+An example of an environment `admin` `ClusterRole` object
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane-env-admin
+  labels:
+    crossplane.io/scope: "environment" # For discoverability for tools
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.crossplane.io/aggregate-to-environment-admin: "true"
 rules: [] # Rules are automatically filled in by the controller manager.
 ```
 


### PR DESCRIPTION
Environment roles, which can be easily identified by their `crossplane.io/scope: "environment"` labels, should not be confused with the `crossplane-admin` role. @lukeweber pointed out that the current assignments of `environment` scope labels includes `crossplane-admin`.

The `crossplane-admin` clusterrole should not have the `environment` scope label.

While included as an example, this was not the intention of https://github.com/crossplaneio/crossplane/blob/master/design/one-pager-stacks-security-isolation.md#default-crossplane-clusterroles

This PR changes the `crossplane.io/scope` label used for the `crossplane-admin` to `system` and updates the design doc to match the intention.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

This scope is not used by aggregation, so it does not affect any generated roles. Only discoverability has changed:

```
$ kubectl get clusterrole -l crossplane.io/scope=environment
NAME                   AGE
crossplane-env-admin   31m
crossplane-env-edit    31m
crossplane-env-view    31m
$ kubectl get clusterrole -l crossplane.io/scope=system
NAME               AGE
crossplane-admin   31m
```
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplaneio/crossplane/tree/master/design/one-pager-definition-of-done.md
