### PR TITLE
template-stacks: bump templating-controller default version to 0.2.0

### DIFF
--- a/cluster/charts/crossplane-controllers/values.yaml.tmpl
+++ b/cluster/charts/crossplane-controllers/values.yaml.tmpl
@@ -25,5 +25,4 @@ hostedConfig:
 
 templateStacks:
   enabled: false
-  # TODO(displague) dont merge until this can point at crossplane/resourcepacks:master
-  controllerImage: crossplane/templating-controller:0.1.0
+  controllerImage: crossplane/templating-controller:0.2.0

--- a/cluster/charts/crossplane/README.md
+++ b/cluster/charts/crossplane/README.md
@@ -211,7 +211,7 @@ The following tables lists the configurable parameters of the Crossplane chart a
 | `clusterStacks.rook.version`     | Rook stack version to deploy                                    | `<latest released version>`   
 | `personas.deploy`                | Install roles and bindings for Crossplane user personas         | `true`     
 | `templateStacks.enabled`         | Enable experimental template stacks support                     | `false`     
-| `templateStacks.controllerImage` | Template Stack controller image                                 | `crossplane/templating-controller:0.1.0`
+| `templateStacks.controllerImage` | Template Stack controller image                                 | `crossplane/templating-controller:0.2.0`
  
 ### Command Line
 

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -35,4 +35,4 @@ hostedConfig:
 
 templateStacks:
   enabled: false
-  controllerImage: crossplane/templating-controller:0.1.0
+  controllerImage: crossplane/templating-controller:0.2.0

--- a/docs/install-crossplane.md
+++ b/docs/install-crossplane.md
@@ -269,7 +269,7 @@ The following tables lists the configurable parameters of the Crossplane chart a
 | `clusterStacks.rook.version`     | Rook stack version to deploy                                    | `<latest released version>`   
 | `personas.deploy`                | Install roles and bindings for Crossplane user personas         | `true`     
 | `templateStacks.enabled`         | Enable experimental template stacks support                     | `false`     
-| `templateStacks.controllerImage` | Template Stack controller image                                 | `crossplane/templating-controller:0.1.0`
+| `templateStacks.controllerImage` | Template Stack controller image                                 | `crossplane/templating-controller:0.2.0`
  
 ### Command Line
 


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

Helm support has been added in this version. Keeping this in draft format until https://github.com/crossplaneio/templating-controller/pull/4 is merged and new image is pushed.

### How has this code been tested?

Manually tested with https://github.com/crossplaneio/sample-stack-wordpress/pull/31 and https://github.com/crossplaneio/stack-minimal-gcp/pull/1
### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [x] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplaneio/crossplane/tree/master/design/one-pager-definition-of-done.md
