### PR TITLE
Add script for host aware stack manager local testing

### DIFF
--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -209,7 +209,8 @@ The following tables lists the configurable parameters of the Crossplane chart a
 | `clusterStacks.azure.version`    | Azure stack version to deploy                                   | `<latest released version>`   
 | `clusterStacks.rook.deploy`      | Deploy Rook stack                                               | `false`    
 | `clusterStacks.rook.version`     | Rook stack version to deploy                                    | `<latest released version>`   
-| `personas.deploy`                | Install roles and bindings for Crossplane user personas        | `true`     
+| `personas.deploy`                | Install roles and bindings for Crossplane user personas         | `true`     
+| `templateStacks.enabled`         | Enable experimental template stacks support                     | `false`     
  
 ### Command Line
 

--- a/cluster/local/hosted_test.sh
+++ b/cluster/local/hosted_test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+scriptdir="$( dirname "${BASH_SOURCE[0]}")"
+projectdir="$( cd "${scriptdir}"/../.. && pwd )"
+
+eval $(make --no-print-directory -C "${projectdir}" build.vars)
+
+TAG=$(cat "${projectdir}"/_output/version)
+BUILD_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-amd64"
+FINAL_IMAGE="${DOCKER_REGISTRY}/${PROJECT_NAME}:${TAG}"
+
+types_chart_dir="${projectdir}/cluster/charts/crossplane-types"
+controllers_chart_dir="${projectdir}/cluster/charts/crossplane-controllers"
+
+kind_context=local-hosted-test
+pseudo_tenant_namespace=default
+system_namespace=crossplane-hosted-system
+controllers_namespace=crossplane-hosted-controllers
+tenant_kubeconfig_secret=tenant-kubeconfig
+
+tenant_kubernetes_service_host=kubernetes.default.svc
+tenant_kubernetes_service_port=443
+
+echo "creating kind cluster ${kind_context} - if not exists"
+if [[ -z "${KUBECONFIG:-}" ]]; then
+    export KUBECONFIG="$HOME/.kube/config"
+fi
+kind get kubeconfig --name ${kind_context} > /dev/null 2>&1 || \
+  kind create cluster --name="${kind_context}" --kubeconfig=${KUBECONFIG}
+
+echo "creating hosted system and controllers namespaces"
+kubectl create ns "${system_namespace}" -o yaml --dry-run | kubectl apply -f -
+kubectl create ns "${controllers_namespace}" -o yaml --dry-run | kubectl apply -f -
+
+echo "creating kubeconfig secret to access cluster from inside"
+local_kubeconfig=$(sed -e 's|server:\s*.*$|server: https://kubernetes.default.svc|g' "${KUBECONFIG}")
+kubectl -n "${system_namespace}" create secret generic "${tenant_kubeconfig_secret}" --from-literal=kubeconfig="${local_kubeconfig}" -o yaml --dry-run \
+  | kubectl apply -f -
+
+echo "tagging crossplane image and loading into kind cluster"
+docker tag "${BUILD_IMAGE}" "${FINAL_IMAGE}"
+kind load docker-image "${FINAL_IMAGE}" --name="${kind_context}"
+
+echo "deploying crossplane-types"
+helm3 upgrade --install cp-types -n "${pseudo_tenant_namespace}" "${types_chart_dir}"
+
+
+crossplane_sa_token_secret=""
+until [[ -n "${crossplane_sa_token_secret}" ]]; do
+    echo "wait until crossplane service account token secret generated"
+    crossplane_sa_token_secret=$(kubectl -n "${pseudo_tenant_namespace}" get sa crossplane -o jsonpath="{.secrets[0].name}" || true)
+    sleep 3
+done
+
+echo "copying service account token from (pseudo) tenant to host"
+token=$(kubectl get secret -n "${pseudo_tenant_namespace}" "${crossplane_sa_token_secret}" -o jsonpath="{.data.token}" | base64 --decode)
+ca=$(kubectl get secret -n "${pseudo_tenant_namespace}" "${crossplane_sa_token_secret}" -o jsonpath="{.data.ca\.crt}" | base64 --decode)
+ns=$(kubectl get secret -n "${pseudo_tenant_namespace}" "${crossplane_sa_token_secret}" -o jsonpath="{.data.namespace}" | base64 --decode)
+kubectl  -n "${system_namespace}" create secret generic "${crossplane_sa_token_secret}" \
+  --from-literal=token="${token}" \
+  --from-literal=ca.crt="${ca}" \
+  --from-literal=namespace="${ns}" \
+  -o yaml --dry-run |kubectl apply -f -
+
+echo "deploying crossplane-controllers"
+helm3 upgrade --install cp-controllers -n "${system_namespace}" "${controllers_chart_dir}" \
+  --set image.pullPolicy=Never \
+  --set hostedConfig.enabled=true \
+  --set hostedConfig.controllerNamespace="${controllers_namespace}" \
+  --set hostedConfig.tenantKubeconfigSecret="${tenant_kubeconfig_secret}" \
+  --set hostedConfig.tenantKubernetesServiceHost="${tenant_kubernetes_service_host}" \
+  --set hostedConfig.tenantKubernetesServicePort="${tenant_kubernetes_service_port}" \
+  --set hostedConfig.crossplaneSATokenSecret="${crossplane_sa_token_secret}"
+
+echo """
+Kind cluster is ${kind_context} created is created:
+
+  export KUBECONFIG=${KUBECONFIG}
+
+A very basic check is to deploy a stack:
+
+  kubectl crossplane stack generate-install --cluster 'crossplane/stack-gcp:master' stack-gcp | kubectl apply -f -
+
+and make sure that its controllers is running in ${controllers_namespace} namespace.
+"""


### PR DESCRIPTION
Signed-off-by: Hasan Turken <turkenh@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
This PR adds a script for testing stack manager host aware mode locally in a single kind cluster. Despite it does not fully cover real scenario where host and tenant Kubernetes clusters are different, still adds a lot of value by testing most of the cases, for example:
- Deployment of crossplane-types and crossplane-controllers charts
- Passing and parsing hosted config parameters
- Disabling `automountServiceAccountToken` and mounting sa token secret for crossplane pod 
- Deployment of stack controllers to separate namespaces (deploying job, reading logs etc.)
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?
**Prerequisite:** Make sure you have binaries available: `kubectl`, `kind` and `helm3`

$ make build -j4
$ ./cluster/local/hosted_test.sh

<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [ ] Integrate to makefile, so that local binaries not used (removes above prerequisite)
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplaneio/crossplane/tree/master/design/one-pager-definition-of-done.md
