### PR TITLE
template stacks: add user-friendly enable flag to helm chart

### DIFF
--- a/cluster/charts/crossplane-controllers/templates/stack-manager-deployment.yaml
+++ b/cluster/charts/crossplane-controllers/templates/stack-manager-deployment.yaml
@@ -33,6 +33,9 @@ spec:
         - --host-controller-namespace
         - {{ .Values.hostedConfig.controllerNamespace | quote }}
         {{- end }}
+        {{- if .Values.templateStacks.enabled }}
+        - --templates
+        {{- end }}
         {{- range $arg := .Values.args }}
         - {{ $arg }}
         {{- end }}

--- a/cluster/charts/crossplane-controllers/values.yaml.tmpl
+++ b/cluster/charts/crossplane-controllers/values.yaml.tmpl
@@ -22,3 +22,6 @@ hostedConfig:
   tenantKubernetesServicePort: ""
   controllerNamespace: ""
   crossplaneSATokenSecret: ""
+
+templateStacks:
+  enabled: false

--- a/cluster/charts/crossplane/templates/stack-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/stack-manager-deployment.yaml
@@ -33,6 +33,9 @@ spec:
         - --host-controller-namespace
         - {{ .Values.hostedConfig.controllerNamespace | quote }}
         {{- end }}
+        {{- if .Values.templateStacks.enabled }}
+        - --templates
+        {{- end }}
         {{- range $arg := .Values.args }}
         - {{ $arg }}
         {{- end }}

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -32,3 +32,6 @@ clusterStacks:
 
 hostedConfig:
   enabled: false
+
+templateStacks:
+  enabled: false

--- a/docs/install-crossplane.md
+++ b/docs/install-crossplane.md
@@ -267,7 +267,8 @@ The following tables lists the configurable parameters of the Crossplane chart a
 | `clusterStacks.azure.version`    | Azure stack version to deploy                                   | `<latest released version>`   
 | `clusterStacks.rook.deploy`      | Deploy Rook stack                                               | `false`    
 | `clusterStacks.rook.version`     | Rook stack version to deploy                                    | `<latest released version>`   
-| `personas.deploy`                | Install roles and bindings for Crossplane user personas        | `true`     
+| `personas.deploy`                | Install roles and bindings for Crossplane user personas         | `true`     
+| `templateStacks.enabled`         | Enable experimental template stacks support                     | `false`     
  
 ### Command Line
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

Fixes #1185 

Now that template stacks can be enabled by adventurous users by passing
a flag to the stack manager, we want to make it more convenient by
supporting it from within the helm chart.

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

Regression test:

* Built helm chart locally
* Installed helm chart locally with development script
* Checked to make sure deployments still started up

Template stack flag test:

* Built helm chart locally
* Installed helm chart locally with development script, adding a `--set templateStacks.enabled=true`
* Checked to make sure deployments still started up
* Looked for `Adding template controllers` in the logs of the stack manager pod

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [x] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplaneio/crossplane/tree/master/design/one-pager-definition-of-done.md
