### PR TITLE
docs: expand explanantion of KubernetesApplication

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -208,10 +208,17 @@ See [Stacks](#stacks).
 
 Crossplane includes an extensible workload scheduler that observes application
 policies to select a suitable target cluster from a pool of available clusters.
-The workload scheduler can be customized to consider a number of criteria
+Workloads are modeled as `KubernetesApplication` resources, which model other
+resources in-line. For instance, a single `KubernetesApplication` may contain
+templates for creating a `Deployment`, `Service`, `PersistentVolume`, and
+`PersistentVolumeClaim` in the target cluster. When a `KubernetesApplication` is
+scheduled to an appropriate target, Crossplane connects to the cluster and
+creates the defined resources from its templates. Currently, the workload
+scheduler selects a suitable target cluster based on [label
+selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors).
+In the future, the workload scheduler will consider a number of criteria
 including capabilities, availability, reliability, cost, regions, and
-performance while deploying workloads and their resources. Complex workloads can
-be modeled as a `KubernetesApplication`.
+performance while deploying workloads and their resources.
 
 ## Crossplane Clusters
 


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

This is a stop-gap expansion of the `KubernetesApplication` in the docs for the `v0.7` release. It is likely that creating a separate document to describe `KubernetesApplication`, along with the current and future state of scheduling, will be needed in the future.

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

N/A

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplaneio/crossplane/tree/master/design/one-pager-definition-of-done.md
