### PR TITLE
Unpack creates StackDefinition resources from Template Stacks behavior.yaml files

### DIFF
--- a/apis/stacks/v1alpha1/stackdefinition.go
+++ b/apis/stacks/v1alpha1/stackdefinition.go
@@ -19,6 +19,8 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/crossplaneio/crossplane-runtime/pkg/meta"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
@@ -120,12 +122,7 @@ func (sd *StackDefinition) DeepCopyIntoStack(s *Stack) {
 	sd.Spec.CRDs.DeepCopyInto(&s.Spec.CRDs)
 	sd.Spec.Controller.DeepCopyInto(&s.Spec.Controller)
 	sd.Spec.Permissions.DeepCopyInto(&s.Spec.Permissions)
-	if s.Labels == nil {
-		s.Labels = map[string]string{}
-	}
-	for key, val := range sd.Labels {
-		s.Labels[key] = val
-	}
+	meta.AddLabels(s, sd.GetLabels())
 }
 
 // DeepCopyIntoStackDefinition copies a Stack to a StackDefinition
@@ -135,5 +132,5 @@ func (s *Stack) DeepCopyIntoStackDefinition(sd *StackDefinition) {
 	s.Spec.CRDs.DeepCopyInto(&sd.Spec.CRDs)
 	s.Spec.Controller.DeepCopyInto(&sd.Spec.Controller)
 	s.Spec.Permissions.DeepCopyInto(&sd.Spec.Permissions)
-	sd.ObjectMeta.SetLabels(s.ObjectMeta.GetLabels())
+	meta.AddLabels(sd, s.GetLabels())
 }

--- a/apis/stacks/v1alpha1/stackdefinition.go
+++ b/apis/stacks/v1alpha1/stackdefinition.go
@@ -113,3 +113,27 @@ type StackDefinitionList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []StackDefinition `json:"items"`
 }
+
+// DeepCopyIntoStack copies a StackDefinition to a Stack
+func (sd *StackDefinition) DeepCopyIntoStack(s *Stack) {
+	sd.Spec.AppMetadataSpec.DeepCopyInto(&s.Spec.AppMetadataSpec)
+	sd.Spec.CRDs.DeepCopyInto(&s.Spec.CRDs)
+	sd.Spec.Controller.DeepCopyInto(&s.Spec.Controller)
+	sd.Spec.Permissions.DeepCopyInto(&s.Spec.Permissions)
+	if s.Labels == nil {
+		s.Labels = map[string]string{}
+	}
+	for key, val := range sd.Labels {
+		s.Labels[key] = val
+	}
+}
+
+// DeepCopyIntoStackDefinition copies a Stack to a StackDefinition
+// TODO(displague) should this reside in types.go with the Stack type
+func (s *Stack) DeepCopyIntoStackDefinition(sd *StackDefinition) {
+	s.Spec.AppMetadataSpec.DeepCopyInto(&sd.Spec.AppMetadataSpec)
+	s.Spec.CRDs.DeepCopyInto(&sd.Spec.CRDs)
+	s.Spec.Controller.DeepCopyInto(&sd.Spec.Controller)
+	s.Spec.Permissions.DeepCopyInto(&sd.Spec.Permissions)
+	sd.ObjectMeta.SetLabels(s.ObjectMeta.GetLabels())
+}

--- a/cluster/charts/crossplane-controllers/templates/stack-manager-deployment.yaml
+++ b/cluster/charts/crossplane-controllers/templates/stack-manager-deployment.yaml
@@ -35,6 +35,10 @@ spec:
         {{- end }}
         {{- if .Values.templateStacks.enabled }}
         - --templates
+        {{- if .Values.templateStacks.controllerImage }}
+        - --templating-controller-image
+        - {{ .Values.templateStacks.controllerImage | quote }}
+        {{- end }}
         {{- end }}
         {{- range $arg := .Values.args }}
         - {{ $arg }}

--- a/cluster/charts/crossplane-controllers/values.yaml.tmpl
+++ b/cluster/charts/crossplane-controllers/values.yaml.tmpl
@@ -25,3 +25,5 @@ hostedConfig:
 
 templateStacks:
   enabled: false
