### PR TITLE
stacks: add rbac rules to predefined personas

### DIFF
--- a/cluster/charts/crossplane-types/templates/crossplane-admin-clusterrole.yaml
+++ b/cluster/charts/crossplane-types/templates/crossplane-admin-clusterrole.yaml
@@ -42,6 +42,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - namespaces

--- a/cluster/charts/crossplane-types/templates/environment-personas-clusterroles.yaml
+++ b/cluster/charts/crossplane-types/templates/environment-personas-clusterroles.yaml
@@ -159,5 +159,21 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
 ---
 {{- end}}

--- a/cluster/charts/crossplane-types/templates/namespace-personas-clusterroles.yaml
+++ b/cluster/charts/crossplane-types/templates/namespace-personas-clusterroles.yaml
@@ -49,7 +49,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "name" . }}:stack-manager:ns:default:edit
   labels:
-    rbac.crossplane.io/aggregate-to-namespace-admin: "true"
+    rbac.crossplane.io/aggregate-to-namespace-default-admin: "true"
     rbac.crossplane.io/aggregate-to-namespace-default-edit: "true"
     app: {{ template "name" . }}
     chart: {{ template "chart" . }}
@@ -92,7 +92,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "name" . }}:stack-manager:ns:default:view
   labels:
-    rbac.crossplane.io/aggregate-to-namespace-edit: "true"
+    rbac.crossplane.io/aggregate-to-namespace-default-edit: "true"
     rbac.crossplane.io/aggregate-to-namespace-default-view: "true"
     app: {{ template "name" . }}
     chart: {{ template "chart" . }}

--- a/cluster/charts/crossplane-types/templates/namespace-personas-clusterroles.yaml
+++ b/cluster/charts/crossplane-types/templates/namespace-personas-clusterroles.yaml
@@ -124,4 +124,30 @@ rules:
   - list
   - watch
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}:system:ns-persona-cluster-rights
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
 {{- end}}

--- a/cluster/charts/crossplane/templates/crossplane-admin-clusterrole.yaml
+++ b/cluster/charts/crossplane/templates/crossplane-admin-clusterrole.yaml
@@ -42,6 +42,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - namespaces

--- a/cluster/charts/crossplane/templates/environment-personas-clusterroles.yaml
+++ b/cluster/charts/crossplane/templates/environment-personas-clusterroles.yaml
@@ -159,5 +159,21 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
 ---
 {{- end}}

--- a/cluster/charts/crossplane/templates/namespace-personas-clusterroles.yaml
+++ b/cluster/charts/crossplane/templates/namespace-personas-clusterroles.yaml
@@ -49,7 +49,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "name" . }}:stack-manager:ns:default:edit
   labels:
-    rbac.crossplane.io/aggregate-to-namespace-admin: "true"
+    rbac.crossplane.io/aggregate-to-namespace-default-admin: "true"
     rbac.crossplane.io/aggregate-to-namespace-default-edit: "true"
     app: {{ template "name" . }}
     chart: {{ template "chart" . }}
@@ -92,7 +92,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "name" . }}:stack-manager:ns:default:view
   labels:
-    rbac.crossplane.io/aggregate-to-namespace-edit: "true"
+    rbac.crossplane.io/aggregate-to-namespace-default-edit: "true"
     rbac.crossplane.io/aggregate-to-namespace-default-view: "true"
     app: {{ template "name" . }}
     chart: {{ template "chart" . }}

--- a/cluster/charts/crossplane/templates/namespace-personas-clusterroles.yaml
+++ b/cluster/charts/crossplane/templates/namespace-personas-clusterroles.yaml
@@ -124,4 +124,30 @@ rules:
   - list
   - watch
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "name" . }}:system:ns-persona-cluster-rights
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
 {{- end}}


### PR DESCRIPTION
### Description of your changes

This PR introduces two changes to the existing personas bundled with Crossplane:

* Environment `*:view` personas get `read,list,watch` on customresourcedefinitions and namespaces
* `crossplane-admin` persona gets `read,list,watch` on ClusterRoles
  `crossplane-admin` also inherits the new environment persona roles
 
Additionally, a new ClusterRole is created:
* `crossplane:system:ns-persona-cluster-rights`
  
  This clusterrole offers `crossplane:ns:{namespace}:{persona}` personas (through an additional clusterrolebinding) the ability to get, list, and watch customresourcedefinition (see https://github.com/crossplaneio/crossplane/pull/1234#issuecomment-583657605) 

  This clusterrole also grants get, list, and watch on namespaces.

Included is a fix to the aggregation from namespace personas (view and edit) into their respective superior personas (edit and view).  The namespace edit persona was observed to have secret writing while the admin persona did not.

Fixes #1247, #1232, #1259

### How has this code been tested?

Give "users" rolebindings:
```
kubectl create namespace precipice
kubectl stack generate-install crossplane/sample-stack-wordpress stack-wordpress | kubectl apply -n precipice -f -
for persona in view edit admin; do
  for namespace in precipice default; do
    kubectl create rolebinding demo-$namespace-$persona --clusterrole crossplane:ns:$namespace:$persona --user $namespace-$persona@example.com --namespace $namespace
  done

  kubectl create clusterrolebinding demo-crossplane-env-$persona --clusterrole crossplane-env-$persona --user env-$persona@example.com
done

kubectl create clusterrolebinding demo-crossplane-admin --clusterrole crossplane-admin --user crossplane-admin@example.com

kubectl create clusterrolebinding demo-crossplane-precipice-view-more --clusterrole crossplane:system:ns-persona-cluster-rights --user precipice-view@example.com
```

Test those users ability to create the affected resources:
```
cat << EOS | 
yes clusterstackinstall crossplane-admin
yes clusterstackinstall env-admin
yes stackinstall crossplane-admin create precipice
yes stackinstall precipice-admin create precipice

no clusterstackinstall env-edit
no stackinstall precipice-edit create precipice

yes clusterrolebinding crossplane-admin
yes clusterrole crossplane-admin get
no clusterrole crossplane-admin
no clusterrolebinding env-admin
no clusterrole env-admin
no rolebinding precipice-admin create precipice
no role precipice-admin create precipice

yes customresourcedefinition env-view list
yes namespace env-view list

yes customresourcedefinition precipice-view list
yes namespace precipice-view list

should-fail foo bar
EOS
while read want resource user verb namespace; do 
  [ -z "$want" ] && continue
  verb=${verb:-create}
  cmd="kubectl auth can-i $verb $resource --as=$user@example.com"
  [ -n "$namespace" ] && cmd="$cmd -n $namespace"
  got=$($cmd)
  [ "$got" == "$want" ] || echo "got $got, want $want: $user $verb $namespace $resource"
done
```

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [x] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplaneio/crossplane/tree/master/design/one-pager-definition-of-done.md
