### PR TITLE
Fix the script path in the docs

### DIFF
--- a/docs/cloud-providers/aws/aws-provider.md
+++ b/docs/cloud-providers/aws/aws-provider.md
@@ -29,7 +29,7 @@ Run [setup.sh] script to read `aws` credentials and region, and create an `aws
 provider` instance in Crossplane:
 
 ```bash
-./cluster/examples/setup-aws-provider/setup.sh [--profile aws_profile]
+./cluster/examples/aws-setup-provider/setup.sh [--profile aws_profile]
 ```
 
 The `--profile` switch is optional and specifies the [aws named profile] that


### PR DESCRIPTION
Signed-off-by: Sayan Chowdhury <sayan.chowdhury2012@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
The directory name of the script to create an aws provider object was incorrect. This PR fixes the incorrect directory name in the docs

### How has this code been tested?
This is a documentation patch.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [X] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplaneio/crossplane/tree/master/design/one-pager-definition-of-done.md