+  # TODO(displague) dont merge until this can point at crossplane/resourcepacks:master
+  controllerImage: crossplane/templating-controller:0.1.0

--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -211,6 +211,7 @@ The following tables lists the configurable parameters of the Crossplane chart a
 | `clusterStacks.rook.version`     | Rook stack version to deploy                                    | `<latest released version>`   
 | `personas.deploy`                | Install roles and bindings for Crossplane user personas         | `true`     
 | `templateStacks.enabled`         | Enable experimental template stacks support                     | `false`     
+| `templateStacks.controllerImage` | Template Stack controller image                                 | `crossplane/templating-controller:0.1.0`
  
 ### Command Line
 

--- a/cluster/charts/crossplane/templates/stack-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/stack-manager-deployment.yaml
@@ -35,6 +35,10 @@ spec:
         {{- end }}
         {{- if .Values.templateStacks.enabled }}
         - --templates
+        {{- if .Values.templateStacks.controllerImage }}
+        - --templating-controller-image
+        - {{ .Values.templateStacks.controllerImage | quote }}
+        {{- end }}
         {{- end }}
         {{- range $arg := .Values.args }}
         - {{ $arg }}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -35,3 +35,4 @@ hostedConfig:
 
 templateStacks:
   enabled: false
+  controllerImage: crossplane/templating-controller:0.1.0

--- a/docs/install-crossplane.md
+++ b/docs/install-crossplane.md
@@ -269,6 +269,7 @@ The following tables lists the configurable parameters of the Crossplane chart a
 | `clusterStacks.rook.version`     | Rook stack version to deploy                                    | `<latest released version>`   
 | `personas.deploy`                | Install roles and bindings for Crossplane user personas         | `true`     
 | `templateStacks.enabled`         | Enable experimental template stacks support                     | `false`     
+| `templateStacks.controllerImage` | Template Stack controller image                                 | `crossplane/templating-controller:0.1.0`
  
 ### Command Line
 

--- a/go.sum
+++ b/go.sum
@@ -250,6 +250,7 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/pty v1.1.5 h1:hyz3dwM5QLc1Rfoz4FuWJQG5BN7tc6K1MndAUnGpQr4=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=

--- a/pkg/controller/stacks/install/installjob.go
+++ b/pkg/controller/stacks/install/installjob.go
@@ -336,11 +336,13 @@ func setStackDefinitionControllerEnv(obj *unstructured.Unstructured, namespace, 
 		return err
 	}
 
-	ts := &sd.Spec.Controller.Deployment.Spec.Template.Spec
-	ts.Containers[0].Env = append(ts.Containers[0].Env, env...)
+	if d := sd.Spec.Controller.Deployment; d != nil {
+		c := d.Spec.Template.Spec.Containers
+		c[0].Env = append(c[0].Env, env...)
 
-	if u, err := convertToUnstructured(sd); err == nil {
-		u.DeepCopyInto(obj)
+		if u, err := convertToUnstructured(sd); err == nil {
+			u.DeepCopyInto(obj)
+		}
 	}
 
 	return err

--- a/pkg/controller/stacks/install/installjob_test.go
+++ b/pkg/controller/stacks/install/installjob_test.go
@@ -218,10 +218,10 @@ func unstructuredObj(uom ...unstructuredObjModifier) *unstructured.Unstructured 
 }
 
 type mockJobCompleter struct {
-	MockHandleJobCompletion func(ctx context.Context, i v1alpha1.StackInstaller, job *batchv1.Job) error
+	MockHandleJobCompletion func(ctx context.Context, i stacks.KindlyIdentifier, job *batchv1.Job) error
 }
 
