### PR TITLE
Make template stacks enabled by default in helm chart

### DIFF
--- a/cluster/charts/crossplane-controllers/values.yaml.tmpl
+++ b/cluster/charts/crossplane-controllers/values.yaml.tmpl
@@ -24,5 +24,5 @@ hostedConfig:
   crossplaneSATokenSecret: ""
 
 templateStacks:
-  enabled: false
+  enabled: true
   controllerImage: crossplane/templating-controller:0.2.0

--- a/cluster/charts/crossplane/values.yaml.tmpl
+++ b/cluster/charts/crossplane/values.yaml.tmpl
@@ -34,5 +34,5 @@ hostedConfig:
   enabled: false
 
 templateStacks:
-  enabled: false
+  enabled: true
   controllerImage: crossplane/templating-controller:0.2.0


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

As per discussion on Slack, we have decided to enable this functionality by default since it will be used by our example wordpress stack and minimal environment stacks.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### How has this code been tested?

Tested manually, several times using https://github.com/crossplaneio/sample-stack-wordpress/pull/31 and https://github.com/crossplaneio/stack-minimal-gcp/pull/1
<!--
Before reviewers can be confident in the correctness of a pull request,
it needs to tested and shown to be correct. In this section, briefly
describe the testing that has already been done or which is planned.
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation] and [examples].
- [x] Reported all new error conditions into the log or as an event, as
  appropriate.

For more about what we believe makes a pull request complete, see our
[definition of done].

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[definition of done]: https://github.com/crossplaneio/crossplane/tree/master/design/one-pager-definition-of-done.md
