### PR TITLE
[Bug] Pass correct number of args to logger

### DIFF
--- a/pkg/controller/workload/kubernetes/application/application.go
+++ b/pkg/controller/workload/kubernetes/application/application.go
@@ -258,7 +258,7 @@ type Reconciler struct {
 // Reconcile scheduled KubernetesApplications by managing their templated
 // KubernetesApplicationResources.
 func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) {
-	r.log.Debug("Reconciling", "kind", "request", req)
+	r.log.Debug("Reconciling", "request", req)
 
 	ctx, cancel := context.WithTimeout(context.Background(), reconcileTimeout)
 	defer cancel()

--- a/pkg/controller/workload/kubernetes/scheduler/scheduler.go
+++ b/pkg/controller/workload/kubernetes/scheduler/scheduler.go
@@ -128,7 +128,7 @@ type Reconciler struct {
 // Reconcile attempts to schedule a KubernetesApplication to a KubernetesTarget
 // that matches its cluster selector.
 func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) {
-	r.log.Debug("Reconciling", "kind", "request", req)
+	r.log.Debug("Reconciling", "request", req)
 
 	ctx, cancel := context.WithTimeout(context.Background(), reconcileTimeout)
 	defer cancel()


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->


@muvaf noticed that these loggers were causing crashes with the following output:

```
E0212 13:34:56.112590   16999 runtime.go:76] Observed a panic: odd number of arguments passed as key-value pairs for logging                                                                                
goroutine 329 [running]:                                                                                                                                                                                    
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1479040, 0xc0002be7b0)                                                                                                                                      
        /home/dan/go/pkg/mod/k8s.io/apimachinery@v0.17.0/pkg/util/runtime/runtime.go:74 +0xa3                                                                                                               
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)                                                                                                                                             
        /home/dan/go/pkg/mod/k8s.io/apimachinery@v0.17.0/pkg/util/runtime/runtime.go:48 +0x82                                                                                                               
panic(0x1479040, 0xc0002be7b0)                                                                                                                                                                              
        /usr/local/go/src/runtime/panic.go:679 +0x1b2                                                                                                                                                       
go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc000634370, 0xc000310840, 0x1, 0x1)                                                                                                                         
        /home/dan/go/pkg/mod/go.uber.org/zap@v1.10.0/zapcore/entry.go:229 +0x546                                                                                                                            
go.uber.org/zap.(*Logger).DPanic(0xc0002fdd40, 0x16f855a, 0x3d, 0xc000310840, 0x1, 0x1)                                                                                                                     
        /home/dan/go/pkg/mod/go.uber.org/zap@v1.10.0/logger.go:215 +0x7f                                                                                                                                    
github.com/go-logr/zapr.handleFields(0xc0002fdd40, 0xc00059c780, 0x3, 0x3, 0x0, 0x0, 0x0, 0x1542160, 0xc0002be720, 0x1)                                                                                     
        /home/dan/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:106 +0x5ce                                                                                                                              
github.com/go-logr/zapr.(*infoLogger).Info(0xc0002be720, 0x16af778, 0xb, 0xc00059c780, 0x3, 0x3)                                                                                                            
        /home/dan/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:70 +0xb1                                                                                                                                
github.com/crossplaneio/crossplane-runtime/pkg/logging.logrLogger.Debug(0x18e56c0, 0xc0003e3940, 0x16af778, 0xb, 0xc00059c780, 0x3, 0x3)                                                                    
        /home/dan/go/pkg/mod/github.com/crossplaneio/crossplane-runtime@v0.4.1-0.20200201005410-a6bb086be888/pkg/logging/logging.go:89 +0x80                                                                
github.com/crossplaneio/crossplane/pkg/controller/workload/kubernetes/application.(*Reconciler).Reconcile(0xc00046a9f0, 0xc00003f7c8, 0x7, 0xc00003f7e0, 0xe, 0xc00068ac00, 0x0, 0x0, 0x0)                  
        /home/dan/code/github.com/crossplaneio/crossplane/pkg/controller/workload/kubernetes/application/application.go:261 +0x15c 
```

They were being passed an extra `"kind"` argument that was not present in other log messages, causing the odd number of args.

### How has this code been tested?
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

I tested by creating and deleting a `KubernetesApplication` and seeing that the controllers logged and reconciled successfully.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation] and [examples].
- [ ] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplaneio/crossplane/tree/master/design/one-pager-definition-of-done.md