-func (m *mockJobCompleter) handleJobCompletion(ctx context.Context, i v1alpha1.StackInstaller, job *batchv1.Job) error {
+func (m *mockJobCompleter) handleJobCompletion(ctx context.Context, i stacks.KindlyIdentifier, job *batchv1.Job) error {
 	return m.MockHandleJobCompletion(ctx, i, job)
 }
 
@@ -411,7 +411,7 @@ func TestHandleJobCompletion(t *testing.T) {
 			ext: resource(),
 			job: job(),
 			want: want{
-				ext: resource(withStackRecord(&corev1.ObjectReference{Name: resourceName, Namespace: namespace})),
+				ext: resource(),
 				err: nil,
 			},
 		},
@@ -450,7 +450,9 @@ func TestCreate(t *testing.T) {
 			name: "CreateInstallJob",
 			handler: &stackInstallHandler{
 				kube: &test.MockClient{
-					MockUpdate:       func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
+					MockPatch: func(_ context.Context, obj runtime.Object, patch client.Patch, _ ...client.PatchOption) error {
+						return nil
+					},
 					MockStatusUpdate: func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
 				},
 				hostKube: &test.MockClient{
@@ -474,7 +476,9 @@ func TestCreate(t *testing.T) {
 			name: "CreateInstallJobHosted",
 			handler: &stackInstallHandler{
 				kube: &test.MockClient{
-					MockUpdate:       func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
+					MockPatch: func(_ context.Context, obj runtime.Object, patch client.Patch, _ ...client.PatchOption) error {
+						return nil
+					},
 					MockStatusUpdate: func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
 				},
 				hostKube: &test.MockClient{
@@ -499,7 +503,9 @@ func TestCreate(t *testing.T) {
 			name: "HandleFailedInstallJobHosted",
 			handler: &stackInstallHandler{
 				kube: &test.MockClient{
-					MockUpdate:       func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
+					MockPatch: func(_ context.Context, obj runtime.Object, patch client.Patch, _ ...client.PatchOption) error {
+						return nil
+					},
 					MockStatusUpdate: func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
 				},
 				hostKube: &test.MockClient{
@@ -524,7 +530,9 @@ func TestCreate(t *testing.T) {
 			name: "FailedToGetInstallJob",
 			handler: &stackInstallHandler{
 				kube: &test.MockClient{
-					MockUpdate:       func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
+					MockPatch: func(_ context.Context, obj runtime.Object, patch client.Patch, _ ...client.PatchOption) error {
+						return nil
+					},
 					MockStatusUpdate: func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
 				},
 				hostKube: &test.MockClient{
@@ -550,7 +558,9 @@ func TestCreate(t *testing.T) {
 			name: "InstallJobNotCompleted",
 			handler: &stackInstallHandler{
 				kube: &test.MockClient{
-					MockUpdate:       func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
+					MockPatch: func(_ context.Context, obj runtime.Object, patch client.Patch, _ ...client.PatchOption) error {
+						return nil
+					},
 					MockStatusUpdate: func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
 				},
 				hostKube: &test.MockClient{
@@ -577,7 +587,9 @@ func TestCreate(t *testing.T) {
 			name: "HandleSuccessfulInstallJob",
 			handler: &stackInstallHandler{
 				kube: &test.MockClient{
-					MockUpdate:       func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
+					MockPatch: func(_ context.Context, obj runtime.Object, patch client.Patch, _ ...client.PatchOption) error {
+						return nil
+					},
 					MockStatusUpdate: func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
 				},
 				hostKube: &test.MockClient{
@@ -588,7 +600,7 @@ func TestCreate(t *testing.T) {
 					},
 				},
 				jobCompleter: &mockJobCompleter{
-					MockHandleJobCompletion: func(ctx context.Context, i v1alpha1.StackInstaller, job *batchv1.Job) error { return nil },
+					MockHandleJobCompletion: func(ctx context.Context, i stacks.KindlyIdentifier, job *batchv1.Job) error { return nil },
 				},
 				executorInfo: &stacks.ExecutorInfo{Image: stackPackageImage},
 				ext: resource(
@@ -600,7 +612,7 @@ func TestCreate(t *testing.T) {
 				err:    nil,
 				ext: resource(
 					withFinalizers(installFinalizer),
-					withConditions(runtimev1alpha1.Available(), runtimev1alpha1.ReconcileSuccess()),
+					withConditions(runtimev1alpha1.Creating(), runtimev1alpha1.ReconcileSuccess()),
 					withInstallJob(&corev1.ObjectReference{Name: resourceName, Namespace: namespace}),
 				),
 			},
@@ -609,7 +621,9 @@ func TestCreate(t *testing.T) {
 			name: "HandleFailedInstallJob",
 			handler: &stackInstallHandler{
 				kube: &test.MockClient{
-					MockUpdate:       func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
+					MockPatch: func(_ context.Context, obj runtime.Object, patch client.Patch, _ ...client.PatchOption) error {
+						return nil
+					},
 					MockStatusUpdate: func(ctx context.Context, obj runtime.Object, _ ...client.UpdateOption) error { return nil },
 				},
 				hostKube: &test.MockClient{
@@ -620,7 +634,7 @@ func TestCreate(t *testing.T) {
 					},
 				},
 				jobCompleter: &mockJobCompleter{
-					MockHandleJobCompletion: func(ctx context.Context, i v1alpha1.StackInstaller, job *batchv1.Job) error { return nil },
+					MockHandleJobCompletion: func(ctx context.Context, i stacks.KindlyIdentifier, job *batchv1.Job) error { return nil },
 				},
 				executorInfo: &stacks.ExecutorInfo{Image: stackPackageImage},
 				ext: resource(

--- a/pkg/controller/stacks/install/stackinstall_test.go
+++ b/pkg/controller/stacks/install/stackinstall_test.go
@@ -49,7 +49,7 @@ const (
 	uid                     = types.UID(uidString)
 	resourceName            = "cool-stackinstall"
 	stackPackageImage       = "cool/stack-package:rad"
-	tsControllerImage       = "crossplane/ts-controller:0.0.0"
+	tsControllerImage       = "cool/fake-ts-controller:0.0.0"
 )
 
 var (

--- a/pkg/controller/stacks/stack/stack_test.go
+++ b/pkg/controller/stacks/stack/stack_test.go
@@ -57,10 +57,10 @@ const (
 	resourceName            = "cool-stack"
 	roleName                = "stack:cool-namespace:cool-stack::system"
 
-	controllerDeploymentName = "cool-controller-deployment"
+	controllerDeploymentName = "cool-stack-controller"
 	controllerContainerName  = "cool-container"
 	controllerImageName      = "cool/controller-image:rad"
-	controllerJobName        = "cool-controller-job"
+	controllerJobName        = "cool-stack-job"
 )
 
 var (
@@ -1107,7 +1107,18 @@ func TestProcessDeployment(t *testing.T) {
 						Labels:    stackspkg.ParentLabels(resource(withControllerSpec(defaultControllerSpec()))),
 					},
 					Spec: apps.DeploymentSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app": controllerDeploymentName,
+							},
+						},
 						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"app": controllerDeploymentName,
+								},
+								Name: controllerDeploymentName,
+							},
 							Spec: corev1.PodSpec{
 								ServiceAccountName: resourceName,
 								Containers: []corev1.Container{
@@ -1143,7 +1154,18 @@ func TestProcessDeployment(t *testing.T) {
 						Labels:    stackspkg.ParentLabels(resource(withControllerSpec(defaultControllerSpec()))),
 					},
 					Spec: apps.DeploymentSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app": controllerDeploymentName,
+							},
+						},
 						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"app": controllerDeploymentName,
+								},
+								Name: controllerDeploymentName,
+							},
 							Spec: corev1.PodSpec{
 								ServiceAccountName:           "",
 								AutomountServiceAccountToken: &disableAutoMount,
@@ -1318,6 +1340,7 @@ func TestProcessJob(t *testing.T) {
 					},
 					Spec: batch.JobSpec{
 						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{Name: controllerJobName},
 							Spec: corev1.PodSpec{
 								RestartPolicy:      corev1.RestartPolicyNever,
 								ServiceAccountName: resourceName,
@@ -1355,6 +1378,9 @@ func TestProcessJob(t *testing.T) {
 					},
 					Spec: batch.JobSpec{
 						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: controllerJobName,
+							},
 							Spec: corev1.PodSpec{
 								RestartPolicy:                corev1.RestartPolicyNever,
 								ServiceAccountName:           "",

--- a/pkg/controller/stacks/stacks.go
+++ b/pkg/controller/stacks/stacks.go
@@ -26,15 +26,17 @@ import (
 )
 
 // Setup Crossplane Stacks controllers.
-func Setup(mgr ctrl.Manager, l logging.Logger, hostControllerNamespace string) error {
-	for _, setup := range []func(ctrl.Manager, logging.Logger, string) error{
-		install.SetupStackInstall,
-		install.SetupClusterStackInstall,
-		stack.Setup,
-	} {
-		if err := setup(mgr, l, hostControllerNamespace); err != nil {
-			return err
-		}
+func Setup(mgr ctrl.Manager, l logging.Logger, hostControllerNamespace, tsControllerImage string) error {
+	if err := install.SetupStackInstall(mgr, l, hostControllerNamespace, tsControllerImage); err != nil {
+		return err
+	}
+
+	if err := install.SetupClusterStackInstall(mgr, l, hostControllerNamespace, tsControllerImage); err != nil {
+		return err
+	}
+
+	if err := stack.Setup(mgr, l, hostControllerNamespace); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/stacks/steps_test.go
+++ b/pkg/stacks/steps_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestIconStep(t *testing.T) {
-	sp := NewStackPackage("/")
+	sp := NewStackPackage("/", "crossplane/ts-controller:0.0.0")
 	step := iconStep(sp)
 	step("/icon.png", []byte("base64me"))
 

--- a/pkg/stacks/unpack_test.go
+++ b/pkg/stacks/unpack_test.go
@@ -63,12 +63,12 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
 `
-	simpleBehaviorStackFile = `---
+
+	simpleStackConfigFile = `---
 apiVersion: stacks.crossplane.io/v1alpha1
 kind: StackConfiguration
 metadata:
   name: template-stack-test
-
 spec:
   behaviors:
     crds:
@@ -80,6 +80,19 @@ spec:
       type: helm2
     source:
       image: crossplane/sample-stack-claim-test:helm2
+`
+
+	simpleBehaviorFile = `
+crd:
+  kind: SampleClaim
+  apiVersion: samples.stacks.crossplane.io/v1alpha1
+engine:
+  type: helm2
+reconcile:
+  path: 'resources'
+source:
+  image: crossplane/sample-stack-claim-test:helm2
+  path: /path
 `
 
 	simpleJobInstallFile = `apiVersion: batch/v1
@@ -163,7 +176,7 @@ spec:
   company: Upbound
   controller:
     deployment:
-      name: crossplane-sample-stack
+      name: ""
       spec:
         replicas: 1
         selector:
@@ -249,8 +262,11 @@ spec:
   website: https://upbound.io
 status:
   conditionedStatus: {}
+
+---
 `
-	expectedSimpleBehaviorStackOutput = `
+
+	expectedSimpleStackConfigurationStackOutput = `
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -364,6 +380,157 @@ spec:
       type: helm2
     source:
       image: crossplane/sample-stack-claim-test:helm2
+
+---
+`
+	expectedSimpleBehaviorStackOutput = `
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    stacks.crossplane.io/icon-data-uri: data:image/jpeg;base64,bW9jay1pY29uLWRhdGE=
+    stacks.crossplane.io/stack-title: Sample Crossplane Stack
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: stack-manager
+    crossplane.io/scope: namespace
+  name: mytypes.samples.upbound.io
+spec:
+  group: samples.upbound.io
+  names:
+    kind: Mytype
+    listKind: MytypeList
+    plural: mytypes
+    singular: mytype
+  scope: Namespaced
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+
+---
+apiVersion: stacks.crossplane.io/v1alpha1
+kind: StackDefinition
+metadata:
+  creationTimestamp: null
+spec:
+  behavior:
+    crd:
+      apiVersion: samples.stacks.crossplane.io/v1alpha1
+      kind: SampleClaim
+    engine:
+      type: helm2
+    source:
+      image: crossplane/sample-stack-claim-test:helm2
+      path: /path
+  category: Category
+  company: Upbound
+  controller:
+    deployment:
+      name: ""
+      spec:
+        selector: {}
+        strategy: {}
+        template:
+          metadata:
+            creationTimestamp: null
+          spec:
+            containers:
+            - args:
+              - --resources-dir
+              - /behaviors
+              - --stack-definition-namespace
+              - $(SD_NAMESPACE)
+              - --stack-definition-name
+              - $(SD_NAME)
+              command:
+              - /manager
+              image: crossplane/ts-controller:0.0.0
+              name: stack-behavior-manager
+              resources: {}
+              volumeMounts:
+              - mountPath: /behaviors
+                name: behaviors
+            initContainers:
+            - command:
+              - cp
+              - -R
+              - /path/.
+              - /behaviors
+              image: crossplane/sample-stack-claim-test:helm2
+              name: stack-behavior-copy-to-manager
+              resources: {}
+              volumeMounts:
+              - mountPath: /behaviors
+                name: behaviors
+            restartPolicy: Always
+            volumes:
+            - emptyDir: {}
+              name: behaviors
+  customresourcedefinitions:
+  - apiVersion: samples.upbound.io/v1alpha1
+    kind: Mytype
+  dependsOn:
+  - crd: foo.mystack.example.org/v1alpha1
+  - crd: '*.yourstack.example.org/v1alpha2'
+  icons:
+  - base64Data: bW9jay1pY29uLWRhdGE=
+    mediatype: image/jpeg
+  keywords:
+  - samples
+  - examples
+  - tutorials
+  license: Apache-2.0
+  maintainers:
+  - email: jared@upbound.io
+    name: Jared Watts
+  overview: text overview
+  overviewShort: short text overview
+  owners:
+  - email: bassam@upbound.io
+    name: Bassam Tabbara
+  permissionScope: Namespaced
+  permissions:
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      - events
+      - secrets
+      verbs:
+      - '*'
+    - apiGroups:
+      - samples.upbound.io
+      resources:
+      - mytypes
+      verbs:
+      - '*'
+    - apiGroups:
+      - mystack.example.org
+      resources:
+      - foo
+      verbs:
+      - '*'
+    - apiGroups:
+      - yourstack.example.org
+      resources:
+      - '*'
+      verbs:
+      - '*'
+  readme: |
+    Markdown describing this sample Crossplane stack project.
+  source: https://github.com/crossplaneio/sample-stack
+  title: Sample Crossplane Stack
+  version: 0.0.1
+  website: https://upbound.io
+status: {}
+
+---
 `
 
 	expectedComplexDeploymentStackOutput = `
@@ -557,7 +724,7 @@ spec:
   company: Upbound
   controller:
     deployment:
-      name: crossplane-sample-stack
+      name: ""
       spec:
         replicas: 1
         selector:
@@ -669,6 +836,8 @@ spec:
   website: https://upbound.io
 status:
   conditionedStatus: {}
+
+---
 `
 
 	expectedComplexInfraStackOutput = `
@@ -862,7 +1031,7 @@ spec:
   company: Upbound
   controller:
     deployment:
-      name: crossplane-sample-stack
+      name: ""
       spec:
         replicas: 1
         selector:
@@ -974,6 +1143,8 @@ spec:
   website: https://upbound.io
 status:
   conditionedStatus: {}
+
+---
 `
 
 	expectedSimpleJobStackOutput = `
@@ -1015,7 +1186,7 @@ spec:
   company: Upbound
   controller:
     job:
-      name: crossplane-sample-install-job
+      name: ""
       spec:
         backoffLimit: 4
         completions: 1
@@ -1099,6 +1270,8 @@ spec:
   website: https://upbound.io
 status:
   conditionedStatus: {}
+
+---
 `
 )
 
@@ -1251,13 +1424,29 @@ func TestUnpack(t *testing.T) {
 			want: want{output: expectedSimpleDeploymentStackOutput, err: nil},
 		},
 		{
+			name: "SimpleStackConfigurationStack",
+			fs: func() afero.Fs {
+				fs := afero.NewMemMapFs()
+				fs.MkdirAll("ext-dir", 0755)
+				afero.WriteFile(fs, "ext-dir/icon.jpg", []byte("mock-icon-data"), 0644)
+				afero.WriteFile(fs, "ext-dir/app.yaml", []byte(simpleAppFile("Namespaced")), 0644)
+				afero.WriteFile(fs, "ext-dir/stack.yaml", []byte(simpleStackConfigFile), 0644)
+				crdDir := "ext-dir/resources/samples.upbound.io/mytype/v1alpha1"
+				fs.MkdirAll(crdDir, 0755)
+				afero.WriteFile(fs, filepath.Join(crdDir, "mytype.v1alpha1.crd.yaml"), []byte(simpleCRDFile("mytype")), 0644)
+				return fs
+			}(),
+			root: "ext-dir",
+			want: want{output: expectedSimpleStackConfigurationStackOutput, err: nil},
+		},
+		{
 			name: "SimpleBehaviorStack",
 			fs: func() afero.Fs {
 				fs := afero.NewMemMapFs()
 				fs.MkdirAll("ext-dir", 0755)
 				afero.WriteFile(fs, "ext-dir/icon.jpg", []byte("mock-icon-data"), 0644)
 				afero.WriteFile(fs, "ext-dir/app.yaml", []byte(simpleAppFile("Namespaced")), 0644)
-				afero.WriteFile(fs, "ext-dir/stack.yaml", []byte(simpleBehaviorStackFile), 0644)
+				afero.WriteFile(fs, "ext-dir/behavior.yaml", []byte(simpleBehaviorFile), 0644)
 				crdDir := "ext-dir/resources/samples.upbound.io/mytype/v1alpha1"
 				fs.MkdirAll(crdDir, 0755)
 				afero.WriteFile(fs, filepath.Join(crdDir, "mytype.v1alpha1.crd.yaml"), []byte(simpleCRDFile("mytype")), 0644)
@@ -1328,7 +1517,7 @@ func TestUnpack(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := &bytes.Buffer{}
 			rd := &walker.ResourceDir{Base: tt.root, Walker: afero.Afero{Fs: tt.fs}}
-			err := Unpack(rd, got, tt.root, "Namespaced")
+			err := Unpack(rd, got, tt.root, "Namespaced", "crossplane/ts-controller:0.0.0")
 
 			if diff := cmp.Diff(tt.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("Unpack() -want error, +got error:\n%s", diff)
@@ -1400,7 +1589,7 @@ func TestUnpackCluster(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := &bytes.Buffer{}
 			rd := &walker.ResourceDir{Base: tt.root, Walker: afero.Afero{Fs: tt.fs}}
-			err := Unpack(rd, got, tt.root, "Cluster")
+			err := Unpack(rd, got, tt.root, "Cluster", "crossplane/ts-controller:0.0.0")
 
 			if diff := cmp.Diff(tt.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("Unpack() -want error, +got error:\n%s", diff)


### PR DESCRIPTION
### Description of your changes

The Stack Manager is taught how to handle `behavior.yaml` files adjacent to `app.yaml`.

In the presence of this file, the Stack-Manager Unpack process will emit a `StackDefinition` resource rather than a `Stack` resource.  Since these template stacks do not (and should not) include an `install.yaml`, the controller in the StackDefinition resource will be configured as `crossplane/templating-controller` with parameters understood by that controller. This image is configurable as a Helm value.

* [templating-controller](https://github.com/crossplaneio/templating-controller/) should be tagged `0.1.0` and pushed to DockerHub to match this PR

The StackDefinition controller has been modified to include an additional RBAC permission in the Stack that it emits.  This added rule enables the templating-controller to access the StackDefinition resource since the behavior metadata is stored in that resource.

Fixes #1210 

### How has this code been tested?

https://github.com/muvaf/stack-minimal-gcp/tree/template-stacks is successfully deployed using:

```
kubectl crossplane stack install --cluster --namespace crossplane-system crossplane/stack-minimal-gcp:0.0.2 stack-minimal-gcp
```
### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplaneio/crossplane/tree/master/design/one-pager-definition-of-done.md
