### PR TITLE
Rehome pod util functions from crossplane-runtime

### DIFF
--- a/pkg/stacks/executorinfo.go
+++ b/pkg/stacks/executorinfo.go
@@ -22,8 +22,6 @@ import (
 	"sync"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/crossplaneio/crossplane-runtime/pkg/util"
 )
 
 var (
@@ -65,10 +63,10 @@ func (eif *KubeExecutorInfoDiscoverer) Discover(ctx context.Context) (*ExecutorI
 		return &ExecutorInfo{Image: image}, nil
 	}
 
-	if pod, err := util.GetRunningPod(ctx, eif.Client); err != nil {
+	if pod, err := GetRunningPod(ctx, eif.Client); err != nil {
 		log.Error(err, "failed to get running pod")
 		return nil, err
-	} else if image, err = util.GetContainerImage(pod, ""); err != nil {
+	} else if image, err = GetContainerImage(pod, ""); err != nil {
 		log.Error(err, "failed to get image for pod", "image", image)
 		return nil, err
 	}

--- a/pkg/stacks/pod.go
+++ b/pkg/stacks/pod.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2019 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stacks
+
+import (
+	"context"
+	"os"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// PodNameEnvVar is the env variable for getting the pod name via downward api
+	PodNameEnvVar = "POD_NAME"
+	// PodNamespaceEnvVar is the env variable for getting the pod namespace via downward api
+	PodNamespaceEnvVar = "POD_NAMESPACE"
+)
+
+// GetRunningPod will get the pod object for the currently running pod.  This assumes that the
+// downward API has been used to inject the pod name and namespace as env vars.
+func GetRunningPod(ctx context.Context, kube client.Client) (*v1.Pod, error) {
+	podName := os.Getenv(PodNameEnvVar)
+	if podName == "" {
+		return nil, errors.New("cannot detect the pod name. Please provide it using the downward API in the manifest file")
+	}
+	podNamespace := os.Getenv(PodNamespaceEnvVar)
+	if podNamespace == "" {
+		return nil, errors.New("cannot detect the pod namespace. Please provide it using the downward API in the manifest file")
+	}
+
+	name := types.NamespacedName{Name: podName, Namespace: podNamespace}
+
+	pod := &v1.Pod{}
+	err := kube.Get(ctx, name, pod)
+
+	return pod, err
+}
+
+// GetContainerImage will get the container image for the container with the given name in the
+// given pod.
+func GetContainerImage(pod *v1.Pod, name string) (string, error) {
+	return GetSpecContainerImage(pod.Spec, name, false)
+}
+
+// GetSpecContainerImage will get the container image for the container with the given name in the
+// given pod spec.
+func GetSpecContainerImage(spec v1.PodSpec, name string, initContainer bool) (string, error) {
+	containers := spec.Containers
+	if initContainer {
+		containers = spec.InitContainers
+	}
+	image, err := GetMatchingContainer(containers, name)
+	if err != nil {
+		return "", err
+	}
+	return image.Image, nil
+}
+
+// GetMatchingContainer returns the container from the given set of containers that matches the
+// given name.  If the given container list has only 1 item then the name field is ignored and
+// that container is returned.
+func GetMatchingContainer(containers []v1.Container, name string) (v1.Container, error) {
+	var result *v1.Container
+	if len(containers) == 1 {
+		// if there is only one pod, use its image rather than require a set container name
+		result = &containers[0]
+	} else {
+		// if there are multiple pods, we require the container to have the expected name
+		for _, container := range containers {
+			container := container // pin range scoped container var
+			if container.Name == name {
+				result = &container
+				break
+			}
+		}
+	}
+
+	if result == nil {
+		return v1.Container{}, errors.Errorf("failed to find image for container %s", name)
+	}
+
+	return *result, nil
+}

--- a/pkg/stacks/pod_test.go
+++ b/pkg/stacks/pod_test.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2019 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stacks
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/crossplaneio/crossplane-runtime/pkg/test"
+)
+
+func TestGetRunningPod(t *testing.T) {
+	type want struct {
+		pod *v1.Pod
+		err error
+	}
+
+	tests := []struct {
+		name    string
+		envvars envvars
+		kube    client.Client
+		want    want
+	}{
+		{
+			name: "EmptyPodNameEnvVar",
+			envvars: envvars{
+				podName:      "",
+				podNamespace: "foo-ns",
+			},
+			kube: nil,
+			want: want{
+				pod: nil,
+				err: errors.New("cannot detect the pod name. Please provide it using the downward API in the manifest file"),
+			},
+		},
+		{
+			name: "EmptyPodNamespaceEnvVar",
+			envvars: envvars{
+				podName:      "foo",
+				podNamespace: "",
+			},
+			kube: nil,
+			want: want{
+				pod: nil,
+				err: errors.New("cannot detect the pod namespace. Please provide it using the downward API in the manifest file"),
+			},
+		},
+		{
+			name: "SimpleGet",
+			envvars: envvars{
+				podName:      "foo",
+				podNamespace: "foo-ns",
+			},
+			kube: fake.NewFakeClientWithScheme(scheme.Scheme, &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "foo-ns"}}),
+			want: want{
+				pod: &v1.Pod{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"}, ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "foo-ns"}},
+				err: nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initialEnvVars := saveEnvVars()
+			defer restoreEnvVars(initialEnvVars)
+
+			os.Setenv(PodNameEnvVar, tt.envvars.podName)
+			os.Setenv(PodNamespaceEnvVar, tt.envvars.podNamespace)
+			got, err := GetRunningPod(context.Background(), tt.kube)
+
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
+				t.Errorf("GetRunningPod() want error != got error:\n%s", diff)
+			}
+
+			if diff := cmp.Diff(got, tt.want.pod); diff != "" {
+				t.Errorf("GetRunningPod() got != want:\n%v", diff)
+			}
+		})
+	}
+}
+
+func TestGetSpecContainerImage(t *testing.T) {
+	type want struct {
+		image string
+		err   error
+	}
+
+	tests := []struct {
+		name          string
+		pod           *v1.Pod
+		containerName string
+		initContainer bool
+		want          want
+	}{
+		{
+			name: "SingleContainer",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "foo", Image: "foo-image"},
+					},
+				},
+			},
+			containerName: "foo",
+			want: want{
+				image: "foo-image",
+				err:   nil,
+			},
+		},
+		{
+			name: "MultipleContainers",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "bar", Image: "bar-image"},
+						{Name: "foo", Image: "foo-image"},
+					},
+				},
+			},
+			containerName: "foo",
+			want: want{
+				image: "foo-image",
+				err:   nil,
+			},
+		},
+		{
+			name: "InitContainer",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						{Name: "foo", Image: "foo-image"},
+					},
+					Containers: []v1.Container{
+						{Name: "bar", Image: "bar-image"},
+					},
+				},
+			},
+			containerName: "foo",
+			initContainer: true,
+			want: want{
+				image: "foo-image",
+				err:   nil,
+			},
+		},
+		{
+			name: "NoMatches",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "bar", Image: "bar-image"},
+						{Name: "foo", Image: "foo-image"},
+					},
+				},
+			},
+			containerName: "baz",
+			want: want{
+				image: "",
+				err:   errors.New("failed to find image for container baz"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetSpecContainerImage(tt.pod.Spec, tt.containerName, tt.initContainer)
+
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
+				t.Errorf("GetSpecContainerImage() want error != got error:\n%s", diff)
+			}
+
+			if diff := cmp.Diff(got, tt.want.image); diff != "" {
+				t.Errorf("GetSpecContainerImage() got != want:\n%v", diff)
+			}
+		})
+	}
+}
+
+func TestGetContainerImage(t *testing.T) {
+	type want struct {
+		image string
+		err   error
+	}
+
+	tests := []struct {
+		name          string
+		pod           *v1.Pod
+		containerName string
+		want          want
+	}{
+		{
+			name: "SingleContainer",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "foo", Image: "foo-image"},
+					},
+				},
+			},
+			containerName: "foo",
+			want: want{
+				image: "foo-image",
+				err:   nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetContainerImage(tt.pod, tt.containerName)
+
+			if diff := cmp.Diff(err, tt.want.err, test.EquateErrors()); diff != "" {
+				t.Errorf("GetContainerImage() want error != got error:\n%s", diff)
+			}
+
+			if diff := cmp.Diff(got, tt.want.image); diff != "" {
+				t.Errorf("GetContainerImage() got != want:\n%v", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->
https://github.com/crossplaneio/crossplane-runtime/issues/1

Per the above issue the util package is deprecated. As best I can tell the stacks package is the only user of these functions, so I suggest they live where they're used.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplaneio/crossplane/tree/master/design/one-pager-definition-of-done.md
