### PR TITLE
Use groupkind, not kind, for controller names

### DIFF
--- a/apis/cache/v1alpha1/register.go
+++ b/apis/cache/v1alpha1/register.go
@@ -40,6 +40,7 @@ var (
 // RedisCluster type metadata.
 var (
 	RedisClusterKind             = reflect.TypeOf(RedisCluster{}).Name()
+	RedisClusterGroupKind        = schema.GroupKind{Group: Group, Kind: RedisClusterKind}.String()
 	RedisClusterKindAPIVersion   = RedisClusterKind + "." + SchemeGroupVersion.String()
 	RedisClusterGroupVersionKind = SchemeGroupVersion.WithKind(RedisClusterKind)
 )

--- a/apis/compute/v1alpha1/register.go
+++ b/apis/compute/v1alpha1/register.go
@@ -40,6 +40,7 @@ var (
 // KubernetesCluster type metadata.
 var (
 	KubernetesClusterKind             = reflect.TypeOf(KubernetesCluster{}).Name()
+	KubernetesClusterGroupKind        = schema.GroupKind{Group: Group, Kind: KubernetesClusterKind}.String()
 	KubernetesClusterKindAPIVersion   = KubernetesClusterKind + "." + SchemeGroupVersion.String()
 	KubernetesClusterGroupVersionKind = SchemeGroupVersion.WithKind(KubernetesClusterKind)
 )
@@ -47,6 +48,7 @@ var (
 // MachineInstance type metadata.
 var (
 	MachineInstanceKind             = reflect.TypeOf(MachineInstance{}).Name()
+	MachineInstanceGroupKind        = schema.GroupKind{Group: Group, Kind: MachineInstanceKind}.String()
 	MachineInstanceKindAPIVersion   = MachineInstanceKind + "." + SchemeGroupVersion.String()
 	MachineInstanceGroupVersionKind = SchemeGroupVersion.WithKind(MachineInstanceKind)
 )

--- a/apis/database/v1alpha1/register.go
+++ b/apis/database/v1alpha1/register.go
@@ -40,6 +40,7 @@ var (
 // MySQLInstance type metadata.
 var (
 	MySQLInstanceKind             = reflect.TypeOf(MySQLInstance{}).Name()
+	MySQLInstanceGroupKind        = schema.GroupKind{Group: Group, Kind: MySQLInstanceKind}.String()
 	MySQLInstanceKindAPIVersion   = MySQLInstanceKind + "." + SchemeGroupVersion.String()
 	MySQLInstanceGroupVersionKind = SchemeGroupVersion.WithKind(MySQLInstanceKind)
 )
@@ -47,6 +48,7 @@ var (
 // PostgreSQLInstance type metadata.
 var (
 	PostgreSQLInstanceKind             = reflect.TypeOf(PostgreSQLInstance{}).Name()
+	PostgreSQLInstanceGroupKind        = schema.GroupKind{Group: Group, Kind: PostgreSQLInstanceKind}.String()
 	PostgreSQLInstanceKindAPIVersion   = PostgreSQLInstanceKind + "." + SchemeGroupVersion.String()
 	PostgreSQLInstanceGroupVersionKind = SchemeGroupVersion.WithKind(PostgreSQLInstanceKind)
 )

--- a/apis/kubernetes/v1alpha1/register.go
+++ b/apis/kubernetes/v1alpha1/register.go
@@ -40,6 +40,7 @@ var (
 // Provider type metadata.
 var (
 	ProviderKind             = reflect.TypeOf(Provider{}).Name()
+	ProviderGroupKind        = schema.GroupKind{Group: Group, Kind: ProviderKind}.String()
 	ProviderKindAPIVersion   = ProviderKind + "." + SchemeGroupVersion.String()
 	ProviderGroupVersionKind = SchemeGroupVersion.WithKind(ProviderKind)
 )

--- a/apis/stacks/v1alpha1/register.go
+++ b/apis/stacks/v1alpha1/register.go
@@ -40,6 +40,7 @@ var (
 // StackInstall type metadata.
 var (
 	StackInstallKind             = reflect.TypeOf(StackInstall{}).Name()
+	StackInstallGroupKind        = schema.GroupKind{Group: Group, Kind: StackInstallKind}.String()
 	StackInstallKindAPIVersion   = StackInstallKind + "." + SchemeGroupVersion.String()
 	StackInstallGroupVersionKind = SchemeGroupVersion.WithKind(StackInstallKind)
 )
@@ -47,6 +48,7 @@ var (
 // ClusterStackInstall type metadata.
 var (
 	ClusterStackInstallKind             = reflect.TypeOf(ClusterStackInstall{}).Name()
+	ClusterStackInstallGroupKind        = schema.GroupKind{Group: Group, Kind: ClusterStackInstallKind}.String()
 	ClusterStackInstallKindAPIVersion   = ClusterStackInstallKind + "." + SchemeGroupVersion.String()
 	ClusterStackInstallGroupVersionKind = SchemeGroupVersion.WithKind(ClusterStackInstallKind)
 )
@@ -54,6 +56,7 @@ var (
 // Stack type metadata.
 var (
 	StackKind             = reflect.TypeOf(Stack{}).Name()
+	StackGroupKind        = schema.GroupKind{Group: Group, Kind: StackKind}.String()
 	StackKindAPIVersion   = StackKind + "." + SchemeGroupVersion.String()
 	StackGroupVersionKind = SchemeGroupVersion.WithKind(StackKind)
 )
@@ -61,6 +64,7 @@ var (
 // StackConfiguration type metadata
 var (
 	StackConfigurationKind             = reflect.TypeOf(StackConfiguration{}).Name()
+	StackConfigurationGroupKind        = schema.GroupKind{Group: Group, Kind: StackConfigurationKind}.String()
 	StackConfigurationKindAPIVersion   = StackConfigurationKind + "." + SchemeGroupVersion.String()
 	StackConfigurationGroupVersionKind = SchemeGroupVersion.WithKind(StackConfigurationKind)
 )
@@ -68,6 +72,7 @@ var (
 // StackDefinition type metadata
 var (
 	StackDefinitionKind             = reflect.TypeOf(StackDefinition{}).Name()
+	StackDefinitionGroupKind        = schema.GroupKind{Group: Group, Kind: StackDefinitionKind}.String()
 	StackDefinitionKindAPIVersion   = StackDefinitionKind + "." + SchemeGroupVersion.String()
 	StackDefinitionGroupVersionKind = SchemeGroupVersion.WithKind(StackDefinitionKind)
 )

--- a/apis/storage/v1alpha1/register.go
+++ b/apis/storage/v1alpha1/register.go
@@ -40,6 +40,7 @@ var (
 // Bucket type metadata.
 var (
 	BucketKind             = reflect.TypeOf(Bucket{}).Name()
+	BucketGroupKind        = schema.GroupKind{Group: Group, Kind: BucketKind}.String()
 	BucketKindAPIVersion   = BucketKind + "." + SchemeGroupVersion.String()
 	BucketGroupVersionKind = SchemeGroupVersion.WithKind(BucketKind)
 )

--- a/apis/workload/v1alpha1/register.go
+++ b/apis/workload/v1alpha1/register.go
@@ -40,6 +40,7 @@ var (
 // KubernetesApplication type metadata.
 var (
 	KubernetesApplicationKind             = reflect.TypeOf(KubernetesApplication{}).Name()
+	KubernetesApplicationGroupKind        = schema.GroupKind{Group: Group, Kind: KubernetesApplicationKind}.String()
 	KubernetesApplicationKindAPIVersion   = KubernetesApplicationKind + "." + SchemeGroupVersion.String()
 	KubernetesApplicationGroupVersionKind = SchemeGroupVersion.WithKind(KubernetesApplicationKind)
 )
@@ -47,6 +48,7 @@ var (
 // KubernetesApplicationResource type metadata.
 var (
 	KubernetesApplicationResourceKind             = reflect.TypeOf(KubernetesApplicationResource{}).Name()
+	KubernetesApplicationResourceGroupKind        = schema.GroupKind{Group: Group, Kind: KubernetesApplicationResourceKind}.String()
 	KubernetesApplicationResourceKindAPIVersion   = KubernetesApplicationResourceKind + "." + SchemeGroupVersion.String()
 	KubernetesApplicationResourceGroupVersionKind = SchemeGroupVersion.WithKind(KubernetesApplicationResourceKind)
 )
@@ -54,6 +56,7 @@ var (
 // KubernetesTarget type metadata.
 var (
 	KubernetesTargetKind             = reflect.TypeOf(KubernetesTarget{}).Name()
+	KubernetesTargetGroupKind        = schema.GroupKind{Group: Group, Kind: KubernetesTargetKind}.String()
 	KubernetesTargetKindAPIVersion   = KubernetesTargetKind + "." + SchemeGroupVersion.String()
 	KubernetesTargetGroupVersionKind = SchemeGroupVersion.WithKind(KubernetesTargetKind)
 )

--- a/go.sum
+++ b/go.sum
@@ -241,6 +241,7 @@ github.com/json-iterator/go v1.1.7 h1:KfgG9LzI+pYjr4xvmz/5H4FXjokeP+rlHLhv3iH62F
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.8 h1:QiWkFLKq0T7mpzwOTu6BzNDbfTE8OLrYhVKYMLF46Ok=
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024 h1:rBMNdlhTLzJjJSDIjNEXX1Pz3Hmwmz91v+zycvx9PJc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/pkg/controller/stacks/install/stackinstall.go
+++ b/pkg/controller/stacks/install/stackinstall.go
@@ -82,7 +82,7 @@ type Reconciler struct {
 // SetupClusterStackInstall adds a controller that reconciles
 // ClusterStackInstalls.
 func SetupClusterStackInstall(mgr ctrl.Manager, l logging.Logger, hostControllerNamespace, tsControllerImage string) error {
-	name := "stacks/" + strings.ToLower(v1alpha1.ClusterStackInstallKind)
+	name := "stacks/" + strings.ToLower(v1alpha1.ClusterStackInstallGroupKind)
 	stackinator := func() v1alpha1.StackInstaller { return &v1alpha1.ClusterStackInstall{} }
 
 	// Fail early if ClusterStackInstall is not registered with the scheme.
@@ -120,7 +120,7 @@ func SetupClusterStackInstall(mgr ctrl.Manager, l logging.Logger, hostController
 
 // SetupStackInstall adds a controller that reconciles StackInstalls.
 func SetupStackInstall(mgr ctrl.Manager, l logging.Logger, hostControllerNamespace, tsControllerImage string) error {
-	name := "stacks/" + strings.ToLower(v1alpha1.StackInstallKind)
+	name := "stacks/" + strings.ToLower(v1alpha1.StackInstallGroupKind)
 	stackinator := func() v1alpha1.StackInstaller { return &v1alpha1.StackInstall{} }
 
 	// Fail early if StackInstall is not registered with the scheme.

--- a/pkg/controller/stacks/stack/stack.go
+++ b/pkg/controller/stacks/stack/stack.go
@@ -97,7 +97,7 @@ type Reconciler struct {
 
 // Setup adds a controller that reconciles Stacks.
 func Setup(mgr ctrl.Manager, l logging.Logger, hostControllerNamespace string) error {
-	name := "stacks/" + strings.ToLower(v1alpha1.StackKind)
+	name := "stacks/" + strings.ToLower(v1alpha1.StackGroupKind)
 
 	hostKube, _, err := hosted.GetClients()
 	if err != nil {

--- a/pkg/controller/stacks/templates/setupphase_controller.go
+++ b/pkg/controller/stacks/templates/setupphase_controller.go
@@ -156,7 +156,7 @@ func (r *SetupPhaseReconciler) newRenderController(gvk *schema.GroupVersionKind,
 	apiType := &unstructured.Unstructured{}
 	apiType.SetGroupVersionKind(*gvk)
 
-	name := "stacks/" + strings.ToLower(gvk.Kind)
+	name := "stacks/" + strings.ToLower(gvk.GroupKind().String())
 	reconciler := &RenderPhaseReconciler{
 		Client:     r.Client,
 		Log:        r.Log.WithValues("controller", name),

--- a/pkg/controller/stacks/templates/templates.go
+++ b/pkg/controller/stacks/templates/templates.go
@@ -27,7 +27,7 @@ import (
 
 // SetupStackConfigurations adds a controller that reconciles StackConfigurations.
 func SetupStackConfigurations(mgr ctrl.Manager, l logging.Logger) error {
-	name := "stacks/" + strings.ToLower(v1alpha1.StackConfigurationKind)
+	name := "stacks/" + strings.ToLower(v1alpha1.StackConfigurationGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -37,7 +37,7 @@ func SetupStackConfigurations(mgr ctrl.Manager, l logging.Logger) error {
 
 // SetupStackDefinitions adds a controller that reconciles StackDefinitions.
 func SetupStackDefinitions(mgr ctrl.Manager, l logging.Logger) error {
-	name := "stacks/" + strings.ToLower(v1alpha1.StackDefinitionKind)
+	name := "stacks/" + strings.ToLower(v1alpha1.StackDefinitionGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).

--- a/pkg/controller/workload/kubernetes/application/application.go
+++ b/pkg/controller/workload/kubernetes/application/application.go
@@ -68,7 +68,7 @@ func UpdatePredicate(event event.UpdateEvent) bool {
 
 // Setup adds a controller that reconciles KubernetesApplications.
 func Setup(mgr ctrl.Manager, l logging.Logger) error {
-	name := "workload/" + strings.ToLower(v1alpha1.KubernetesApplicationKind)
+	name := "workload/" + strings.ToLower(v1alpha1.KubernetesApplicationGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).

--- a/pkg/controller/workload/kubernetes/resource/resource.go
+++ b/pkg/controller/workload/kubernetes/resource/resource.go
@@ -85,7 +85,7 @@ func UpdatePredicate(event event.UpdateEvent) bool {
 
 // Setup adds a controller that reconciles KubernetesApplicationResources.
 func Setup(mgr ctrl.Manager, l logging.Logger) error {
-	name := "workload/" + strings.ToLower(v1alpha1.KubernetesApplicationResourceKind)
+	name := "workload/" + strings.ToLower(v1alpha1.KubernetesApplicationResourceGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).

--- a/pkg/controller/workload/kubernetes/scheduler/scheduler.go
+++ b/pkg/controller/workload/kubernetes/scheduler/scheduler.go
@@ -105,7 +105,7 @@ func UpdatePredicate(e event.UpdateEvent) bool {
 
 // Setup adds a controller that schedules KubernetesApplications.
 func Setup(mgr ctrl.Manager, l logging.Logger) error {
-	name := "scheduler/" + strings.ToLower(workloadv1alpha1.KubernetesApplicationKind)
+	name := "scheduler/" + strings.ToLower(workloadv1alpha1.KubernetesApplicationGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).

--- a/pkg/controller/workload/kubernetes/target/target.go
+++ b/pkg/controller/workload/kubernetes/target/target.go
@@ -57,7 +57,7 @@ func clusterIsBound(obj runtime.Object) bool {
 // Setup adds a controller that creates KubernetesTargets for
 // KubernetesClusters.
 func Setup(mgr ctrl.Manager, l logging.Logger) error {
-	name := "autotarget/" + strings.ToLower(computev1alpha1.KubernetesClusterKind)
+	name := "autotarget/" + strings.ToLower(computev1alpha1.KubernetesClusterGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
#1254

Per the above issue we attempted to use kind only. Unfortunately there are some cases in which we have two controllers of the same type (e.g. "managed") for the same kind in different groups. This means using a "type/kind" controller name like "claimbinding/rediscluster" can result in duplicate controller names, which breaks metric registration.

This commit switches Crossplane core to "type/groupkind", e.g. "claimbinding/rediscluster.cache.crossplane.io". This is longer than we'd like (per #388), but at least now the controller name is stored under a key ("controller") by convention, rather than literally being the name of the logger. I chose "type/groupkind" because in practice there can be only one controller per GroupKind.

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplaneio/crossplane/tree/master/design/one-pager-definition-of-done.md
