### PR TITLE
stacks: remove overly permissive rules from namespace, environment, and crossplane-admin personas

### DIFF
--- a/cluster/charts/crossplane/templates/environment-personas-clusterroles.yaml
+++ b/cluster/charts/crossplane/templates/environment-personas-clusterroles.yaml
@@ -47,19 +47,6 @@ rules:
   - deletecollection
   - patch
   - update
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterrolebindings
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -95,21 +82,10 @@ rules:
   - database.crossplane.io
   - kubernetes.crossplane.io
   - core.crossplane.io
-  - stacks.crossplane.io
   - storage.crossplane.io
   - workload.crossplane.io
   resources:
   - "*"
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
-- apiGroups:
-  - stacks.crossplane.io
-  resources:
-  - clusterstackinstall
   verbs:
   - create
   - delete

--- a/cluster/charts/crossplane/templates/namespace-personas-clusterroles.yaml
+++ b/cluster/charts/crossplane/templates/namespace-personas-clusterroles.yaml
@@ -43,19 +43,6 @@ rules:
   - deletecollection
   - patch
   - update
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - rolebindings
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -79,16 +66,6 @@ rules:
   - workload.crossplane.io
   resources:
   - "*"
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
-- apiGroups:
-  - stacks.crossplane.io
-  resources:
-  - stackinstalls
   verbs:
   - create
   - delete


### PR DESCRIPTION
### Description of your changes

Part of #1190, Related to #1165

Remove ClusterRole rules that granted admins access to ClusterRoleBinding,
and RoleBinding. (crossplane-admin, environment admins)

Remove ClusterRole rules that granted editors the ability to create and
delete StackInstalls and ClusterStackInstalls. (environment editors,
namespace editors)

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

Give "users" rolebindings:
```
kubectl create namespace precipice
kubectl stack generate-install crossplane/sample-stack-wordpress stack-wordpress | kubectl apply -n precipice -f -
for persona in view edit admin; do
  for namespace in precipice default; do
    kubectl create rolebinding demo-$namespace-$persona --clusterrole crossplane:ns:$namespace:$persona --user $namespace-$persona@example.com --namespace $namespace
  done

  kubectl create clusterrolebinding demo-crossplane-env-$persona --clusterrole crossplane-env-$persona --user env-$persona@example.com
done

kubectl create clusterrolebinding demo-crossplane-admin --clusterrole crossplane-admin --user crossplane-admin@example.com
```

Test those users ability to create the affected resources:
```
cat << EOS | 
yes clusterstackinstall crossplane-admin
yes clusterstackinstall env-admin
yes stackinstall crossplane-admin precipice
yes stackinstall precipice-admin precipice

no clusterstackinstall env-edit
no stackinstall precipice-edit precipice

no clusterrolebinding crossplane-admin
no clusterrolebinding env-admin
no rolebinding precipice-admin precipice

should-fail foo bar
EOS
while read want resource user namespace; do 
  [ -z "$want" ] && continue
  cmd="kubectl auth can-i create $resource --as=$user@example.com"
  [ -n "$namespace" ] && cmd="$cmd -n $namespace"
  got=$($cmd)
  [ "$got" == "$want" ] || echo "got $got, want $want: $resource $user"
done
```
 (table-based shell tests `\o/` )
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplaneio/crossplane/tree/master/design/one-pager-definition-of-done.md
